### PR TITLE
Compact IAM policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,33 +140,17 @@ Replace `<INSERT_YOUR_HOSTED_ZONE_ID_HERE>` with the Route 53 zone ID of the dom
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "1",
             "Effect": "Allow",
-            "Action": [
-                "route53:ChangeResourceRecordSets"
-            ],
-            "Resource": [
-                "arn:aws:route53:::hostedzone/<INSERT_YOUR_HOSTED_ZONE_ID_HERE>"
-            ]
-        },
-        {
-            "Sid": "2",
-            "Effect": "Allow",
-            "Action": [
-                "route53:GetChange"
-            ],
-            "Resource": [
-                "arn:aws:route53:::change/*"
-            ]
-        },
-        {
-            "Sid": "3",
-            "Effect": "Allow",
-            "Action": [
-                "route53:ListHostedZones"
-            ],
+            "Action": [ "route53:ListHostedZones", "route53:GetChange" ],
             "Resource": [
                 "*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": ["route53:ChangeResourceRecordSets"],
+            "Resource": [
+                "arn:aws:route53:::hostedzone/<INSERT_YOUR_HOSTED_ZONE_ID_HERE>"
             ]
         }
     ]


### PR DESCRIPTION
The IAM policy in the README seemed like it would benefit from being shorter, which I accomplished as follows:

* `Sid` is optional and can be omitted for brevity.
* Both `route53:ListHostedZones` and `route53:GetChange` are effectively allowed for `*`, so they can be combined into a single statement.
* Actions can be specified on the same line as  `"Action": […]`, since the JSON is equivalent either way.

See [the README in my fork](https://github.com/willglynn/lego/tree/compact_iam_policy#aws-route-53) for a preview, and compare to [the README in master](https://github.com/xenolf/lego/blob/master/README.md#aws-route-53). `Resource: […]` could be combined too, but that would make the `<INSERT_YOUR_HOSTED_ZONE_ID_HERE>` line really long, so I left that as-is.