### PR TITLE
Basic tests for crypto wrapper functions

### DIFF
--- a/acme/crypto_test.go
+++ b/acme/crypto_test.go
@@ -1,0 +1,48 @@
+package acme
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"testing"
+)
+
+func TestGeneratePrivateKey(t *testing.T) {
+	key, err := generatePrivateKey(32)
+	if err != nil {
+		t.Error("Error generating private key:", err)
+	}
+	if key == nil {
+		t.Error("Expected key to not be nil, but it was")
+	}
+}
+
+func TestGenerateCSR(t *testing.T) {
+	key, err := generatePrivateKey(512)
+	if err != nil {
+		t.Fatal("Error generating private key:", err)
+	}
+
+	csr, err := generateCsr(key, "fizz.buzz")
+	if err != nil {
+		t.Error("Error generating CSR:", err)
+	}
+	if csr == nil || len(csr) == 0 {
+		t.Error("Expected CSR with data, but it was nil or length 0")
+	}
+}
+
+func TestPEMEncode(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 32)
+	if err != nil {
+		t.Fatal("Error generating private key:", err)
+	}
+
+	data := pemEncode(key)
+
+	if data == nil {
+		t.Fatal("Expected result to not be nil, but it was")
+	}
+	if len(data) != 127 {
+		t.Errorf("Expected PEM encoding to be length 127, but it was %d", len(data))
+	}
+}


### PR DESCRIPTION
Even though the std lib does the heavy lifting, this should verify (somewhat) that the helper functions are working.

Better tests would involve replacing crypto/rand.Reader with a non-random Reader then comparing the contents to make sure the proper std lib crypto functions were called and their values returned.