### PR TITLE
Route53 provider fixes

### DIFF
--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -123,3 +123,23 @@ func unFqdn(name string) string {
 	}
 	return name
 }
+
+// waitFor polls the given function 'f', once per second, up to 'timeout' seconds.
+func waitFor(timeout int, f func() (bool, error)) error {
+	start := time.Now().Second()
+	for {
+		time.Sleep(1 * time.Second)
+
+		if delta := time.Now().Second() - start; delta >= timeout {
+			return fmt.Errorf("Time limit exceeded (%d seconds)", delta)
+		}
+
+		stop, err := f()
+		if err != nil {
+			return err
+		}
+		if stop {
+			return nil
+		}
+	}
+}

--- a/acme/dns_challenge_route53_test.go
+++ b/acme/dns_challenge_route53_test.go
@@ -51,9 +51,19 @@ var ListHostedZonesAnswer = `<?xml version="1.0" encoding="utf-8"?>
     <MaxItems>100</MaxItems>
 </ListHostedZonesResponse>`
 
+var GetChangeAnswer = `<?xml version="1.0" encoding="UTF-8"?>
+<GetChangeResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+   <ChangeInfo>
+      <Id>/change/asdf</Id>
+      <Status>INSYNC</Status>
+      <SubmittedAt>2016-02-03T01:36:41.958Z</SubmittedAt>
+   </ChangeInfo>
+</GetChangeResponse>`
+
 var serverResponseMap = testutil.ResponseMap{
 	"/2013-04-01/hostedzone/":                      testutil.Response{200, nil, ListHostedZonesAnswer},
 	"/2013-04-01/hostedzone/Z2K123214213123/rrset": testutil.Response{200, nil, ChangeResourceRecordSetsAnswer},
+	"/2013-04-01/change/asdf":                      testutil.Response{200, nil, GetChangeAnswer},
 }
 
 func init() {
@@ -112,7 +122,7 @@ func TestRoute53Present(t *testing.T) {
 	assert := assert.New(t)
 	testServer := makeRoute53TestServer()
 	provider := makeRoute53Provider(testServer)
-	testServer.ResponseMap(2, serverResponseMap)
+	testServer.ResponseMap(3, serverResponseMap)
 
 	domain := "example.com"
 	keyAuth := "123456d=="
@@ -120,7 +130,7 @@ func TestRoute53Present(t *testing.T) {
 	err := provider.Present(domain, "", keyAuth)
 	assert.NoError(err, "Expected Present to return no error")
 
-	httpReqs := testServer.WaitRequests(2)
+	httpReqs := testServer.WaitRequests(3)
 	httpReq := httpReqs[1]
 
 	assert.Equal("/2013-04-01/hostedzone/Z2K123214213123/rrset", httpReq.URL.Path,


### PR DESCRIPTION
Fixes:
- InvalidTXTRDATA error when creating TXT record (closes #94)
- Present() should poll and wait until the status of the record change becomes INSYNC (thanks @oov)

Adds a retry w/ timeout utility function that may be used in other places