### PR TITLE
Add explicit fallthrough

### DIFF
--- a/acme/client.go
+++ b/acme/client.go
@@ -468,10 +468,8 @@ func (c *Client) requestCertificate(authz []authorizationResource, bundle bool, 
 		PrivateKey: privateKeyPem}
 
 	for {
-
 		switch resp.StatusCode {
-		case 202:
-		case 201:
+		case 201, 202:
 			cert, err := ioutil.ReadAll(limitReader(resp.Body, 1024*1024))
 			resp.Body.Close()
 			if err != nil {


### PR DESCRIPTION
An empty case in Go does not fallthrough to the next one.