### PR TITLE
Allow to customize the TSIG algorithm and allow to omit the DNS port

### DIFF
--- a/acme/dns_challenge_rfc2136.go
+++ b/acme/dns_challenge_rfc2136.go
@@ -2,6 +2,7 @@ package acme
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/miekg/dns"
@@ -20,9 +21,13 @@ type DNSProviderRFC2136 struct {
 
 // NewDNSProviderRFC2136 returns a new DNSProviderRFC2136 instance.
 // To disable TSIG authentication 'tsigAlgorithm, 'tsigKey' and 'tsigSecret' must be set to the empty string.
-// 'nameserver' must be a network address in the the form "host:port". 'zone' must be the fully
+// 'nameserver' must be a network address in the the form "host" or "host:port". 'zone' must be the fully
 // qualified name of the zone.
 func NewDNSProviderRFC2136(nameserver, zone, tsigAlgorithm, tsigKey, tsigSecret string) (*DNSProviderRFC2136, error) {
+	// Append the default DNS port if none is specified.
+	if !strings.Contains(nameserver, ":") {
+		nameserver += ":53"
+	}
 	d := &DNSProviderRFC2136{
 		nameserver: nameserver,
 		zone:       zone,

--- a/acme/dns_challenge_rfc2136_test.go
+++ b/acme/dns_challenge_rfc2136_test.go
@@ -57,7 +57,7 @@ func TestRFC2136ServerSuccess(t *testing.T) {
 	}
 	defer server.Shutdown()
 
-	provider, err := NewDNSProviderRFC2136(addrstr, rfc2136TestZone, "", "")
+	provider, err := NewDNSProviderRFC2136(addrstr, rfc2136TestZone, "", "", "")
 	if err != nil {
 		t.Fatalf("Expected NewDNSProviderRFC2136() to return no error but the error was -> %v", err)
 	}
@@ -76,7 +76,7 @@ func TestRFC2136ServerError(t *testing.T) {
 	}
 	defer server.Shutdown()
 
-	provider, err := NewDNSProviderRFC2136(addrstr, rfc2136TestZone, "", "")
+	provider, err := NewDNSProviderRFC2136(addrstr, rfc2136TestZone, "", "", "")
 	if err != nil {
 		t.Fatalf("Expected NewDNSProviderRFC2136() to return no error but the error was -> %v", err)
 	}
@@ -97,7 +97,7 @@ func TestRFC2136TsigClient(t *testing.T) {
 	}
 	defer server.Shutdown()
 
-	provider, err := NewDNSProviderRFC2136(addrstr, rfc2136TestZone, rfc2136TestTsigKey, rfc2136TestTsigSecret)
+	provider, err := NewDNSProviderRFC2136(addrstr, rfc2136TestZone, "", rfc2136TestTsigKey, rfc2136TestTsigSecret)
 	if err != nil {
 		t.Fatalf("Expected NewDNSProviderRFC2136() to return no error but the error was -> %v", err)
 	}
@@ -135,7 +135,7 @@ func TestRFC2136ValidUpdatePacket(t *testing.T) {
 		t.Fatalf("Error packing expect msg: %v", err)
 	}
 
-	provider, err := NewDNSProviderRFC2136(addrstr, rfc2136TestZone, "", "")
+	provider, err := NewDNSProviderRFC2136(addrstr, rfc2136TestZone, "", "", "")
 	if err != nil {
 		t.Fatalf("Expected NewDNSProviderRFC2136() to return no error but the error was -> %v", err)
 	}

--- a/cli_handlers.go
+++ b/cli_handlers.go
@@ -69,10 +69,11 @@ func setup(c *cli.Context) (*Configuration, *Account, *acme.Client) {
 		case "rfc2136":
 			nameserver := os.Getenv("RFC2136_NAMESERVER")
 			zone := os.Getenv("RFC2136_ZONE")
+			tsigAlgorithm := os.Getenv("RFC2136_TSIG_ALGORITHM")
 			tsigKey := os.Getenv("RFC2136_TSIG_KEY")
 			tsigSecret := os.Getenv("RFC2136_TSIG_SECRET")
 
-			provider, err = acme.NewDNSProviderRFC2136(nameserver, zone, tsigKey, tsigSecret)
+			provider, err = acme.NewDNSProviderRFC2136(nameserver, zone, tsigAlgorithm, tsigKey, tsigSecret)
 		case "manual":
 			provider, err = acme.NewDNSProviderManual()
 		}


### PR DESCRIPTION
The TSIG algorithm is currently hardcoded as HMAC-MD5. Any other key type cannot be used. Let's add an environment variable that allows to pass through the pseudo domain name used for the HMAC type.

Also append the default DNS port to the target nameserver to be updated, in case none is specified. This is caused by the Go API wanting to know the port for the connection, but we know a sensible destination default.