### PR TITLE
Refactor DNS check

### DIFF
--- a/acme/dns_challenge_route53.go
+++ b/acme/dns_challenge_route53.go
@@ -68,7 +68,7 @@ func (r *DNSProviderRoute53) changeRecord(action, fqdn, value string, ttl int) e
 		return err
 	}
 
-	return waitFor(90, func() (bool, error) {
+	return waitFor(90, 5, func() (bool, error) {
 		status, err := r.client.GetChange(resp.ChangeInfo.ID)
 		if err != nil {
 			return false, err

--- a/acme/dns_challenge_test.go
+++ b/acme/dns_challenge_test.go
@@ -6,13 +6,79 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"reflect"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 )
 
+var lookupNameserversTestsOK = []struct {
+	fqdn string
+	nss  []string
+}{
+	{"books.google.com.ng.",
+		[]string{"ns1.google.com.", "ns2.google.com.", "ns3.google.com.", "ns4.google.com."},
+	},
+	{"www.google.com.",
+		[]string{"ns1.google.com.", "ns2.google.com.", "ns3.google.com.", "ns4.google.com."},
+	},
+	{"physics.georgetown.edu.",
+		[]string{"ns1.georgetown.edu.", "ns2.georgetown.edu.", "ns3.georgetown.edu."},
+	},
+}
+
+var lookupNameserversTestsErr = []struct {
+	fqdn  string
+	error string
+}{
+	// invalid tld
+	{"_null.n0n0.",
+		"Could not resolve TLD",
+	},
+	// invalid domain
+	{"_null.com.",
+		"Could not resolve NXDOMAIN",
+	},
+	// invalid subdomain
+	{"_null.google.com.",
+		"Could not resolve NXDOMAIN",
+	},
+}
+
+var checkAuthoritativeNssTests = []struct {
+	fqdn, value string
+	ns          []string
+	ok          bool
+}{
+	// TXT RR w/ expected value
+	{"8.8.8.8.asn.routeviews.org.", "151698.8.8.024", []string{"asnums.routeviews.org."},
+		true,
+	},
+	// No TXT RR
+	{"ns1.google.com.", "", []string{"ns2.google.com."},
+		false,
+	},
+}
+
+var checkAuthoritativeNssTestsErr = []struct {
+	fqdn, value string
+	ns          []string
+	error       string
+}{
+	// TXT RR /w unexpected value
+	{"8.8.8.8.asn.routeviews.org.", "fe01=", []string{"asnums.routeviews.org."},
+		"did not return the expected TXT record",
+	},
+	// No TXT RR
+	{"ns1.google.com.", "fe01=", []string{"ns2.google.com."},
+		"did not return the expected TXT record",
+	},
+}
+
 func TestDNSValidServerResponse(t *testing.T) {
-	preCheckDNS = func(domain, fqdn string) bool {
-		return true
+	preCheckDNS = func(domain, fqdn, value string) error {
+		return nil
 	}
 	privKey, _ := generatePrivateKey(rsakey, 512)
 
@@ -39,7 +105,80 @@ func TestDNSValidServerResponse(t *testing.T) {
 }
 
 func TestPreCheckDNS(t *testing.T) {
-	if !preCheckDNS("api.letsencrypt.org", "acme-staging.api.letsencrypt.org") {
+	err := preCheckDNS("api.letsencrypt.org", "acme-staging.api.letsencrypt.org", "fe01=")
+	if err != nil {
 		t.Errorf("preCheckDNS failed for acme-staging.api.letsencrypt.org")
+	}
+}
+
+func TestLookupNameserversOK(t *testing.T) {
+	for _, tt := range lookupNameserversTestsOK {
+		nss, err := lookupNameservers(tt.fqdn)
+		if err != nil {
+			t.Fatalf("#%s: got %q; want nil", tt.fqdn, err)
+		}
+
+		sort.Strings(nss)
+		sort.Strings(tt.nss)
+
+		if !reflect.DeepEqual(nss, tt.nss) {
+			t.Errorf("#%s: got %v; want %v", tt.fqdn, nss, tt.nss)
+		}
+	}
+}
+
+func TestLookupNameserversErr(t *testing.T) {
+	for _, tt := range lookupNameserversTestsErr {
+		_, err := lookupNameservers(tt.fqdn)
+		if err == nil {
+			t.Fatalf("#%s: expected %q (error); got <nil>", tt.fqdn, tt.error)
+		}
+
+		if !strings.Contains(err.Error(), tt.error) {
+			t.Errorf("#%s: expected %q (error); got %q", tt.fqdn, tt.error, err)
+			continue
+		}
+	}
+}
+
+func TestCheckAuthoritativeNss(t *testing.T) {
+	for _, tt := range checkAuthoritativeNssTests {
+		ok, _ := checkAuthoritativeNss(tt.fqdn, tt.value, tt.ns)
+		if ok != tt.ok {
+			t.Errorf("#%s: got %t; want %t", tt.fqdn, tt.ok)
+		}
+	}
+}
+
+func TestCheckAuthoritativeNssErr(t *testing.T) {
+	for _, tt := range checkAuthoritativeNssTestsErr {
+		_, err := checkAuthoritativeNss(tt.fqdn, tt.value, tt.ns)
+		if err == nil {
+			t.Fatalf("#%s: expected %q (error); got <nil>", tt.fqdn, tt.error)
+		}
+		if !strings.Contains(err.Error(), tt.error) {
+			t.Errorf("#%s: expected %q (error); got %q", tt.fqdn, tt.error, err)
+			continue
+		}
+	}
+}
+
+func TestWaitForTimeout(t *testing.T) {
+	c := make(chan error)
+	go func() {
+		err := waitFor(3, 1, func() (bool, error) {
+			return false, nil
+		})
+		c <- err
+	}()
+
+	timeout := time.After(4 * time.Second)
+	select {
+	case <-timeout:
+		t.Fatal("timeout exceeded")
+	case err := <-c:
+		if err == nil {
+			t.Errorf("expected timeout error; got <nil>", err)
+		}
 	}
 }


### PR DESCRIPTION
Fixes #95 

* Implements a (semi-)~~recursive~~ iterative lookup mechanism to find all authoritative
nameservers for the zone enclosing the domain.
This is necessary because a direct query for NS records at a recursive DNS server (e.g. Google Public DNS) or at the zone's primary nameserver will often yield an incomplete list of authoritative nameservers or even those of a another zone (e.g.
when the domain is a CNAME pointing to another zone).
* All authoritative nameservers are then queried for the TXT record to make
sure that it has been completely propagated.
* The waitFor utility function now takes an interval parameter and returns
the last seen error on timeout.