### PR TITLE
http-01 challenge: disable TCP connection reuse

### DIFF
--- a/acme/http_challenge_server.go
+++ b/acme/http_challenge_server.go
@@ -58,6 +58,12 @@ func (s *httpChallengeServer) serve(domain, token, keyAuth string) {
 		}
 	})
 
-	http.Serve(s.listener, mux)
+	httpServer := &http.Server{
+		Handler: mux,
+	}
+	// Once httpServer is shut down we don't want any lingering
+	// connections, so disable KeepAlives.
+	httpServer.SetKeepAlivesEnabled(false)
+	httpServer.Serve(s.listener)
 	s.done <- true
 }


### PR DESCRIPTION
If TCP connection reuse (KeepAlives) are left on then, in a sequence
of challenges arising from a multiple-domain certficate, challenges
after the 1st can fail due to reusing the now defunct tcp connection
used in the first challenge. This has been observed when using the Go
standard library reverse proxy to forward the challenges to Lego.

Fixes #107