### PR TITLE
Make acme.Logger optional; otherwise use standard log.Logger

### DIFF
--- a/acme/client.go
+++ b/acme/client.go
@@ -106,7 +106,10 @@ func NewClient(caURL string, usr User, keyBits int, optPort string) (*Client, er
 
 // Register the current account to the ACME server.
 func (c *Client) Register() (*RegistrationResource, error) {
-	logf("Registering account ... ")
+	if c == nil || c.user == nil {
+		return nil, errors.New("acme: cannot register a nil client or user")
+	}
+	logf("[INFO] acme: Registering account for %s", c.user.GetEmail())
 
 	regMsg := registrationMessage{
 		Resource: "new-reg",
@@ -150,7 +153,7 @@ func (c *Client) Register() (*RegistrationResource, error) {
 	if links["next"] != "" {
 		reg.NewAuthzURL = links["next"]
 	} else {
-		return nil, errors.New("The server did not return enough information to proceed...")
+		return nil, errors.New("acme: The server did not return 'next' link to proceed")
 	}
 
 	return reg, nil
@@ -185,7 +188,12 @@ func (c *Client) AgreeToTOS() error {
 // If bundle is true, the []byte contains both the issuer certificate and
 // your issued certificate as a bundle.
 func (c *Client) ObtainCertificates(domains []string, bundle bool) ([]CertificateResource, map[string]error) {
-	logf("Obtaining certificates...")
+	if bundle {
+		logf("[INFO] acme: Obtaining bundled certificates for %v", strings.Join(domains, ", "))
+	} else {
+		logf("[INFO] acme: Obtaining certificates for %v", strings.Join(domains, ", "))
+	}
+
 	challenges, failures := c.getChallenges(domains)
 	if len(challenges) == 0 {
 		return nil, failures
@@ -200,7 +208,7 @@ func (c *Client) ObtainCertificates(domains []string, bundle bool) ([]Certificat
 		return nil, failures
 	}
 
-	logf("Validations succeeded. Getting certificates")
+	logf("[INFO] acme: Validations succeeded; requesting certificates")
 
 	certs, err := c.requestCertificates(challenges, bundle)
 	for k, v := range err {
@@ -264,7 +272,7 @@ func (c *Client) RenewCertificate(cert CertificateResource, revokeOld bool, bund
 
 	// This is just meant to be informal for the user.
 	timeLeft := x509Cert.NotAfter.Sub(time.Now().UTC())
-	logf("[%s] Trying to renew certificate with %d hours remaining.", cert.Domain, int(timeLeft.Hours()))
+	logf("[INFO] acme: [%s] Trying renewal with %d hours remaining", cert.Domain, int(timeLeft.Hours()))
 
 	// The first step of renewal is to check if we get a renewed cert
 	// directly from the cert URL.
@@ -286,7 +294,7 @@ func (c *Client) RenewCertificate(cert CertificateResource, revokeOld bool, bund
 	// If the server responds with a different certificate we are effectively renewed.
 	// TODO: Further test if we can actually use the new certificate (Our private key works)
 	if !x509Cert.Equal(serverCert) {
-		logf("[%s] The server responded with a renewed certificate.", cert.Domain)
+		logf("[INFO] acme: [%s] Server responded with renewed certificate", cert.Domain)
 		if revokeOld {
 			c.RevokeCertificate(cert.Certificate)
 		}
@@ -300,7 +308,7 @@ func (c *Client) RenewCertificate(cert CertificateResource, revokeOld bool, bund
 			issuerCert, err := c.getIssuerCertificate(links["up"])
 			if err != nil {
 				// If we fail to aquire the issuer cert, return the issued certificate - do not fail.
-				logf("[%s] Could not bundle issuer certificate.\n%v", cert.Domain, err)
+				logf("[ERROR] acme: [%s] Could not bundle issuer certificate: %v", cert.Domain, err)
 			} else {
 				// Success - append the issuer cert to the issued cert.
 				issuerCert = pemEncode(derCertificateBytes(issuerCert))
@@ -341,7 +349,7 @@ func (c *Client) solveChallenges(challenges []*authorizationResource) map[string
 				}
 			}
 		} else {
-			failures[authz.Domain] = fmt.Errorf("Could not determine solvers for %s", authz.Domain)
+			failures[authz.Domain] = fmt.Errorf("acme: Could not determine solvers for %s", authz.Domain)
 		}
 	}
 
@@ -357,7 +365,7 @@ func (c *Client) chooseSolvers(auth authorization, domain string) map[int]solver
 			if solver, ok := c.solvers[auth.Challenges[idx].Type]; ok {
 				solvers[idx] = solver
 			} else {
-				logf("Could not find solver for: %s", auth.Challenges[idx].Type)
+				logf("[ERROR] acme: Could not find solver for: %s", auth.Challenges[idx].Type)
 			}
 		}
 
@@ -393,7 +401,7 @@ func (c *Client) getChallenges(domains []string) ([]*authorizationResource, map[
 
 			links := parseLinks(resp.Header["Link"])
 			if links["next"] == "" {
-				logf("The server did not provide enough information to proceed.")
+				logf("[ERROR] acme: Server did not provide next link to proceed")
 				return
 			}
 
@@ -515,7 +523,7 @@ func (c *Client) requestCertificate(authz *authorizationResource, result chan Ce
 					issuerCert, err := c.getIssuerCertificate(links["up"])
 					if err != nil {
 						// If we fail to aquire the issuer cert, return the issued certificate - do not fail.
-						logf("[%s] Could not bundle issuer certificate.\n%v", authz.Domain, err)
+						logf("[WARNING] acme: [%s] Could not bundle issuer certificate: %v", authz.Domain, err)
 					} else {
 						// Success - append the issuer cert to the issued cert.
 						issuerCert = pemEncode(derCertificateBytes(issuerCert))
@@ -538,7 +546,7 @@ func (c *Client) requestCertificate(authz *authorizationResource, result chan Ce
 				return
 			}
 
-			logf("[%s] Server responded with status 202. Respecting retry-after of: %d", authz.Domain, retryAfter)
+			logf("[INFO] acme: [%s] Server responded with status 202; retrying after %ds", authz.Domain, retryAfter)
 			time.Sleep(time.Duration(retryAfter) * time.Second)
 
 			break
@@ -558,7 +566,7 @@ func (c *Client) requestCertificate(authz *authorizationResource, result chan Ce
 // getIssuerCertificate requests the issuer certificate and caches it for
 // subsequent requests.
 func (c *Client) getIssuerCertificate(url string) ([]byte, error) {
-	logf("Requesting issuer cert from: %s", url)
+	logf("[INFO] acme: Requesting issuer cert from %s", url)
 	if c.issuerCert != nil {
 		return c.issuerCert, nil
 	}
@@ -580,18 +588,6 @@ func (c *Client) getIssuerCertificate(url string) ([]byte, error) {
 
 	c.issuerCert = issuerBytes
 	return issuerBytes, err
-}
-
-func logResponseHeaders(resp *http.Response) {
-	logf(resp.Status)
-	for k, v := range resp.Header {
-		logf("-- %s: %s", k, v)
-	}
-}
-
-func logResponseBody(resp *http.Response) {
-	body, _ := ioutil.ReadAll(resp.Body)
-	logf("Returned json data: \n%s", body)
 }
 
 func parseLinks(links []string) map[string]string {

--- a/acme/client_test.go
+++ b/acme/client_test.go
@@ -44,7 +44,7 @@ func TestNewClient(t *testing.T) {
 	}
 
 	if expected, actual := 1, len(client.solvers); actual != expected {
-		t.Fatal("Expected %d solver(s), got %d", expected, actual)
+		t.Fatalf("Expected %d solver(s), got %d", expected, actual)
 	}
 
 	simphttp, ok := client.solvers["simpleHttp"].(*simpleHTTPChallenge)

--- a/acme/error.go
+++ b/acme/error.go
@@ -18,7 +18,7 @@ type RemoteError struct {
 }
 
 func (e RemoteError) Error() string {
-	return fmt.Sprintf("[%d] Type: %s Detail: %s", e.StatusCode, e.Type, e.Detail)
+	return fmt.Sprintf("acme: Error %d - %s - %s", e.StatusCode, e.Type, e.Detail)
 }
 
 // TOSError represents the error which is returned if the user needs to

--- a/acme/simple_http_challenge.go
+++ b/acme/simple_http_challenge.go
@@ -27,7 +27,7 @@ type simpleHTTPChallenge struct {
 
 func (s *simpleHTTPChallenge) Solve(chlng challenge, domain string) error {
 
-	logger().Print("Trying to solve SimpleHTTP")
+	logf("Trying to solve SimpleHTTP")
 
 	// Generate random string for the path. The acme server will
 	// access this path on the server in order to validate the request
@@ -68,7 +68,7 @@ Loop:
 			if OnSimpleHTTPEnd != nil {
 				OnSimpleHTTPEnd(true)
 			}
-			logger().Print("The server validated our request")
+			logf("The server validated our request")
 			break Loop
 		case "pending":
 			break
@@ -148,9 +148,9 @@ func (s *simpleHTTPChallenge) startHTTPSServer(domain string, token string) (net
 		if strings.HasPrefix(r.Host, domain) && r.Method == "GET" {
 			w.Header().Add("Content-Type", "application/jose+json")
 			w.Write([]byte(signedCompact))
-			logger().Print("Served JWS payload...")
+			logf("Served JWS payload...")
 		} else {
-			logger().Printf("Received request for domain %s with method %s", r.Host, r.Method)
+			logf("Received request for domain %s with method %s", r.Host, r.Method)
 			w.Write([]byte("TEST"))
 		}
 	})

--- a/acme/simple_http_challenge_test.go
+++ b/acme/simple_http_challenge_test.go
@@ -138,7 +138,7 @@ func TestSimpleHTTPServerError(t *testing.T) {
 	if err := solver.Solve(clientChallenge, "127.0.0.1"); err == nil {
 		t.Error("UNEXPECTED: Expected Solve to return an error but the error was nil.")
 	} else {
-		expectedError := "[500] Type: urn:acme:error:unauthorized Detail: Error creating new authz :: Syntax error"
+		expectedError := "acme: Error 500 - urn:acme:error:unauthorized - Error creating new authz :: Syntax error"
 		if err.Error() != expectedError {
 			t.Errorf("Expected error |%s| but instead got |%s|", expectedError, err.Error())
 		}


### PR DESCRIPTION
My logic behind this change is basically this: a user of this library can set `acme.Logger` to something custom if they want to; otherwise it uses the default log.Logger instance. (Currently, acme package _never_ uses the standard log.Logger, which is causing problems in Caddy which uses that logger.)

Also, my next PR will clean up the log statements a bit, making them more consistent and also removing the superfluous `\n` at the end (the log package adds them for us, which is nice -- keeps our strings cleaner).