### PR TITLE
Move DNS providers into a separate package

### DIFF
--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -182,24 +182,6 @@ func lookupNameservers(fqdn string) ([]string, error) {
 	return lookupNameservers(next)
 }
 
-// toFqdn converts the name into a fqdn appending a trailing dot.
-func toFqdn(name string) string {
-	n := len(name)
-	if n == 0 || name[n-1] == '.' {
-		return name
-	}
-	return name + "."
-}
-
-// unFqdn converts the fqdn into a name removing the trailing dot.
-func unFqdn(name string) string {
-	n := len(name)
-	if n != 0 && name[n-1] == '.' {
-		return name[:n-1]
-	}
-	return name
-}
-
 // waitFor polls the given function 'f', once every 'interval' seconds, up to 'timeout' seconds.
 func waitFor(timeout, interval int, f func() (bool, error)) error {
 	var lastErr string

--- a/acme/dns_challenge_test.go
+++ b/acme/dns_challenge_test.go
@@ -72,6 +72,17 @@ var checkAuthoritativeNssTestsErr = []struct {
 	},
 }
 
+// make a no-op provider for this test
+type nullProvider struct{}
+
+func (_ nullProvider) Present(domain, token, keyAuth string) error {
+	return nil
+}
+
+func (_ nullProvider) CleanUp(domain, token, keyAuth string) error {
+	return nil
+}
+
 func TestDNSValidServerResponse(t *testing.T) {
 	preCheckDNS = func(fqdn, value string) (bool, error) {
 		return true, nil
@@ -83,9 +94,8 @@ func TestDNSValidServerResponse(t *testing.T) {
 		w.Write([]byte("{\"type\":\"dns01\",\"status\":\"valid\",\"uri\":\"http://some.url\",\"token\":\"http8\"}"))
 	}))
 
-	manualProvider, _ := NewDNSProviderManual()
 	jws := &jws{privKey: privKey.(*rsa.PrivateKey), directoryURL: ts.URL}
