### PR TITLE
Replaced fatal with print; return errors from NewClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,10 @@ myUser := MyUser{
 // configured for a local dev instance of Boulder running in Docker in a VM.
 // We specify an optPort of 5001 because we aren't running as root and can't
 // bind a listener to port 443 (used later when we attempt to pass challenge).
-client := acme.NewClient("http://192.168.99.100:4000", &myUser, rsaKeySize, "5001")
+client, err := acme.NewClient("http://192.168.99.100:4000", &myUser, rsaKeySize, "5001")
+if err != inl {
+  log.Fatal(err)
+}
 
 // New users will need to register; be sure to save it
 reg, err := client.Register()

--- a/acme/client_test.go
+++ b/acme/client_test.go
@@ -27,7 +27,10 @@ func TestNewClient(t *testing.T) {
 	}))
 
 	caURL, optPort := ts.URL, "1234"
-	client := NewClient(caURL, user, keyBits, optPort)
+	client, err := NewClient(caURL, user, keyBits, optPort)
+	if err != nil {
+		t.Fatalf("Could not create client: %v", err)
+	}
 
 	if client.jws == nil {
 		t.Fatalf("Expected client.jws to not be nil")

--- a/cli_handlers.go
+++ b/cli_handlers.go
@@ -32,7 +32,13 @@ func setup(c *cli.Context) (*Configuration, *Account, *acme.Client) {
 
 	//TODO: move to account struct? Currently MUST pass email.
 	acc := NewAccount(c.GlobalString("email"), conf)
-	return conf, acc, acme.NewClient(c.GlobalString("server"), acc, conf.RsaBits(), conf.OptPort())
+
+	client, err := acme.NewClient(c.GlobalString("server"), acc, conf.RsaBits(), conf.OptPort())
+	if err != nil {
+		logger().Fatal("Could not create client:", err)
+	}
+
+	return conf, acc, client
 }
 
 func saveCertRes(certRes acme.CertificateResource, conf *Configuration) {


### PR DESCRIPTION
Error handling can still be improved and cleaned up a bit, but this is a start. Since `acme` is a package that will be imported by other programs, I took out all the log.Fatal lines that kill the program and either returned the error or, where that wasn't immediately obvious how to do, replaced with log.Print.