### PR TITLE
Refactor CloudFlare DNS provider to have no 3rd party dependencies

### DIFF
--- a/acme/dns_challenge_cloudflare.go
+++ b/acme/dns_challenge_cloudflare.go
@@ -163,9 +163,7 @@ func (c *DNSProviderCloudFlare) makeRequest(method, uri string, body io.Reader) 
 	req.Header.Set("X-Auth-Key", c.authKey)
 	req.Header.Set("User-Agent", userAgent())
 
-	client := http.DefaultClient
-	client.Timeout = time.Duration(30 * time.Second)
-
+	client := http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("Error querying API -> %v", err)

--- a/acme/dns_challenge_cloudflare.go
+++ b/acme/dns_challenge_cloudflare.go
@@ -161,6 +161,7 @@ func (c *DNSProviderCloudFlare) makeRequest(method, uri string, body io.Reader) 
 
 	req.Header.Set("X-Auth-Email", c.authEmail)
 	req.Header.Set("X-Auth-Key", c.authKey)
+	req.Header.Set("User-Agent", userAgent())
 
 	client := http.DefaultClient
 	client.Timeout = time.Duration(30 * time.Second)

--- a/acme/dns_challenge_cloudflare_test.go
+++ b/acme/dns_challenge_cloudflare_test.go
@@ -70,7 +70,7 @@ func TestCloudFlareCleanUp(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	time.Sleep(time.Second * 1)
+	time.Sleep(time.Second * 2)
 
 	provider, err := NewDNSProviderCloudFlare(cflareEmail, cflareAPIKey)
 	assert.NoError(t, err)


### PR DESCRIPTION
Since there is no officially maintained (or widely accepted) library for CloudFlare it is better to implement the API calls using just the standard net/http library.