-	solver := &dnsChallenge{jws: jws, validate: validate, provider: manualProvider}
+	solver := &dnsChallenge{jws: jws, validate: validate, provider: nullProvider{}}
 	clientChallenge := challenge{Type: "dns01", Status: "pending", URI: ts.URL, Token: "http8"}
 
 	go func() {

--- a/cli.go
+++ b/cli.go
@@ -6,10 +6,12 @@ import (
 	"log"
 	"os"
 	"path"
+	"sort"
 	"strings"
 
 	"github.com/codegangsta/cli"
 	"github.com/xenolf/lego/acme"
+	"github.com/xenolf/lego/dns_provider"
 )
 
 // Logger is used to log errors; if nil, the default log.Logger is used.
@@ -24,6 +26,19 @@ func logger() *log.Logger {
 }
 
 var gittag string
+
+// Return a string describing all the DNS providers together, like
+// "\n\t{name}: {config description}", suitable for use in a CLI flag description
+func dnsProviderHelpString() string {
+	lines := []string{}
+
+	for _, entry := range dns_provider.Registry.Entries() {
+		lines = append(lines, "\n\t"+entry.Name+": "+entry.ConfigDescription)
+	}
+
+	sort.Strings(lines)
+	return strings.Join(lines, "")
+}
 
 func main() {
 	app := cli.NewApp()
@@ -115,13 +130,7 @@ func main() {
 			Usage: "Solve a DNS challenge using the specified provider. Disables all other challenges." +
 				"\n\tCredentials for providers have to be passed through environment variables." +
 				"\n\tFor a more detailed explanation of the parameters, please see the online docs." +
-				"\n\tValid providers:" +
-				"\n\tcloudflare: CLOUDFLARE_EMAIL, CLOUDFLARE_API_KEY" +
-				"\n\tdigitalocean: DO_AUTH_TOKEN" +
-				"\n\tdnsimple: DNSIMPLE_EMAIL, DNSIMPLE_API_KEY" +
-				"\n\troute53: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION" +
-				"\n\trfc2136: RFC2136_TSIG_KEY, RFC2136_TSIG_SECRET, RFC2136_NAMESERVER, RFC2136_ZONE" +
-				"\n\tmanual: none",
+				"\n\tValid providers:" + dnsProviderHelpString(),
 		},
 	}
 

--- a/cli_handlers.go
+++ b/cli_handlers.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/codegangsta/cli"
 	"github.com/xenolf/lego/acme"
+	"github.com/xenolf/lego/dns_provider"
 )
 
 func checkFolder(path string) error {
@@ -56,16 +57,16 @@ func setup(c *cli.Context) (*Configuration, *Account, *acme.Client) {
 		var provider acme.ChallengeProvider
 		switch c.GlobalString("dns") {
 		case "cloudflare":
-			provider, err = acme.NewDNSProviderCloudFlare("", "")
+			provider, err = dns_provider.NewDNSProviderCloudFlare("", "")
 		case "digitalocean":
 			authToken := os.Getenv("DO_AUTH_TOKEN")
 
-			provider, err = acme.NewDNSProviderDigitalOcean(authToken)
+			provider, err = dns_provider.NewDNSProviderDigitalOcean(authToken)
 		case "dnsimple":
-			provider, err = acme.NewDNSProviderDNSimple("", "")
+			provider, err = dns_provider.NewDNSProviderDNSimple("", "")
 		case "route53":
 			awsRegion := os.Getenv("AWS_REGION")
-			provider, err = acme.NewDNSProviderRoute53("", "", awsRegion)
+			provider, err = dns_provider.NewDNSProviderRoute53("", "", awsRegion)
 		case "rfc2136":
 			nameserver := os.Getenv("RFC2136_NAMESERVER")
 			zone := os.Getenv("RFC2136_ZONE")
@@ -73,9 +74,9 @@ func setup(c *cli.Context) (*Configuration, *Account, *acme.Client) {
 			tsigKey := os.Getenv("RFC2136_TSIG_KEY")
 			tsigSecret := os.Getenv("RFC2136_TSIG_SECRET")
 
-			provider, err = acme.NewDNSProviderRFC2136(nameserver, zone, tsigAlgorithm, tsigKey, tsigSecret)
+			provider, err = dns_provider.NewDNSProviderRFC2136(nameserver, zone, tsigAlgorithm, tsigKey, tsigSecret)
 		case "manual":
-			provider, err = acme.NewDNSProviderManual()
+			provider, err = dns_provider.NewDNSProviderManual()
 		}
 
 		if err != nil {

--- a/cli_handlers.go
+++ b/cli_handlers.go
@@ -53,31 +53,16 @@ func setup(c *cli.Context) (*Configuration, *Account, *acme.Client) {
 	}
 
 	if c.GlobalIsSet("dns") {
-		var err error
-		var provider acme.ChallengeProvider
-		switch c.GlobalString("dns") {
-		case "cloudflare":
-			provider, err = dns_provider.NewDNSProviderCloudFlare("", "")
-		case "digitalocean":
-			authToken := os.Getenv("DO_AUTH_TOKEN")
+		providerName := c.GlobalString("dns")
 
-			provider, err = dns_provider.NewDNSProviderDigitalOcean(authToken)
-		case "dnsimple":
-			provider, err = dns_provider.NewDNSProviderDNSimple("", "")
-		case "route53":
-			awsRegion := os.Getenv("AWS_REGION")
-			provider, err = dns_provider.NewDNSProviderRoute53("", "", awsRegion)
-		case "rfc2136":
-			nameserver := os.Getenv("RFC2136_NAMESERVER")
-			zone := os.Getenv("RFC2136_ZONE")
-			tsigAlgorithm := os.Getenv("RFC2136_TSIG_ALGORITHM")
-			tsigKey := os.Getenv("RFC2136_TSIG_KEY")
-			tsigSecret := os.Getenv("RFC2136_TSIG_SECRET")
-
-			provider, err = dns_provider.NewDNSProviderRFC2136(nameserver, zone, tsigAlgorithm, tsigKey, tsigSecret)
-		case "manual":
-			provider, err = dns_provider.NewDNSProviderManual()
+		// look up the registry entry for this provider name
+		entry := dns_provider.Registry.FindEntryByName(providerName)
+		if entry == nil {
+			logger().Fatalf("no such DNS challenge provider %q", providerName)
 		}
+
+		// instantiate an acme.ChallengeProvider
+		provider, err := entry.NewChallengeProvider()
 
 		if err != nil {
 			logger().Fatal(err)

--- a/dns_provider/cloudflare.go
+++ b/dns_provider/cloudflare.go
@@ -1,4 +1,4 @@
-package acme
+package dns_provider
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/crackcomm/cloudflare"
+	"github.com/xenolf/lego/acme"
 	"golang.org/x/net/context"
 )
 
@@ -36,7 +37,7 @@ func NewDNSProviderCloudFlare(cloudflareEmail, cloudflareKey string) (*DNSProvid
 
 // Present creates a TXT record to fulfil the dns-01 challenge
 func (c *DNSProviderCloudFlare) Present(domain, token, keyAuth string) error {
-	fqdn, value, ttl := DNS01Record(domain, keyAuth)
+	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
 	zoneID, err := c.getHostedZoneID(fqdn)
 	if err != nil {
 		return err
@@ -53,7 +54,7 @@ func (c *DNSProviderCloudFlare) Present(domain, token, keyAuth string) error {
 
 // CleanUp removes the TXT record matching the specified parameters
 func (c *DNSProviderCloudFlare) CleanUp(domain, token, keyAuth string) error {
-	fqdn, _, _ := DNS01Record(domain, keyAuth)
+	fqdn, _, _ := acme.DNS01Record(domain, keyAuth)
 	records, err := c.findTxtRecords(fqdn)
 	if err != nil {
 		return err

--- a/dns_provider/cloudflare.go
+++ b/dns_provider/cloudflare.go
@@ -10,6 +10,12 @@ import (
 	"golang.org/x/net/context"
 )
 
+func init() {
+	Registry.addProvider("cloudflare", "CLOUDFLARE_EMAIL, CLOUDFLARE_API_KEY", func() (acme.ChallengeProvider, error) {
+		return NewDNSProviderCloudFlare("", "")
+	})
+}
+
 // DNSProviderCloudFlare is an implementation of the DNSProvider interface
 type DNSProviderCloudFlare struct {
 	client *cloudflare.Client

--- a/dns_provider/cloudflare_test.go
+++ b/dns_provider/cloudflare_test.go
@@ -1,4 +1,4 @@
-package acme
+package dns_provider
 
 import (
 	"os"

--- a/dns_provider/digitalocean.go
+++ b/dns_provider/digitalocean.go
@@ -1,4 +1,4 @@
-package acme
+package dns_provider
 
 import (
 	"bytes"
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+
+	"github.com/xenolf/lego/acme"
 )
 
 // DNSProviderDigitalOcean is an implementation of the DNSProvider interface
@@ -45,7 +47,7 @@ func (d *DNSProviderDigitalOcean) Present(domain, token, keyAuth string) error {
 		} `json:"domain_record"`
 	}
 
-	fqdn, value, _ := DNS01Record(domain, keyAuth)
+	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
 
 	reqURL := fmt.Sprintf("%s/v2/domains/%s/records", digitalOceanBaseURL, domain)
 	reqData := txtRecordRequest{RecordType: "TXT", Name: fqdn, Data: value}
@@ -88,7 +90,7 @@ func (d *DNSProviderDigitalOcean) Present(domain, token, keyAuth string) error {
 
 // CleanUp removes the TXT record matching the specified parameters
 func (d *DNSProviderDigitalOcean) CleanUp(domain, token, keyAuth string) error {
-	fqdn, _, _ := DNS01Record(domain, keyAuth)
+	fqdn, _, _ := acme.DNS01Record(domain, keyAuth)
 
 	// get the record's unique ID from when we created it
 	d.recordIDsMu.Lock()

--- a/dns_provider/digitalocean.go
+++ b/dns_provider/digitalocean.go
@@ -5,10 +5,17 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"sync"
 
 	"github.com/xenolf/lego/acme"
 )
+
+func init() {
+	Registry.addProvider("digitalocean", "DO_AUTH_TOKEN", func() (acme.ChallengeProvider, error) {
+		return NewDNSProviderDigitalOcean(os.Getenv("DO_AUTH_TOKEN"))
+	})
+}
 
 // DNSProviderDigitalOcean is an implementation of the DNSProvider interface
 // that uses DigitalOcean's REST API to manage TXT records for a domain.

--- a/dns_provider/digitalocean_test.go
+++ b/dns_provider/digitalocean_test.go
@@ -1,4 +1,4 @@
-package acme
+package dns_provider
 
 import (
 	"fmt"

--- a/dns_provider/dnsimple.go
+++ b/dns_provider/dnsimple.go
@@ -9,6 +9,12 @@ import (
 	"github.com/xenolf/lego/acme"
 )
 
+func init() {
+	Registry.addProvider("dnsimple", "DNSIMPLE_EMAIL, DNSIMPLE_API_KEY", func() (acme.ChallengeProvider, error) {
+		return NewDNSProviderDNSimple("", "")
+	})
+}
+
 // DNSProviderDNSimple is an implementation of the DNSProvider interface.
 type DNSProviderDNSimple struct {
 	client *dnsimple.Client

--- a/dns_provider/dnsimple.go
+++ b/dns_provider/dnsimple.go
@@ -1,4 +1,4 @@
-package acme
+package dns_provider
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/weppos/dnsimple-go/dnsimple"
+	"github.com/xenolf/lego/acme"
 )
 
 // DNSProviderDNSimple is an implementation of the DNSProvider interface.
@@ -33,7 +34,7 @@ func NewDNSProviderDNSimple(dnsimpleEmail, dnsimpleApiKey string) (*DNSProviderD
 
 // Present creates a TXT record to fulfil the dns-01 challenge.
 func (c *DNSProviderDNSimple) Present(domain, token, keyAuth string) error {
-	fqdn, value, ttl := DNS01Record(domain, keyAuth)
+	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
 
 	zoneID, zoneName, err := c.getHostedZone(domain)
 	if err != nil {
@@ -51,7 +52,7 @@ func (c *DNSProviderDNSimple) Present(domain, token, keyAuth string) error {
 
 // CleanUp removes the TXT record matching the specified parameters.
 func (c *DNSProviderDNSimple) CleanUp(domain, token, keyAuth string) error {
-	fqdn, _, _ := DNS01Record(domain, keyAuth)
+	fqdn, _, _ := acme.DNS01Record(domain, keyAuth)
 
 	records, err := c.findTxtRecords(domain, fqdn)
 	if err != nil {

--- a/dns_provider/dnsimple_test.go
+++ b/dns_provider/dnsimple_test.go
@@ -1,4 +1,4 @@
-package acme
+package dns_provider
 
 import (
 	"os"

--- a/dns_provider/manual.go
+++ b/dns_provider/manual.go
@@ -1,9 +1,11 @@
-package acme
+package dns_provider
 
 import (
 	"bufio"
 	"fmt"
 	"os"
+
+	"github.com/xenolf/lego/acme"
 )
 
 const (
@@ -20,7 +22,7 @@ func NewDNSProviderManual() (*DNSProviderManual, error) {
 
 // Present prints instructions for manually creating the TXT record
 func (*DNSProviderManual) Present(domain, token, keyAuth string) error {
-	fqdn, value, ttl := DNS01Record(domain, keyAuth)
+	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
 	dnsRecord := fmt.Sprintf(dnsTemplate, fqdn, ttl, value)
 	logf("[INFO] acme: Please create the following TXT record in your DNS zone:")
 	logf("[INFO] acme: %s", dnsRecord)
@@ -32,7 +34,7 @@ func (*DNSProviderManual) Present(domain, token, keyAuth string) error {
 
 // CleanUp prints instructions for manually removing the TXT record
 func (*DNSProviderManual) CleanUp(domain, token, keyAuth string) error {
-	fqdn, _, ttl := DNS01Record(domain, keyAuth)
+	fqdn, _, ttl := acme.DNS01Record(domain, keyAuth)
 	dnsRecord := fmt.Sprintf(dnsTemplate, fqdn, ttl, "...")
 	logf("[INFO] acme: You can now remove this TXT record from your DNS zone:")
 	logf("[INFO] acme: %s", dnsRecord)

--- a/dns_provider/manual.go
+++ b/dns_provider/manual.go
@@ -12,6 +12,12 @@ const (
 	dnsTemplate = "%s %d IN TXT \"%s\""
 )
 
+func init() {
+	Registry.addProvider("manual", "(none)", func() (acme.ChallengeProvider, error) {
+		return NewDNSProviderManual()
+	})
+}
+
 // DNSProviderManual is an implementation of the ChallengeProvider interface
 type DNSProviderManual struct{}
 

--- a/dns_provider/provider_registry.go
+++ b/dns_provider/provider_registry.go
@@ -1,0 +1,52 @@
+package dns_provider
+
+import "github.com/xenolf/lego/acme"
+
+type providerFactory func() (acme.ChallengeProvider, error)
+
+type ProviderRegistry struct {
+	entries []ProviderRegistryEntry
+}
+
+// The global registry object, accessible outside the package
+var Registry ProviderRegistry
+
+// Add a provider to the registry, so external consumers can instantiate them as needed.
+func (r *ProviderRegistry) addProvider(name string, configDescription string, factory providerFactory) {
+	entry := ProviderRegistryEntry{
+		Name:              name,
+		ConfigDescription: configDescription,
+		factory:           factory,
+	}
+	r.entries = append(r.entries, entry)
+}
+
+// Returns a list of registered providers
+func (reg ProviderRegistry) Entries() []ProviderRegistryEntry {
+	return reg.entries
+}
+
+// Looks up a provider by name, returning nil if not found
+func (reg ProviderRegistry) FindEntryByName(name string) *ProviderRegistryEntry {
+	for _, e := range reg.entries {
+		if e.Name == name {
+			return &e
+		}
+	}
+
+	return nil
+}
+
+// Represents a single provider
+type ProviderRegistryEntry struct {
+	Name              string
+	ConfigDescription string
+	factory           providerFactory
+}
+
+// Given a ProviderRegistryEntry, return a new acme.ChallengeProvider. The challenge provider
+// will attempt to configure itself based on environment variables supplied by os.Getenv().
+// If this fails, you'll get a nil ChallengeProvider and a non-nil error.
+func (pre ProviderRegistryEntry) NewChallengeProvider() (acme.ChallengeProvider, error) {
+	return pre.factory()
+}

--- a/dns_provider/provider_registry_test.go
+++ b/dns_provider/provider_registry_test.go
@@ -1,0 +1,10 @@
+package dns_provider
+
+import "testing"
+
+func TestProviderResistry(t *testing.T) {
+	entries := Registry.Entries()
+	if len(entries) == 0 {
+		t.Fatal("expected to have entries, had 0")
+	}
+}

--- a/dns_provider/rfc2136.go
+++ b/dns_provider/rfc2136.go
@@ -2,12 +2,25 @@ package dns_provider
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/miekg/dns"
 	"github.com/xenolf/lego/acme"
 )
+
+func init() {
+	Registry.addProvider("rfc2136", "RFC2136_TSIG_KEY, RFC2136_TSIG_SECRET, RFC2136_TSIG_ALGORITHM, RFC2136_NAMESERVER, RFC2136_ZONE", func() (acme.ChallengeProvider, error) {
+		nameserver := os.Getenv("RFC2136_NAMESERVER")
+		zone := os.Getenv("RFC2136_ZONE")
+		tsigAlgorithm := os.Getenv("RFC2136_TSIG_ALGORITHM")
+		tsigKey := os.Getenv("RFC2136_TSIG_KEY")
+		tsigSecret := os.Getenv("RFC2136_TSIG_SECRET")
+
+		return NewDNSProviderRFC2136(nameserver, zone, tsigAlgorithm, tsigKey, tsigSecret)
+	})
+}
 
 // DNSProviderRFC2136 is an implementation of the ChallengeProvider interface that
 // uses dynamic DNS updates (RFC 2136) to create TXT records on a nameserver.

--- a/dns_provider/rfc2136.go
+++ b/dns_provider/rfc2136.go
@@ -1,4 +1,4 @@
-package acme
+package dns_provider
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/xenolf/lego/acme"
 )
 
 // DNSProviderRFC2136 is an implementation of the ChallengeProvider interface that
@@ -47,14 +48,14 @@ func NewDNSProviderRFC2136(nameserver, zone, tsigAlgorithm, tsigKey, tsigSecret 
 
 // Present creates a TXT record using the specified parameters
 func (r *DNSProviderRFC2136) Present(domain, token, keyAuth string) error {
-	fqdn, value, ttl := DNS01Record(domain, keyAuth)
+	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
 	r.records[fqdn] = value
 	return r.changeRecord("INSERT", fqdn, value, ttl)
 }
 
 // CleanUp removes the TXT record matching the specified parameters
 func (r *DNSProviderRFC2136) CleanUp(domain, token, keyAuth string) error {
-	fqdn, _, ttl := DNS01Record(domain, keyAuth)
+	fqdn, _, ttl := acme.DNS01Record(domain, keyAuth)
 	value := r.records[fqdn]
 	return r.changeRecord("REMOVE", fqdn, value, ttl)
 }

--- a/dns_provider/rfc2136_test.go
+++ b/dns_provider/rfc2136_test.go
@@ -1,4 +1,4 @@
-package acme
+package dns_provider
 
 import (
 	"bytes"

--- a/dns_provider/route53.go
+++ b/dns_provider/route53.go
@@ -2,6 +2,7 @@ package dns_provider
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -9,6 +10,12 @@ import (
 	"github.com/mitchellh/goamz/route53"
 	"github.com/xenolf/lego/acme"
 )
+
+func init() {
+	Registry.addProvider("route53", "AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION, etc.", func() (acme.ChallengeProvider, error) {
+		return NewDNSProviderRoute53("", "", os.Getenv("AWS_REGION"))
+	})
+}
 
 // DNSProviderRoute53 is an implementation of the DNSProvider interface
 type DNSProviderRoute53 struct {

--- a/dns_provider/route53.go
+++ b/dns_provider/route53.go
@@ -1,4 +1,4 @@
-package acme
+package dns_provider
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mitchellh/goamz/aws"
 	"github.com/mitchellh/goamz/route53"
+	"github.com/xenolf/lego/acme"
 )
 
 // DNSProviderRoute53 is an implementation of the DNSProvider interface
@@ -42,14 +43,14 @@ func NewDNSProviderRoute53(awsAccessKey, awsSecretKey, awsRegionName string) (*D
 
 // Present creates a TXT record using the specified parameters
 func (r *DNSProviderRoute53) Present(domain, token, keyAuth string) error {
-	fqdn, value, ttl := DNS01Record(domain, keyAuth)
+	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
 	value = `"` + value + `"`
 	return r.changeRecord("UPSERT", fqdn, value, ttl)
 }
 
 // CleanUp removes the TXT record matching the specified parameters
 func (r *DNSProviderRoute53) CleanUp(domain, token, keyAuth string) error {
-	fqdn, value, ttl := DNS01Record(domain, keyAuth)
+	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
 	value = `"` + value + `"`
 	return r.changeRecord("DELETE", fqdn, value, ttl)
 }

--- a/dns_provider/route53_test.go
+++ b/dns_provider/route53_test.go
@@ -1,4 +1,4 @@
-package acme
+package dns_provider
 
 import (
 	"net/http"

--- a/dns_provider/util.go
+++ b/dns_provider/util.go
@@ -1,0 +1,60 @@
+package dns_provider
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/xenolf/lego/acme"
+)
+
+// toFqdn converts the name into a fqdn appending a trailing dot.
+func toFqdn(name string) string {
+	n := len(name)
+	if n == 0 || name[n-1] == '.' {
+		return name
+	}
+	return name + "."
+}
+
+// unFqdn converts the fqdn into a name removing the trailing dot.
+func unFqdn(name string) string {
+	n := len(name)
+	if n != 0 && name[n-1] == '.' {
+		return name[:n-1]
+	}
+	return name
+}
+
+// waitFor polls the given function 'f', once every 'interval' seconds, up to 'timeout' seconds.
+func waitFor(timeout, interval int, f func() (bool, error)) error {
+	var lastErr string
+	timeup := time.After(time.Duration(timeout) * time.Second)
+	for {
+		select {
+		case <-timeup:
+			return fmt.Errorf("Time limit exceeded. Last error: %s", lastErr)
+		default:
+		}
+
+		stop, err := f()
+		if stop {
+			return nil
+		}
+		if err != nil {
+			lastErr = err.Error()
+		}
+
+		time.Sleep(time.Duration(interval) * time.Second)
+	}
+}
+
+// logf writes a log entry. It uses acme.Logger if not
+// nil, otherwise it uses the default log.Logger.
+func logf(format string, args ...interface{}) {
+	if acme.Logger != nil {
+		acme.Logger.Printf(format, args...)
+	} else {
+		log.Printf(format, args...)
+	}
+}


### PR DESCRIPTION
This changeset moves the DNS challenge providers into a new `dns_provider` package.

This package a sibling of `acme`. I felt this was appropriate given the low amount of coupling between `acme` and `dns_provider`, and that this coupling can be reduced further. (The DNS providers don't need to know anything ACME-specific – they only need to be able to create and destroy TXT records with short TTLs – but that's a topic for a later changeset.)

All the providers are together in the `dns_provider` package to keep this changeset minimal. Similarly, all the providers are initialized the way they were before – usually by passing in empty strings – even though there are clear opportunities for cleanup.

The `lego` CLI interacts with this package via `dns_provider.Registry`. This registry provides a list of entries describing the available DNS challenge providers in exactly the way that `lego help` describes them, and `lego help` output is constructed based on the contents of this registry. Once the CLI decides it wants a specific entry, the CLI calls `NewChallengeProvider()` to yield an `acme.ChallengeProvider`.

Individual providers register themselves like:

    func init() {
    	Registry.addProvider("digitalocean", "DO_AUTH_TOKEN", func() (acme.ChallengeProvider, error) {
    		return NewDNSProviderDigitalOcean(os.Getenv("DO_AUTH_TOKEN"))
    	})
    }

This pattern permits both additional refactoring into separate packages and conditional compilation (#111). Go guarantees that `init()` gets called after initializing imports and before `main()`, so there's no fuss for either of those changes.