### PR TITLE
dns_challenge preCheckDNS: let system resolver decide IPv4 ./. IPv6.

### DIFF
--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -73,7 +73,7 @@ func checkDNS(domain, fqdn string) bool {
 	m := new(dns.Msg)
 	m.SetQuestion(domain+".", dns.TypeSOA)
 	c := new(dns.Client)
-	in, _, err := c.Exchange(m, "8.8.8.8:53")
+	in, _, err := c.Exchange(m, "google-public-dns-a.google.com:53")
 	if err != nil {
 		return false
 	}

--- a/acme/dns_challenge_test.go
+++ b/acme/dns_challenge_test.go
@@ -37,3 +37,9 @@ func TestDNSValidServerResponse(t *testing.T) {
 		t.Errorf("VALID: Expected Solve to return no error but the error was -> %v", err)
 	}
 }
+
+func TestPreCheckDNS(t *testing.T) {
+	if !preCheckDNS("api.letsencrypt.org", "acme-staging.api.letsencrypt.org") {
+		t.Errorf("preCheckDNS failed for acme-staging.api.letsencrypt.org")
+	}
+}


### PR DESCRIPTION
We can ask the OS resolver for the IP of Google's public anycast DNS.
No need to "bootstrap" with literal IP address. The OS resolver knows
best about IPv4 ./. IPv6.

Mostly fixes #88.