### PR TITLE
Add missing domain name for consistency

### DIFF
--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -37,8 +37,7 @@ type dnsChallenge struct {
 }
 
 func (s *dnsChallenge) Solve(chlng challenge, domain string) error {
-
-	logf("[INFO] acme: Trying to solve DNS-01")
+	logf("[INFO][%s] acme: Trying to solve DNS-01", domain)
 
 	if s.provider == nil {
 		return errors.New("No DNS Provider configured")


### PR DESCRIPTION
This is a very trivial change.

While debugging #90 I noticed that the message related to the DNS validation did not include the domain name (whereas the HTTP and TLS challenges do). This is very useful when multiple domains are requested, and the challenges for each domain are run in parallel.

I added the domain for consistency with the other two log messages.