### PR TITLE
Added "register" and "agree" actions

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -72,6 +72,16 @@ func main() {
 				},
 			},
 		},
+		{
+			Name:   "register",
+			Usage:  "Register an account",
+			Action: register,
+		},
+		{
+			Name:   "agree",
+			Usage:  "Agree to CA Terms Of Service",
+			Action: agree,
+		},
 	}
 
 	app.Flags = []cli.Flag{


### PR DESCRIPTION
`lego register` only does the registration part of the `lego run`
process.
`lego agree` only does the TOS agreement part of the `lego run` process.

This is great for using with a 3rd party tool/GUI while still using the
standard lego CLI binary.
