### PR TITLE
http-01: refactor provider for presenting token

### DIFF
--- a/acme/challenges.go
+++ b/acme/challenges.go
@@ -1,0 +1,15 @@
+package acme
+
+type Challenge string
+
+const (
+	// HTTP01 is the "http-01" ACME challenge https://github.com/ietf-wg-acme/acme/blob/master/draft-ietf-acme-acme.md#http
+	// Note: HTTP01ChallengePath returns the URL path to fulfill this challenge
+	HTTP01 = Challenge("http-01")
+	// TLSSNI01 is the "tls-sni-01" ACME challenge https://github.com/ietf-wg-acme/acme/blob/master/draft-ietf-acme-acme.md#tls-with-server-name-indication-tls-sni
+	// Note: TLSSNI01ChallengeCert returns a certificate to fulfill this challenge
+	TLSSNI01 = Challenge("tls-sni-01")
+	// DNS01 is the "dns-01" ACME challenge https://github.com/ietf-wg-acme/acme/blob/master/draft-ietf-acme-acme.md#dns
+	// Note: DNS01Record returns a DNS record which will fulfill this challenge
+	DNS01 = Challenge("dns-01")
+)

--- a/acme/client_test.go
+++ b/acme/client_test.go
@@ -75,32 +75,32 @@ func TestClientOptPort(t *testing.T) {
 	client.SetHTTPAddress(net.JoinHostPort(optHost, optPort))
 	client.SetTLSAddress(net.JoinHostPort(optHost, optPort))
 
-	httpSolver, ok := client.solvers["http-01"].(*httpChallenge)
+	httpSolver, ok := client.solvers[HTTP01].(*httpChallenge)
 	if !ok {
 		t.Fatal("Expected http-01 solver to be httpChallenge type")
 	}
 	if httpSolver.jws != client.jws {
 		t.Error("Expected http-01 to have same jws as client")
 	}
-	if httpSolver.port != optPort {
-		t.Errorf("Expected http-01 to have port %s but was %s", optPort, httpSolver.port)
+	if got := httpSolver.provider.(*httpChallengeServer).port; got != optPort {
+		t.Errorf("Expected http-01 to have port %s but was %s", optPort, got)
 	}
-	if httpSolver.iface != optHost {
-		t.Errorf("Expected http-01 to have iface %s but was %s", optHost, httpSolver.iface)
+	if got := httpSolver.provider.(*httpChallengeServer).iface; got != optHost {
+		t.Errorf("Expected http-01 to have iface %s but was %s", optHost, got)
 	}
 
-	httpsSolver, ok := client.solvers["tls-sni-01"].(*tlsSNIChallenge)
+	httpsSolver, ok := client.solvers[TLSSNI01].(*tlsSNIChallenge)
 	if !ok {
 		t.Fatal("Expected tls-sni-01 solver to be httpChallenge type")
 	}
 	if httpsSolver.jws != client.jws {
 		t.Error("Expected tls-sni-01 to have same jws as client")
 	}
-	if httpsSolver.port != optPort {
-		t.Errorf("Expected tls-sni-01 to have port %s but was %s", optPort, httpSolver.port)
+	if got := httpsSolver.provider.(*tlsSNIChallengeServer).port; got != optPort {
+		t.Errorf("Expected tls-sni-01 to have port %s but was %s", optPort, got)
 	}
-	if httpsSolver.port != optPort {
-		t.Errorf("Expected tls-sni-01 to have port %s but was %s", optHost, httpSolver.iface)
+	if got := httpsSolver.provider.(*tlsSNIChallengeServer).iface; got != optHost {
+		t.Errorf("Expected tls-sni-01 to have port %s but was %s", optHost, got)
 	}
 
 	// test setting different host
@@ -108,11 +108,11 @@ func TestClientOptPort(t *testing.T) {
 	client.SetHTTPAddress(net.JoinHostPort(optHost, optPort))
 	client.SetTLSAddress(net.JoinHostPort(optHost, optPort))
 
-	if httpSolver.iface != optHost {
-		t.Errorf("Expected http-01 to have iface %s but was %s", optHost, httpSolver.iface)
+	if got := httpSolver.provider.(*httpChallengeServer).iface; got != optHost {
+		t.Errorf("Expected http-01 to have iface %s but was %s", optHost, got)
 	}
-	if httpsSolver.port != optPort {
-		t.Errorf("Expected tls-sni-01 to have port %s but was %s", optHost, httpSolver.iface)
+	if got := httpsSolver.provider.(*tlsSNIChallengeServer).port; got != optPort {
+		t.Errorf("Expected tls-sni-01 to have port %s but was %s", optPort, got)
 	}
 }
 

--- a/acme/dns_challenge_cloudflare_test.go
+++ b/acme/dns_challenge_cloudflare_test.go
@@ -1,7 +1,6 @@
 package acme
 
 import (
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -54,7 +53,7 @@ func TestNewDNSProviderCloudFlareMissingCredErr(t *testing.T) {
 	restoreCloudFlareEnv()
 }
 
-func TestCloudFlareCreateTXTRecord(t *testing.T) {
+func TestCloudFlarePresent(t *testing.T) {
 	if !cflareLiveTest {
 		t.Skip("skipping live test")
 	}
@@ -62,12 +61,11 @@ func TestCloudFlareCreateTXTRecord(t *testing.T) {
 	provider, err := NewDNSProviderCloudFlare(cflareEmail, cflareAPIKey)
 	assert.NoError(t, err)
 
-	fqdn := fmt.Sprintf("_acme-challenge.123.%s.", cflareDomain)
-	err = provider.CreateTXTRecord(fqdn, "123d==", 120)
+	err = provider.Present(cflareDomain, "", "123d==")
 	assert.NoError(t, err)
 }
 
-func TestCloudFlareRemoveTXTRecord(t *testing.T) {
+func TestCloudFlareCleanUp(t *testing.T) {
 	if !cflareLiveTest {
 		t.Skip("skipping live test")
 	}
@@ -77,7 +75,6 @@ func TestCloudFlareRemoveTXTRecord(t *testing.T) {
 	provider, err := NewDNSProviderCloudFlare(cflareEmail, cflareAPIKey)
 	assert.NoError(t, err)
 
-	fqdn := fmt.Sprintf("_acme-challenge.123.%s.", cflareDomain)
-	err = provider.RemoveTXTRecord(fqdn, "123d==", 120)
+	err = provider.CleanUp(cflareDomain, "", "123d==")
 	assert.NoError(t, err)
 }

--- a/acme/dns_challenge_manual.go
+++ b/acme/dns_challenge_manual.go
@@ -10,7 +10,7 @@ const (
 	dnsTemplate = "%s %d IN TXT \"%s\""
 )
 
-// DNSProviderManual is an implementation of the DNSProvider interface
+// DNSProviderManual is an implementation of the ChallengeProvider interface
 type DNSProviderManual struct{}
 
 // NewDNSProviderManual returns a DNSProviderManual instance.
@@ -18,8 +18,9 @@ func NewDNSProviderManual() (*DNSProviderManual, error) {
 	return &DNSProviderManual{}, nil
 }
 
-// CreateTXTRecord prints instructions for manually creating the TXT record
-func (*DNSProviderManual) CreateTXTRecord(fqdn, value string, ttl int) error {
+// Present prints instructions for manually creating the TXT record
+func (*DNSProviderManual) Present(domain, token, keyAuth string) error {
+	fqdn, value, ttl := DNS01Record(domain, keyAuth)
 	dnsRecord := fmt.Sprintf(dnsTemplate, fqdn, ttl, value)
 	logf("[INFO] acme: Please create the following TXT record in your DNS zone:")
 	logf("[INFO] acme: %s", dnsRecord)
@@ -29,9 +30,10 @@ func (*DNSProviderManual) CreateTXTRecord(fqdn, value string, ttl int) error {
 	return nil
 }
 
-// RemoveTXTRecord prints instructions for manually removing the TXT record
-func (*DNSProviderManual) RemoveTXTRecord(fqdn, value string, ttl int) error {
-	dnsRecord := fmt.Sprintf(dnsTemplate, fqdn, ttl, value)
+// CleanUp prints instructions for manually removing the TXT record
+func (*DNSProviderManual) CleanUp(domain, token, keyAuth string) error {
+	fqdn, _, ttl := DNS01Record(domain, keyAuth)
+	dnsRecord := fmt.Sprintf(dnsTemplate, fqdn, ttl, "...")
 	logf("[INFO] acme: You can now remove this TXT record from your DNS zone:")
 	logf("[INFO] acme: %s", dnsRecord)
 	return nil

--- a/acme/dns_challenge_rfc2136_test.go
+++ b/acme/dns_challenge_rfc2136_test.go
@@ -11,7 +11,9 @@ import (
 )
 
 var (
-	rfc2136TestValue      = "so6ZGir4GaZqI11h9UccBB=="
+	rfc2136TestDomain     = "123456789.www.example.com"
+	rfc2136TestKeyAuth    = "123d=="
+	rfc2136TestValue      = "Now36o-3BmlB623-0c1qCIUmgWVVmDJb88KGl24pqpo"
 	rfc2136TestFqdn       = "_acme-challenge.123456789.www.example.com."
 	rfc2136TestZone       = "example.com."
 	rfc2136TestTTL        = 120
@@ -58,8 +60,8 @@ func TestRFC2136ServerSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected NewDNSProviderRFC2136() to return no error but the error was -> %v", err)
 	}
-	if err := provider.CreateTXTRecord(rfc2136TestFqdn, rfc2136TestValue, rfc2136TestTTL); err != nil {
-		t.Errorf("Expected CreateTXTRecord() to return no error but the error was -> %v", err)
+	if err := provider.Present(rfc2136TestDomain, "", rfc2136TestKeyAuth); err != nil {
+		t.Errorf("Expected Present() to return no error but the error was -> %v", err)
 	}
 }
 
@@ -77,10 +79,10 @@ func TestRFC2136ServerError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected NewDNSProviderRFC2136() to return no error but the error was -> %v", err)
 	}
-	if err := provider.CreateTXTRecord(rfc2136TestFqdn, rfc2136TestValue, rfc2136TestTTL); err == nil {
-		t.Errorf("Expected CreateTXTRecord() to return an error but it did not.")
+	if err := provider.Present(rfc2136TestDomain, "", rfc2136TestKeyAuth); err == nil {
+		t.Errorf("Expected Present() to return an error but it did not.")
 	} else if !strings.Contains(err.Error(), "NOTZONE") {
-		t.Errorf("Expected CreateTXTRecord() to return an error with the 'NOTZONE' rcode string but it did not.")
+		t.Errorf("Expected Present() to return an error with the 'NOTZONE' rcode string but it did not.")
 	}
 }
 
@@ -98,8 +100,8 @@ func TestRFC2136TsigClient(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected NewDNSProviderRFC2136() to return no error but the error was -> %v", err)
 	}
-	if err := provider.CreateTXTRecord(rfc2136TestFqdn, rfc2136TestValue, rfc2136TestTTL); err != nil {
-		t.Errorf("Expected CreateTXTRecord() to return no error but the error was -> %v", err)
+	if err := provider.Present(rfc2136TestDomain, "", rfc2136TestKeyAuth); err != nil {
+		t.Errorf("Expected Present() to return no error but the error was -> %v", err)
 	}
 }
 
@@ -136,8 +138,9 @@ func TestRFC2136ValidUpdatePacket(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected NewDNSProviderRFC2136() to return no error but the error was -> %v", err)
 	}
-	if err := provider.CreateTXTRecord(rfc2136TestFqdn, rfc2136TestValue, rfc2136TestTTL); err != nil {
-		t.Errorf("Expected CreateTXTRecord() to return no error but the error was -> %v", err)
+
+	if err := provider.Present(rfc2136TestDomain, "", "1234d=="); err != nil {
+		t.Errorf("Expected Present() to return no error but the error was -> %v", err)
 	}
 
 	rcvMsg := <-reqChan

--- a/acme/dns_challenge_route53.go
+++ b/acme/dns_challenge_route53.go
@@ -40,13 +40,15 @@ func NewDNSProviderRoute53(awsAccessKey, awsSecretKey, awsRegionName string) (*D
 	return &DNSProviderRoute53{client: client}, nil
 }
 
-// CreateTXTRecord creates a TXT record using the specified parameters
-func (r *DNSProviderRoute53) CreateTXTRecord(fqdn, value string, ttl int) error {
+// Present creates a TXT record using the specified parameters
+func (r *DNSProviderRoute53) Present(domain, token, keyAuth string) error {
+	fqdn, value, ttl := DNS01Record(domain, keyAuth)
 	return r.changeRecord("UPSERT", fqdn, value, ttl)
 }
 
-// RemoveTXTRecord removes the TXT record matching the specified parameters
-func (r *DNSProviderRoute53) RemoveTXTRecord(fqdn, value string, ttl int) error {
+// CleanUp removes the TXT record matching the specified parameters
+func (r *DNSProviderRoute53) CleanUp(domain, token, keyAuth string) error {
+	fqdn, value, ttl := DNS01Record(domain, keyAuth)
 	return r.changeRecord("DELETE", fqdn, value, ttl)
 }
 
@@ -110,7 +112,7 @@ func newTXTRecordSet(fqdn, value string, ttl int) route53.ResourceRecordSet {
 
 // Route53 API has pretty strict rate limits (5req/s globally per account)
 // Hence we check if we are being throttled to maybe retry the request
-func rateExceeded (err error) bool {
+func rateExceeded(err error) bool {
 	if strings.Contains(err.Error(), "Throttling") {
 		return true
 	}

--- a/acme/dns_challenge_route53_test.go
+++ b/acme/dns_challenge_route53_test.go
@@ -108,19 +108,22 @@ func TestNewDNSProviderRoute53InvalidRegionErr(t *testing.T) {
 	assert.EqualError(t, err, "Invalid AWS region name us-east-3")
 }
 
-func TestRoute53CreateTXTRecord(t *testing.T) {
+func TestRoute53Present(t *testing.T) {
 	assert := assert.New(t)
 	testServer := makeRoute53TestServer()
 	provider := makeRoute53Provider(testServer)
 	testServer.ResponseMap(2, serverResponseMap)
 
-	err := provider.CreateTXTRecord("_acme-challenge.123.example.com.", "123456d==", 120)
-	assert.NoError(err, "Expected CreateTXTRecord to return no error")
+	domain := "example.com"
+	keyAuth := "123456d=="
+
+	err := provider.Present(domain, "", keyAuth)
+	assert.NoError(err, "Expected Present to return no error")
 
 	httpReqs := testServer.WaitRequests(2)
 	httpReq := httpReqs[1]
 
 	assert.Equal("/2013-04-01/hostedzone/Z2K123214213123/rrset", httpReq.URL.Path,
-		"Expected CreateTXTRecord to select the correct hostedzone")
+		"Expected Present to select the correct hostedzone")
 
 }

--- a/acme/http_challenge_server.go
+++ b/acme/http_challenge_server.go
@@ -1,0 +1,63 @@
+package acme
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// httpChallengeServer implements ChallengeProvider for `http-01` challenge
+type httpChallengeServer struct {
+	iface    string
+	port     string
+	done     chan bool
+	listener net.Listener
+}
+
+// Present makes the token available at `HTTP01ChallengePath(token)`
+func (s *httpChallengeServer) Present(domain, token, keyAuth string) error {
+	if s.port == "" {
+		s.port = "80"
+	}
+
+	var err error
+	s.listener, err = net.Listen("tcp", net.JoinHostPort(s.iface, s.port))
+	if err != nil {
+		return fmt.Errorf("Could not start HTTP server for challenge -> %v", err)
+	}
+
+	s.done = make(chan bool)
+	go s.serve(domain, token, keyAuth)
+	return nil
+}
+
+func (s *httpChallengeServer) CleanUp(domain, token, keyAuth string) error {
+	if s.listener == nil {
+		return nil
+	}
+	s.listener.Close()
+	<-s.done
+	return nil
+}
+
+func (s *httpChallengeServer) serve(domain, token, keyAuth string) {
+	path := HTTP01ChallengePath(token)
+
+	// The handler validates the HOST header and request type.
+	// For validation it then writes the token the server returned with the challenge
+	mux := http.NewServeMux()
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.Host, domain) && r.Method == "GET" {
+			w.Header().Add("Content-Type", "text/plain")
+			w.Write([]byte(keyAuth))
+			logf("[INFO][%s] Served key authentication", domain)
+		} else {
+			logf("[INFO] Received request for domain %s with method %s", r.Host, r.Method)
+			w.Write([]byte("TEST"))
+		}
+	})
+
+	http.Serve(s.listener, mux)
+	s.done <- true
+}

--- a/acme/http_challenge_test.go
+++ b/acme/http_challenge_test.go
@@ -10,7 +10,7 @@ import (
 func TestHTTPChallenge(t *testing.T) {
 	privKey, _ := generatePrivateKey(rsakey, 512)
 	j := &jws{privKey: privKey.(*rsa.PrivateKey)}
-	clientChallenge := challenge{Type: "http-01", Token: "http1"}
+	clientChallenge := challenge{Type: HTTP01, Token: "http1"}
 	mockValidate := func(_ *jws, _, _ string, chlng challenge) error {
 		uri := "http://localhost:23457/.well-known/acme-challenge/" + chlng.Token
 		resp, err := httpGet(uri)
@@ -35,7 +35,7 @@ func TestHTTPChallenge(t *testing.T) {
 
 		return nil
 	}
-	solver := &httpChallenge{jws: j, validate: mockValidate, port: "23457"}
+	solver := &httpChallenge{jws: j, validate: mockValidate, provider: &httpChallengeServer{port: "23457"}}
 
 	if err := solver.Solve(clientChallenge, "localhost:23457"); err != nil {
 		t.Errorf("Solve error: got %v, want nil", err)
@@ -45,8 +45,8 @@ func TestHTTPChallenge(t *testing.T) {
 func TestHTTPChallengeInvalidPort(t *testing.T) {
 	privKey, _ := generatePrivateKey(rsakey, 128)
 	j := &jws{privKey: privKey.(*rsa.PrivateKey)}
-	clientChallenge := challenge{Type: "http-01", Token: "http2"}
-	solver := &httpChallenge{jws: j, validate: stubValidate, port: "123456"}
+	clientChallenge := challenge{Type: HTTP01, Token: "http2"}
+	solver := &httpChallenge{jws: j, validate: stubValidate, provider: &httpChallengeServer{port: "123456"}}
 
 	if err := solver.Solve(clientChallenge, "localhost:123456"); err == nil {
 		t.Errorf("Solve error: got %v, want error", err)

--- a/acme/messages.go
+++ b/acme/messages.go
@@ -82,7 +82,7 @@ type validationRecord struct {
 
 type challenge struct {
 	Resource          string             `json:"resource,omitempty"`
-	Type              string             `json:"type,omitempty"`
+	Type              Challenge          `json:"type,omitempty"`
 	Status            string             `json:"status,omitempty"`
 	URI               string             `json:"uri,omitempty"`
 	Token             string             `json:"token,omitempty"`

--- a/acme/provider.go
+++ b/acme/provider.go
@@ -1,0 +1,8 @@
+package acme
+
+// ChallengeProvider presents the solution to a challenge available to be solved
+// CleanUp will be called by the challenge if Present ends in a non-error state.
+type ChallengeProvider interface {
+	Present(domain, token, keyAuth string) error
+	CleanUp(domain, token, keyAuth string) error
+}

--- a/acme/tls_sni_challenge_server.go
+++ b/acme/tls_sni_challenge_server.go
@@ -1,0 +1,52 @@
+package acme
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+)
+
+// tlsSNIChallengeServer implements ChallengeProvider for `TLS-SNI-01` challenge
+type tlsSNIChallengeServer struct {
+	iface    string
+	port     string
+	done     chan bool
+	listener net.Listener
+}
+
+// Present makes the keyAuth available as a cert
+func (s *tlsSNIChallengeServer) Present(domain, token, keyAuth string) error {
+	if s.port == "" {
+		s.port = "443"
+	}
+
+	cert, err := TLSSNI01ChallengeCert(keyAuth)
+	if err != nil {
+		return err
+	}
+
+	tlsConf := new(tls.Config)
+	tlsConf.Certificates = []tls.Certificate{cert}
+
+	s.listener, err = tls.Listen("tcp", net.JoinHostPort(s.iface, s.port), tlsConf)
+	if err != nil {
+		return fmt.Errorf("Could not start HTTPS server for challenge -> %v", err)
+	}
+
+	s.done = make(chan bool)
+	go func() {
+		http.Serve(s.listener, nil)
+		s.done <- true
+	}()
+	return nil
+}
+
+func (s *tlsSNIChallengeServer) CleanUp(domain, token, keyAuth string) error {
+	if s.listener == nil {
+		return nil
+	}
+	s.listener.Close()
+	<-s.done
+	return nil
+}

--- a/acme/tls_sni_challenge_test.go
+++ b/acme/tls_sni_challenge_test.go
@@ -13,7 +13,7 @@ import (
 func TestTLSSNIChallenge(t *testing.T) {
 	privKey, _ := generatePrivateKey(rsakey, 512)
 	j := &jws{privKey: privKey.(*rsa.PrivateKey)}
-	clientChallenge := challenge{Type: "tls-sni-01", Token: "tlssni1"}
+	clientChallenge := challenge{Type: TLSSNI01, Token: "tlssni1"}
 	mockValidate := func(_ *jws, _, _ string, chlng challenge) error {
 		conn, err := tls.Dial("tcp", "localhost:23457", &tls.Config{
 			InsecureSkipVerify: true,
@@ -43,7 +43,7 @@ func TestTLSSNIChallenge(t *testing.T) {
 
 		return nil
 	}
-	solver := &tlsSNIChallenge{jws: j, validate: mockValidate, port: "23457"}
+	solver := &tlsSNIChallenge{jws: j, validate: mockValidate, provider: &tlsSNIChallengeServer{port: "23457"}}
 
 	if err := solver.Solve(clientChallenge, "localhost:23457"); err != nil {
 		t.Errorf("Solve error: got %v, want nil", err)
@@ -53,8 +53,8 @@ func TestTLSSNIChallenge(t *testing.T) {
 func TestTLSSNIChallengeInvalidPort(t *testing.T) {
 	privKey, _ := generatePrivateKey(rsakey, 128)
 	j := &jws{privKey: privKey.(*rsa.PrivateKey)}
-	clientChallenge := challenge{Type: "tls-sni-01", Token: "tlssni2"}
-	solver := &tlsSNIChallenge{jws: j, validate: stubValidate, port: "123456"}
+	clientChallenge := challenge{Type: TLSSNI01, Token: "tlssni2"}
+	solver := &tlsSNIChallenge{jws: j, validate: stubValidate, provider: &tlsSNIChallengeServer{port: "123456"}}
 
 	if err := solver.Solve(clientChallenge, "localhost:123456"); err == nil {
 		t.Errorf("Solve error: got %v, want error", err)

--- a/configuration.go
+++ b/configuration.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/codegangsta/cli"
+	"github.com/xenolf/lego/acme"
 )
 
 // Configuration type from CLI and config files.
@@ -24,8 +25,11 @@ func (c *Configuration) RsaBits() int {
 	return c.context.GlobalInt("rsa-key-size")
 }
 
-func (c *Configuration) ExcludedSolvers() []string {
-	return c.context.GlobalStringSlice("exclude")
+func (c *Configuration) ExcludedSolvers() (cc []acme.Challenge) {
+	for _, s := range c.context.GlobalStringSlice("exclude") {
+		cc = append(cc, acme.Challenge(s))
+	}
+	return
 }
 
 // ServerPath returns the OS dependent path to the data for a specific CA


### PR DESCRIPTION
This implements the last suggestion from #32 by @janeczku to separate solving the `http-01` challenge, from making the `keyAuth` available at the appropriate path.

This change creates a new interface

```go
type HTTPChallengeProvider interface {
	PresentToken(domain, path, keyAuth string) error
	CleanUp(domain, path string)
}
```

And a `httpChallengeServer` (extracted from `httpChallenge`) which implements that interface and is used by `Client`. 

I am looking to use `lego` as a library to generate certs and will need to have my own logic for making the token available, so the suggestion in #32 was quite useful.

@xenolf If you have any thoughts on this change (or suggestions on impelemtnation) i'm all ears.