### PR TITLE
GetOCSPForCert should fail if there are no OCSP servers in the cert.

### DIFF
--- a/acme/crypto.go
+++ b/acme/crypto.go
@@ -90,6 +90,10 @@ func GetOCSPForCert(bundle []byte) ([]byte, *ocsp.Response, error) {
 	issuedCert := certificates[0]
 	issuerCert := certificates[1]
 
+	if len(issuedCert.OCSPServer) == 0 {
+		return nil, nil, errors.New("no OCSP server specified in cert")
+	}
+
 	// Finally kick off the OCSP request.
 	ocspReq, err := ocsp.CreateRequest(issuedCert, issuerCert, nil)
 	if err != nil {


### PR DESCRIPTION
This issue came up on another project, see: https://github.com/mholt/caddy/pull/579