### PR TITLE
Reflect result of renew action in cli exit code.

### DIFF
--- a/cli_handlers.go
+++ b/cli_handlers.go
@@ -244,7 +244,7 @@ func renew(c *cli.Context) {
 
 		if int(expTime.Sub(time.Now()).Hours()/24.0) > c.Int("days") {
 			logger().Printf("Certification expiration not reached for domain %s", domain);
-			os.Exit(1)
+			os.Exit(2)
 		}
 	}
 

--- a/cli_handlers.go
+++ b/cli_handlers.go
@@ -243,7 +243,8 @@ func renew(c *cli.Context) {
 		}
 
 		if int(expTime.Sub(time.Now()).Hours()/24.0) > c.Int("days") {
-			return
+			logger().Printf("Certification expiration not reached for domain %s", domain);
+			os.Exit(1)
 		}
 	}
 


### PR DESCRIPTION
Since after renewing a certificate most probably some action has to occur like restarting webservers and so on it is very useful to reflect a successful renewal with a zero and a not yet required renewal with a non-zero exit code.

This way you can do something like this in a cronjob or shell script:

lego ... renew --days="30" && echo "now restart the daemons" 

(Note: I did not use logger.Fatal on purpose to make clear that this is not actually an error)
