### PR TITLE
Handle HEAD request errors

### DIFF
--- a/acme/http.go
+++ b/acme/http.go
@@ -33,9 +33,10 @@ func httpHead(url string) (resp *http.Response, err error) {
 	req.Header.Set("User-Agent", userAgent())
 
 	resp, err = http.DefaultClient.Do(req)
-	if resp.Body != nil {
-		resp.Body.Close()
+	if err != nil {
+		return resp, err
 	}
+	resp.Body.Close()
 	return resp, err
 }
 


### PR DESCRIPTION
When a HEAD request failed, the error wasn't handled correctly causing the subsequent `Body.Close()` to panic.

```
2016/01/30 18:47:58 client.go:31: [INFO][redacted] acme: Obtaining bundled SAN certificate
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x40 pc=0x4ed32f]

goroutine 14377 [running]:
github.com/xenolf/lego/acme.httpHead(0x8d57d0, 0x2e, 0x0, 0x2b21962ff5d8, 0xc2081be660)
        /.../src/github.com/xenolf/lego/acme/http.go:37 +0x14f
github.com/xenolf/lego/acme.(*jws).getNonce(0xc2081bf6b0, 0x0, 0x0)
        /.../src/github.com/xenolf/lego/acme/jws.go:74 +0x4a
github.com/xenolf/lego/acme.(*jws).Nonce(0xc2081bf6b0, 0x0, 0x0, 0x0, 0x0)
        /.../src/github.com/xenolf/lego/acme/jws.go:85 +0x78
github.com/square/go-jose.(*genericSigner).Sign(0xc2081be2d0, 0xc2083d22d0, 0x6b, 0x8b, 0x2b2192cf7e98, 0x0, 0x0)
        /tmp/go-install-as_m9gtLkFG/src/github.com/square/go-jose/signing.go:150 +0x2f9
github.com/xenolf/lego/acme.(*jws).signContent(0xc2081bf6b0, 0xc2083d22d0, 0x6b, 0x8b, 0xc2081be210, 0x0, 0x0)
        /.../src/github.com/xenolf/lego/acme/jws.go:56 +0x157
github.com/xenolf/lego/acme.(*jws).post(0xc2081bf6b0, 0xc208295fc0, 0x33, 0xc2083d22d0, 0x6b, 0x8b, 0x0, 0x0, 0x0)
        /.../src/github.com/xenolf/lego/acme/jws.go:33 +0x72
github.com/xenolf/lego/acme.postJSON(0xc2081bf6b0, 0xc208295fc0, 0x33, 0x80a420, 0xc2083d2240, 0x708080, 0xc2083d21b0, 0x0, 0x0, 0x0)
        /.../src/github.com/xenolf/lego/acme/http.go:94 +0x1f4
github.com/xenolf/lego/acme.func·001(0xc208086230, 0xb)
        /.../src/github.com/xenolf/lego/acme/client.go:396 +0x1c5
```
