### PR TITLE
initialize struct so cli doesn't panic when domains aren't set

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -61,6 +61,7 @@ func main() {
 		cli.StringSliceFlag{
 			Name:  "domains, d",
 			Usage: "Add domains to the process",
+			Value: &cli.StringSlice{},
 		},
 		cli.StringFlag{
 			Name:  "server, s",


### PR DESCRIPTION
fixes a panic when no domains are passed

```
-> % lego
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0xaa60d]

goroutine 1 [running]:
github.com/codegangsta/cli.(*StringSlice).String(0x0, 0x0, 0x0)
	/Users/drew/src/github.com/codegangsta/cli/flag.go:99 +0x11d
flag.(*FlagSet).Var(0xc820074180, 0x1504698, 0x0, 0x4354a0, 0x7, 0x477520, 0x1a)
	/usr/local/go151/src/flag/flag.go:766 +0x6e
github.com/codegangsta/cli.StringSliceFlag.Apply.func1(0x4354a0, 0x7)
	/Users/drew/src/github.com/codegangsta/cli/flag.go:131 +0x8b
github.com/codegangsta/cli.eachName(0x4354a0, 0xa, 0xc8200517c8)
	/Users/drew/src/github.com/codegangsta/cli/flag.go:52 +0x11f
github.com/codegangsta/cli.StringSliceFlag.Apply(0x4354a0, 0xa, 0x0, 0x477520, 0x1a, 0x0, 0x0, 0xc820074180)
	/Users/drew/src/github.com/codegangsta/cli/flag.go:132 +0x32b
github.com/codegangsta/cli.(*StringSliceFlag).Apply(0xc8200723c0, 0xc820074180)
	<autogenerated>:21 +0xa0
github.com/codegangsta/cli.flagSet(0x42bbc0, 0x4, 0xc8200c4000, 0x9, 0xe, 0x1504660)
	/Users/drew/src/github.com/codegangsta/cli/flag.go:43 +0x11a
github.com/codegangsta/cli.(*App).Run(0xc8200c2000, 0xc820076180, 0x1, 0x1, 0x0, 0x0)
	/Users/drew/src/github.com/codegangsta/cli/app.go:86 +0x267
main.main()
	/Users/drew/src/github.com/xenolf/lego/cli.go:94 +0xba6

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
	/usr/local/go151/src/runtime/asm_amd64.s:1696 +0x1
```