### PR TITLE
--dns=foo means we specifically intend to fulfill a DNS challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ GLOBAL OPTIONS:
    --exclude, -x [--exclude option --exclude option]			Explicitly disallow solvers by name from being used. Solvers: "http-01", "tls-sni-01".
    --http 								Set the port and interface to use for HTTP based challenges to listen on. Supported: interface:port or :port
    --tls 								Set the port and interface to use for TLS based challenges to listen on. Supported: interface:port or :port
-   --dns 								Enable the DNS challenge for solving using a provider.
+   --dns 								Solve a DNS challenge using the specified provider.
 									Credentials for providers have to be passed through environment variables.
 									For a more detailed explanation of the parameters, please see the online docs.
 									Valid providers:
@@ -125,8 +125,10 @@ $ lego --email="foo@bar.com" --domains="example.com" renew
 Obtain a certificate using the DNS challenge and AWS Route 53:
 
 ```bash
-$ AWS_REGION=us-east-1 AWS_ACCESS_KEY_ID=my_id AWS_SECRET_ACCESS_KEY=my_key lego --email="foo@bar.com" --domains="example.com" --dns="route53" --exclude="http-01" --exclude="tls-sni-01" run
+$ AWS_REGION=us-east-1 AWS_ACCESS_KEY_ID=my_id AWS_SECRET_ACCESS_KEY=my_key lego --email="foo@bar.com" --domains="example.com" --dns="route53" run
 ```
+
+Note that `--dns=foo` implies `--exclude=http-01` and `--exclude=tls-sni-01`. lego will not attempt other challenges if you've told it to use DNS instead.
 
 lego defaults to communicating with the production Let's Encrypt ACME server. If you'd like to test something without issuing real certificates, consider using the staging endpoint instead:
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ GLOBAL OPTIONS:
    --exclude, -x [--exclude option --exclude option]			Explicitly disallow solvers by name from being used. Solvers: "http-01", "tls-sni-01".
    --http 								Set the port and interface to use for HTTP based challenges to listen on. Supported: interface:port or :port
    --tls 								Set the port and interface to use for TLS based challenges to listen on. Supported: interface:port or :port
-   --dns 								Solve a DNS challenge using the specified provider.
+   --dns 								Solve a DNS challenge using the specified provider. Disables all other solvers.
 									Credentials for providers have to be passed through environment variables.
 									For a more detailed explanation of the parameters, please see the online docs.
 									Valid providers:

--- a/cli.go
+++ b/cli.go
@@ -112,7 +112,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name: "dns",
-			Usage: "Enable the DNS challenge for solving using a provider." +
+			Usage: "Solve a DNS challenge using the specified provider." +
 				"\n\tCredentials for providers have to be passed through environment variables." +
 				"\n\tFor a more detailed explanation of the parameters, please see the online docs." +
 				"\n\tValid providers:" +

--- a/cli.go
+++ b/cli.go
@@ -112,7 +112,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name: "dns",
-			Usage: "Solve a DNS challenge using the specified provider." +
+			Usage: "Solve a DNS challenge using the specified provider. Disables all other challenges." +
 				"\n\tCredentials for providers have to be passed through environment variables." +
 				"\n\tFor a more detailed explanation of the parameters, please see the online docs." +
 				"\n\tValid providers:" +

--- a/cli_handlers.go
+++ b/cli_handlers.go
@@ -83,6 +83,10 @@ func setup(c *cli.Context) (*Configuration, *Account, *acme.Client) {
 		}
 
 		client.SetChallengeProvider(acme.DNS01, provider)
+
+		// --dns=foo indicates that the user specifically want to do a DNS challenge
+		// infer that the user also wants to exclude all other challenges
+		client.ExcludeChallenges([]acme.Challenge{acme.HTTP01, acme.TLSSNI01})
 	}
 
 	return conf, acc, client


### PR DESCRIPTION
This irks me, particularly because challenge selection is non-deterministic:

    $ AWS_PROFILE=… AWS_REGION=us-east-1 lego -m … --dns=route53 --server=https://acme-stang.api.letsencrypt.org/directory -d foo.willglynn.com run
    2016/02/11 19:48:49 [INFO][foo.willglynn.com] acme: Obtaining bundled SAN certificate
    2016/02/11 19:48:49 [INFO][foo.willglynn.com] acme: Trying to solve HTTP-01
    2016/02/11 19:48:49 [foo.willglynn.com] Could not obtain certificates
    	[foo.willglynn.com] error presenting token: Could not start HTTP server for challenge -> listen tcp :80: bind: permission denied

If I say `lego --dns=foo`, I want `lego` to solve a DNS challenge. That's why I told it which provider I want it to use when solving a DNS challenge.

The commit below makes `--dns=foo` also imply `-x http-01 -x tls-sni-01`.