### PR TITLE
Tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: go
 
 go:
-    - 1.4.3
-    - 1.5.3
-    - tip
+  - 1.4.3
+  - 1.5.3
+  - tip
+
+install:
+  - go get -t ./...
+  - go get golang.org/x/tools/cmd/vet
+
+script:
+  - go vet ./...
+  - go test -v ./...

--- a/acme/challenges.go
+++ b/acme/challenges.go
@@ -1,5 +1,6 @@
 package acme
 
+// Challenge is a string that identifies a particular type and version of ACME challenge.
 type Challenge string
 
 const (

--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -15,7 +15,7 @@ import (
 
 type preCheckDNSFunc func(fqdn, value string) (bool, error)
 
-var preCheckDNS preCheckDNSFunc = checkDnsPropagation
+var preCheckDNS preCheckDNSFunc = checkDNSPropagation
 
 var recursiveNameserver = "google-public-dns-a.google.com"
 
@@ -75,8 +75,8 @@ func (s *dnsChallenge) Solve(chlng challenge, domain string) error {
 	return s.validate(s.jws, domain, chlng.URI, challenge{Resource: "challenge", Type: chlng.Type, Token: chlng.Token, KeyAuthorization: keyAuth})
 }
 
-// checkDnsPropagation checks if the expected TXT record has been propagated to all authoritative nameservers.
-func checkDnsPropagation(fqdn, value string) (bool, error) {
+// checkDNSPropagation checks if the expected TXT record has been propagated to all authoritative nameservers.
+func checkDNSPropagation(fqdn, value string) (bool, error) {
 	// Initial attempt to resolve at the recursive NS
 	r, err := dnsQuery(fqdn, dns.TypeTXT, recursiveNameserver, true)
 	if err != nil {

--- a/acme/dns_challenge_cloudflare.go
+++ b/acme/dns_challenge_cloudflare.go
@@ -27,7 +27,7 @@ func NewDNSProviderCloudFlare(cloudflareEmail, cloudflareKey string) (*DNSProvid
 	}
 
 	c := &DNSProviderCloudFlare{
-		client: cloudflare.New(&cloudflare.Options{cloudflareEmail, cloudflareKey}),
+		client: cloudflare.New(&cloudflare.Options{Email: cloudflareEmail, Key: cloudflareKey}),
 		ctx:    context.Background(),
 	}
 

--- a/acme/dns_challenge_dnsimple.go
+++ b/acme/dns_challenge_dnsimple.go
@@ -16,16 +16,16 @@ type DNSProviderDNSimple struct {
 // NewDNSProviderDNSimple returns a DNSProviderDNSimple instance with a configured dnsimple client.
 // Authentication is either done using the passed credentials or - when empty - using the environment
 // variables DNSIMPLE_EMAIL and DNSIMPLE_API_KEY.
-func NewDNSProviderDNSimple(dnsimpleEmail, dnsimpleApiKey string) (*DNSProviderDNSimple, error) {
-	if dnsimpleEmail == "" || dnsimpleApiKey == "" {
-		dnsimpleEmail, dnsimpleApiKey = dnsimpleEnvAuth()
-		if dnsimpleEmail == "" || dnsimpleApiKey == "" {
+func NewDNSProviderDNSimple(dnsimpleEmail, dnsimpleAPIKey string) (*DNSProviderDNSimple, error) {
+	if dnsimpleEmail == "" || dnsimpleAPIKey == "" {
+		dnsimpleEmail, dnsimpleAPIKey = dnsimpleEnvAuth()
+		if dnsimpleEmail == "" || dnsimpleAPIKey == "" {
 			return nil, fmt.Errorf("DNSimple credentials missing")
 		}
 	}
 
 	c := &DNSProviderDNSimple{
-		client: dnsimple.NewClient(dnsimpleApiKey, dnsimpleEmail),
+		client: dnsimple.NewClient(dnsimpleAPIKey, dnsimpleEmail),
 	}
 
 	return c, nil

--- a/acme/dns_challenge_route53_test.go
+++ b/acme/dns_challenge_route53_test.go
@@ -65,9 +65,9 @@ var GetChangeAnswer = `<?xml version="1.0" encoding="UTF-8"?>
 </GetChangeResponse>`
 
 var serverResponseMap = testutil.ResponseMap{
-	"/2013-04-01/hostedzone/":                      testutil.Response{200, nil, ListHostedZonesAnswer},
-	"/2013-04-01/hostedzone/Z2K123214213123/rrset": testutil.Response{200, nil, ChangeResourceRecordSetsAnswer},
-	"/2013-04-01/change/asdf":                      testutil.Response{200, nil, GetChangeAnswer},
+	"/2013-04-01/hostedzone/":                      testutil.Response{Status: 200, Headers: nil, Body: ListHostedZonesAnswer},
+	"/2013-04-01/hostedzone/Z2K123214213123/rrset": testutil.Response{Status: 200, Headers: nil, Body: ChangeResourceRecordSetsAnswer},
+	"/2013-04-01/change/asdf":                      testutil.Response{Status: 200, Headers: nil, Body: GetChangeAnswer},
 }
 
 func init() {
@@ -92,7 +92,7 @@ func makeRoute53TestServer() *testutil.HTTPServer {
 }
 
 func makeRoute53Provider(server *testutil.HTTPServer) *DNSProviderRoute53 {
-	auth := aws.Auth{"abc", "123", ""}
+	auth := aws.Auth{AccessKey: "abc", SecretKey: "123", Token: ""}
 	client := route53.NewWithClient(auth, aws.Region{Route53Endpoint: server.URL}, testutil.DefaultClient)
 	return &DNSProviderRoute53{client: client}
 }

--- a/acme/dns_challenge_test.go
+++ b/acme/dns_challenge_test.go
@@ -141,7 +141,7 @@ func TestCheckAuthoritativeNss(t *testing.T) {
 	for _, tt := range checkAuthoritativeNssTests {
 		ok, _ := checkAuthoritativeNss(tt.fqdn, tt.value, tt.ns)
 		if ok != tt.ok {
-			t.Errorf("#%s: got %t; want %t", tt.fqdn, tt.ok)
+			t.Errorf("%s: got %t; want %t", tt.fqdn, tt.ok, tt.ok)
 		}
 	}
 }
@@ -174,7 +174,7 @@ func TestWaitForTimeout(t *testing.T) {
 		t.Fatal("timeout exceeded")
 	case err := <-c:
 		if err == nil {
-			t.Errorf("expected timeout error; got <nil>", err)
+			t.Errorf("expected timeout error; got %v", err)
 		}
 	}
 }

--- a/acme/http.go
+++ b/acme/http.go
@@ -8,10 +8,14 @@ import (
 	"net/http"
 	"runtime"
 	"strings"
+	"time"
 )
 
 // UserAgent (if non-empty) will be tacked onto the User-Agent string in requests.
 var UserAgent string
+
+// defaultClient is an HTTP client with a reasonable timeout value.
+var defaultClient = http.Client{Timeout: 10 * time.Second}
 
 const (
 	// defaultGoUserAgent is the Go HTTP package user agent string. Too
@@ -32,7 +36,7 @@ func httpHead(url string) (resp *http.Response, err error) {
 
 	req.Header.Set("User-Agent", userAgent())
 
-	resp, err = http.DefaultClient.Do(req)
+	resp, err = defaultClient.Do(req)
 	if err != nil {
 		return resp, err
 	}
@@ -50,7 +54,7 @@ func httpPost(url string, bodyType string, body io.Reader) (resp *http.Response,
 	req.Header.Set("Content-Type", bodyType)
 	req.Header.Set("User-Agent", userAgent())
 
-	return http.DefaultClient.Do(req)
+	return defaultClient.Do(req)
 }
 
 // httpGet performs a GET request with a proper User-Agent string.
@@ -62,7 +66,7 @@ func httpGet(url string) (resp *http.Response, err error) {
 	}
 	req.Header.Set("User-Agent", userAgent())
 
-	return http.DefaultClient.Do(req)
+	return defaultClient.Do(req)
 }
 
 // getJSON performs an HTTP GET request and parses the response body

--- a/configuration.go
+++ b/configuration.go
@@ -25,6 +25,7 @@ func (c *Configuration) RsaBits() int {
 	return c.context.GlobalInt("rsa-key-size")
 }
 
+// ExcludedSolvers is a list of solvers that are to be excluded.
 func (c *Configuration) ExcludedSolvers() (cc []acme.Challenge) {
 	for _, s := range c.context.GlobalStringSlice("exclude") {
 		cc = append(cc, acme.Challenge(s))
@@ -39,6 +40,7 @@ func (c *Configuration) ServerPath() string {
 	return strings.Replace(srvStr, "/", string(os.PathSeparator), -1)
 }
 
+// CertPath gets the path for certificates.
 func (c *Configuration) CertPath() string {
 	return path.Join(c.context.GlobalString("path"), "certificates")
 }
@@ -54,7 +56,7 @@ func (c *Configuration) AccountPath(acc string) string {
 	return path.Join(c.AccountsPath(), acc)
 }
 
-// AccountPath returns the OS dependent path to the keys of a particular account
+// AccountKeysPath returns the OS dependent path to the keys of a particular account
 func (c *Configuration) AccountKeysPath(acc string) string {
 	return path.Join(c.AccountPath(acc), "keys")
 }


### PR DESCRIPTION
This does 3 things, mostly inconsequential:

- Limit HTTP requests to 10 seconds
- Fixes vet errors and lint warnings
- Adds `go vet` to CI as a way to be reminded to keep the code clean and correct

I also have a small tweak to the GetOCSPForCert function ready to go pending your response on gitter.