### PR TITLE
Add DNSimple DNS support

### DIFF
--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -106,3 +106,21 @@ func checkDNS(domain, fqdn string) bool {
 
 	return false
 }
+
+// toFqdn converts the name into a fqdn appending a trailing dot.
+func toFqdn(name string) string {
+	n := len(name)
+	if n == 0 || name[n-1] == '.' {
+		return name
+	}
+	return name + "."
+}
+
+// unFqdn converts the fqdn into a name removing the trailing dot.
+func unFqdn(name string) string {
+	n := len(name)
+	if n != 0 && name[n-1] == '.' {
+		return name[:n-1]
+	}
+	return name
+}

--- a/acme/dns_challenge_cloudflare.go
+++ b/acme/dns_challenge_cloudflare.go
@@ -123,22 +123,6 @@ func newTxtRecord(zoneID, fqdn, value string, ttl int) *cloudflare.Record {
 	}
 }
 
-func toFqdn(name string) string {
-	n := len(name)
-	if n == 0 || name[n-1] == '.' {
-		return name
-	}
-	return name + "."
-}
-
-func unFqdn(name string) string {
-	n := len(name)
-	if n != 0 && name[n-1] == '.' {
-		return name[:n-1]
-	}
-	return name
-}
-
 // TTL must be between 120 and 86400 seconds
 func sanitizeTTL(ttl int) int {
 	switch {

--- a/acme/dns_challenge_cloudflare.go
+++ b/acme/dns_challenge_cloudflare.go
@@ -20,7 +20,7 @@ type DNSProviderCloudFlare struct {
 // variables CLOUDFLARE_EMAIL and CLOUDFLARE_API_KEY.
 func NewDNSProviderCloudFlare(cloudflareEmail, cloudflareKey string) (*DNSProviderCloudFlare, error) {
 	if cloudflareEmail == "" || cloudflareKey == "" {
-		cloudflareEmail, cloudflareKey = envAuth()
+		cloudflareEmail, cloudflareKey = cloudflareEnvAuth()
 		if cloudflareEmail == "" || cloudflareKey == "" {
 			return nil, fmt.Errorf("CloudFlare credentials missing")
 		}
@@ -151,7 +151,7 @@ func sanitizeTTL(ttl int) int {
 	}
 }
 
-func envAuth() (email, apiKey string) {
+func cloudflareEnvAuth() (email, apiKey string) {
 	email = os.Getenv("CLOUDFLARE_EMAIL")
 	apiKey = os.Getenv("CLOUDFLARE_API_KEY")
 	if len(email) == 0 || len(apiKey) == 0 {

--- a/acme/dns_challenge_dnsimple.go
+++ b/acme/dns_challenge_dnsimple.go
@@ -3,6 +3,7 @@ package acme
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/weppos/go-dnsimple/dnsimple"
 )
@@ -32,12 +33,100 @@ func NewDNSProviderDNSimple(dnsimpleEmail, dnsimpleApiKey string) (*DNSProviderD
 
 // Present creates a TXT record to fulfil the dns-01 challenge.
 func (c *DNSProviderDNSimple) Present(domain, token, keyAuth string) error {
+	fqdn, value, ttl := DNS01Record(domain, keyAuth)
+
+	zoneID, err := c.getHostedZoneID(domain)
+	if err != nil {
+		return err
+	}
+
+	recordAttributes := c.newTxtRecord(domain, fqdn, value, ttl)
+	_, _, err = c.client.Domains.CreateRecord(zoneID, *recordAttributes)
+	if err != nil {
+		return fmt.Errorf("DNSimple API call failed: %v", err)
+	}
+
 	return nil
 }
 
 // CleanUp removes the TXT record matching the specified parameters.
 func (c *DNSProviderDNSimple) CleanUp(domain, token, keyAuth string) error {
+	fqdn, _, _ := DNS01Record(domain, keyAuth)
+
+	records, err := c.findTxtRecords(domain, fqdn)
+	if err != nil {
+		return err
+	}
+
+	for _, rec := range records {
+		_, err := c.client.Domains.DeleteRecord(rec.DomainId, rec.Id)
+		if err != nil {
+			return err
+		}
+	}
 	return nil
+}
+
+func (c *DNSProviderDNSimple) getHostedZoneID(domain string) (string, error) {
+	domains, _, err := c.client.Domains.List()
+	if err != nil {
+		return "", fmt.Errorf("DNSimple API call failed: %v", err)
+	}
+
+	var hostedDomain dnsimple.Domain
+	for _, d := range domains {
+		if strings.HasSuffix(domain, d.Name) {
+			if len(d.Name) > len(hostedDomain.Name) {
+				hostedDomain = d
+			}
+		}
+	}
+	if hostedDomain.Id == 0 {
+		return "", fmt.Errorf("No matching DNSimple domain found for domain %s", domain)
+	}
+
+	return fmt.Sprintf("%v", hostedDomain.Id), nil
+}
+
+func (c *DNSProviderDNSimple) findTxtRecords(domain, fqdn string) ([]*dnsimple.Record, error) {
+	zoneID, err := c.getHostedZoneID(domain)
+	if err != nil {
+		return nil, err
+	}
+
+	var records []*dnsimple.Record
+	result, _, err := c.client.Domains.ListRecords(zoneID, "", "TXT")
+	if err != nil {
+		return records, fmt.Errorf("DNSimple API call has failed: %v", err)
+	}
+
+	recordName := c.extractRecordName(fqdn, domain)
+	for _, record := range result {
+		if record.Name == recordName {
+			records = append(records, &record)
+		}
+	}
+
+	return records, nil
+}
+
+func (c *DNSProviderDNSimple) newTxtRecord(domain, fqdn, value string, ttl int) *dnsimple.Record {
+	name := c.extractRecordName(fqdn, domain)
+
+	return &dnsimple.Record{
+		Type:    "TXT",
+		Name:    name,
+		Content: value,
+		TTL:     ttl,
+	}
+}
+
+func (c *DNSProviderDNSimple) extractRecordName(fqdn, domain string) string {
+	name := unFqdn(fqdn)
+	if idx := strings.Index(name, "."+domain); idx != -1 {
+		return name[:idx]
+	}
+	return name
 }
 
 func dnsimpleEnvAuth() (email, apiKey string) {

--- a/acme/dns_challenge_dnsimple.go
+++ b/acme/dns_challenge_dnsimple.go
@@ -2,6 +2,7 @@ package acme
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/weppos/go-dnsimple/dnsimple"
 )
@@ -12,10 +13,14 @@ type DNSProviderDNSimple struct {
 }
 
 // NewDNSProviderDNSimple returns a DNSProviderDNSimple instance with a configured dnsimple client.
-// Authentication is either done using the passed credentials.
+// Authentication is either done using the passed credentials or - when empty - using the environment
+// variables DNSIMPLE_EMAIL and DNSIMPLE_API_KEY.
 func NewDNSProviderDNSimple(dnsimpleEmail, dnsimpleApiKey string) (*DNSProviderDNSimple, error) {
 	if dnsimpleEmail == "" || dnsimpleApiKey == "" {
-		return nil, fmt.Errorf("DNSimple credentials missing")
+		dnsimpleEmail, dnsimpleApiKey = dnsimpleEnvAuth()
+		if dnsimpleEmail == "" || dnsimpleApiKey == "" {
+			return nil, fmt.Errorf("DNSimple credentials missing")
+		}
 	}
 
 	c := &DNSProviderDNSimple{
@@ -33,4 +38,13 @@ func (c *DNSProviderDNSimple) Present(domain, token, keyAuth string) error {
 // CleanUp removes the TXT record matching the specified parameters.
 func (c *DNSProviderDNSimple) CleanUp(domain, token, keyAuth string) error {
 	return nil
+}
+
+func dnsimpleEnvAuth() (email, apiKey string) {
+	email = os.Getenv("DNSIMPLE_EMAIL")
+	apiKey = os.Getenv("DNSIMPLE_API_KEY")
+	if len(email) == 0 || len(apiKey) == 0 {
+		return "", ""
+	}
+	return
 }

--- a/acme/dns_challenge_dnsimple.go
+++ b/acme/dns_challenge_dnsimple.go
@@ -1,6 +1,8 @@
 package acme
 
 import (
+	"fmt"
+
 	"github.com/weppos/go-dnsimple/dnsimple"
 )
 
@@ -12,7 +14,15 @@ type DNSProviderDNSimple struct {
 // NewDNSProviderDNSimple returns a DNSProviderDNSimple instance with a configured dnsimple client.
 // Authentication is either done using the passed credentials.
 func NewDNSProviderDNSimple(dnsimpleEmail, dnsimpleApiKey string) (*DNSProviderDNSimple, error) {
-	return nil, nil
+	if dnsimpleEmail == "" || dnsimpleApiKey == "" {
+		return nil, fmt.Errorf("DNSimple credentials missing")
+	}
+
+	c := &DNSProviderDNSimple{
+		client: dnsimple.NewClient(dnsimpleApiKey, dnsimpleEmail),
+	}
+
+	return c, nil
 }
 
 // Present creates a TXT record to fulfil the dns-01 challenge.

--- a/acme/dns_challenge_dnsimple.go
+++ b/acme/dns_challenge_dnsimple.go
@@ -1,0 +1,26 @@
+package acme
+
+import (
+	"github.com/weppos/go-dnsimple/dnsimple"
+)
+
+// DNSProviderDNSimple is an implementation of the DNSProvider interface.
+type DNSProviderDNSimple struct {
+	client *dnsimple.Client
+}
+
+// NewDNSProviderDNSimple returns a DNSProviderDNSimple instance with a configured dnsimple client.
+// Authentication is either done using the passed credentials.
+func NewDNSProviderDNSimple(dnsimpleEmail, dnsimpleApiKey string) (*DNSProviderDNSimple, error) {
+	return nil, nil
+}
+
+// Present creates a TXT record to fulfil the dns-01 challenge.
+func (c *DNSProviderDNSimple) Present(domain, token, keyAuth string) error {
+	return nil
+}
+
+// CleanUp removes the TXT record matching the specified parameters.
+func (c *DNSProviderDNSimple) CleanUp(domain, token, keyAuth string) error {
+	return nil
+}

--- a/acme/dns_challenge_dnsimple_test.go
+++ b/acme/dns_challenge_dnsimple_test.go
@@ -1,0 +1,13 @@
+package acme
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+
+func TestNewDNSProviderDNSimpleValid(t *testing.T) {
+	_, err := NewDNSProviderDNSimple("example@example.com", "123")
+	assert.NoError(t, err)
+}

--- a/acme/dns_challenge_dnsimple_test.go
+++ b/acme/dns_challenge_dnsimple_test.go
@@ -1,17 +1,46 @@
 package acme
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	dnsimpleEmail  string
+	dnsimpleAPIKey string
+)
+
+func init() {
+	dnsimpleEmail = os.Getenv("DNSIMPLE_EMAIL")
+	dnsimpleAPIKey = os.Getenv("DNSIMPLE_API_KEY")
+}
+
+func restoreDNSimpleEnv() {
+	os.Setenv("DNSIMPLE_EMAIL", dnsimpleEmail)
+	os.Setenv("DNSIMPLE_API_KEY", dnsimpleAPIKey)
+}
+
 func TestNewDNSProviderDNSimpleValid(t *testing.T) {
+	os.Setenv("DNSIMPLE_EMAIL", "")
+	os.Setenv("DNSIMPLE_API_KEY", "")
 	_, err := NewDNSProviderDNSimple("example@example.com", "123")
 	assert.NoError(t, err)
+	restoreDNSimpleEnv()
+}
+func TestNewDNSProviderDNSimpleValidEnv(t *testing.T) {
+	os.Setenv("DNSIMPLE_EMAIL", "example@example.com")
+	os.Setenv("DNSIMPLE_API_KEY", "123")
+	_, err := NewDNSProviderDNSimple("", "")
+	assert.NoError(t, err)
+	restoreDNSimpleEnv()
 }
 
 func TestNewDNSProviderDNSimpleMissingCredErr(t *testing.T) {
+	os.Setenv("DNSIMPLE_EMAIL", "")
+	os.Setenv("DNSIMPLE_API_KEY", "")
 	_, err := NewDNSProviderDNSimple("", "")
 	assert.EqualError(t, err, "DNSimple credentials missing")
+	restoreDNSimpleEnv()
 }

--- a/acme/dns_challenge_dnsimple_test.go
+++ b/acme/dns_challenge_dnsimple_test.go
@@ -10,9 +10,9 @@ import (
 
 var (
 	dnsimpleLiveTest bool
-	dnsimpleEmail  string
-	dnsimpleAPIKey string
-	dnsimpleDomain string
+	dnsimpleEmail    string
+	dnsimpleAPIKey   string
+	dnsimpleDomain   string
 )
 
 func init() {

--- a/acme/dns_challenge_dnsimple_test.go
+++ b/acme/dns_challenge_dnsimple_test.go
@@ -3,18 +3,25 @@ package acme
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
 var (
+	dnsimpleLiveTest bool
 	dnsimpleEmail  string
 	dnsimpleAPIKey string
+	dnsimpleDomain string
 )
 
 func init() {
 	dnsimpleEmail = os.Getenv("DNSIMPLE_EMAIL")
 	dnsimpleAPIKey = os.Getenv("DNSIMPLE_API_KEY")
+	dnsimpleDomain = os.Getenv("DNSIMPLE_DOMAIN")
+	if len(dnsimpleEmail) > 0 && len(dnsimpleAPIKey) > 0 && len(dnsimpleDomain) > 0 {
+		dnsimpleLiveTest = true
+	}
 }
 
 func restoreDNSimpleEnv() {
@@ -43,4 +50,30 @@ func TestNewDNSProviderDNSimpleMissingCredErr(t *testing.T) {
 	_, err := NewDNSProviderDNSimple("", "")
 	assert.EqualError(t, err, "DNSimple credentials missing")
 	restoreDNSimpleEnv()
+}
+
+func TestLiveDNSimplePresent(t *testing.T) {
+	if !dnsimpleLiveTest {
+		t.Skip("skipping live test")
+	}
+
+	provider, err := NewDNSProviderDNSimple(dnsimpleEmail, dnsimpleAPIKey)
+	assert.NoError(t, err)
+
+	err = provider.Present(dnsimpleDomain, "", "123d==")
+	assert.NoError(t, err)
+}
+
+func TestLiveDNSimpleCleanUp(t *testing.T) {
+	if !dnsimpleLiveTest {
+		t.Skip("skipping live test")
+	}
+
+	time.Sleep(time.Second * 1)
+
+	provider, err := NewDNSProviderDNSimple(cflareEmail, cflareAPIKey)
+	assert.NoError(t, err)
+
+	err = provider.CleanUp(dnsimpleDomain, "", "123d==")
+	assert.NoError(t, err)
 }

--- a/acme/dns_challenge_dnsimple_test.go
+++ b/acme/dns_challenge_dnsimple_test.go
@@ -6,8 +6,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-
 func TestNewDNSProviderDNSimpleValid(t *testing.T) {
 	_, err := NewDNSProviderDNSimple("example@example.com", "123")
 	assert.NoError(t, err)
+}
+
+func TestNewDNSProviderDNSimpleMissingCredErr(t *testing.T) {
+	_, err := NewDNSProviderDNSimple("", "")
+	assert.EqualError(t, err, "DNSimple credentials missing")
 }


### PR DESCRIPTION
This PR adds support for [DNSimple](https://dnsimple.com/) using the [DNSimple API](https://developer.dnsimple.com/) and the [DNSimple Go client](https://github.com/weppos/go-dnsimple).

For now there are unit tests for the initialization, and live integration tests for Present/CleanUp. I'm planning to add some integration tests that use a mock client, but I need to check a few things on the existing go client first.

---

In the implementation, I tried to reuse the same conventions of the existing DNS providers. I have a couple of questions related to this implementation:

1. In the tests, none of the clients tests the proper assignment of the credentials:

    ```go
    func TestNewDNSProviderDNSimpleValid(t *testing.T) {
        os.Setenv("DNSIMPLE_EMAIL", "")
        os.Setenv("DNSIMPLE_API_KEY", "")
        _, err := NewDNSProviderDNSimple("example@example.com", "123")
        assert.NoError(t, err)
        restoreDNSimpleEnv()
    }
    ```

    For example, here the return value from `NewDNSProviderDNSimple` is ignored. Therefore, it's possible that the credentials are not properly set internally.

    In this particular cases, there are live tests that will catch the issue. However, assuming the tests will never run in a live environment, the bug will stay there. Is it something that you didn't check on purpose on the existing providers?

2. Are you against extracting header names into constants to avoid repeating `DNSIMPLE_EMAIL` all the time?

3. I reused `unFqdn` in the DNSimple provider, but it is defined in the cloudflare one. Is it fine, or do you prefer me to reimplement it or move it to a less provider-oriented place?
