### PR TITLE
Listen on *:port when the port is specified

### DIFF
--- a/acme/http_challenge.go
+++ b/acme/http_challenge.go
@@ -95,12 +95,13 @@ Loop:
 func (s *httpChallenge) startHTTPServer(domain string, token string, keyAuth string) {
 
 	// Allow for CLI port override
-	port := ":80"
+	port := domain + ":80"
 	if s.optPort != "" {
 		port = ":" + s.optPort
 	}
 
-	listener, err := net.Listen("tcp", domain+port)
+	logf("[INFO] Listening to %s", port)
+	listener, err := net.Listen("tcp", port)
 	if err != nil {
 		// if the domain:port bind failed, fall back to :port bind and try that instead.
 		listener, err = net.Listen("tcp", port)

--- a/acme/http_challenge_test.go
+++ b/acme/http_challenge_test.go
@@ -25,7 +25,7 @@ func TestHTTPNonRootBind(t *testing.T) {
 	if err := solver.Solve(clientChallenge, "127.0.0.1"); err == nil {
 		t.Error("BIND: Expected Solve to return an error but the error was nil.")
 	} else {
-		expectedError := "Could not start HTTP server for challenge -> listen tcp :80: bind: permission denied"
+		expectedError := "Could not start HTTP server for challenge -> listen tcp 127.0.0.1:80: bind: permission denied"
 		if err.Error() != expectedError {
 			t.Errorf("Expected error \"%s\" but instead got \"%s\"", expectedError, err.Error())
 		}


### PR DESCRIPTION
The expectation should be that if you're listening to a non-default port
you are forwarding the connection in some way and listening on the
IP from DNS won't be useful.

Also print the {ip}:port that's being listened to.

This should help on #39; the issue I ran into was that lego could
listen on public-ip:port (when I specified the port), but I was
forwarding the connection to private-ip:port.