### PR TITLE
DNS Challenge: Do not join TXT record values

### DIFF
--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -119,9 +119,11 @@ func checkAuthoritativeNss(fqdn, value string, nameservers []string) (bool, erro
 		var found bool
 		for _, rr := range r.Answer {
 			if txt, ok := rr.(*dns.TXT); ok {
-				if strings.Join(txt.Txt, "") == value {
-					found = true
-					break
+				for _, recval := range txt.Txt {
+					if recval == value {
+						found = true
+						break
+					}
 				}
 			}
 		}

--- a/acme/dns_challenge_test.go
+++ b/acme/dns_challenge_test.go
@@ -48,7 +48,13 @@ var checkAuthoritativeNssTests = []struct {
 	ok          bool
 }{
 	// TXT RR w/ expected value
-	{"8.8.8.8.asn.routeviews.org.", "151698.8.8.024", []string{"asnums.routeviews.org."},
+	{"8.8.8.8.asn.routeviews.org.", "15169", []string{"asnums.routeviews.org."},
+		true,
+	},
+	{"8.8.8.8.asn.routeviews.org.", "8.8.8.0", []string{"asnums.routeviews.org."},
+		true,
+	},
+	{"8.8.8.8.asn.routeviews.org.", "24", []string{"asnums.routeviews.org."},
 		true,
 	},
 	// No TXT RR
@@ -141,7 +147,7 @@ func TestCheckAuthoritativeNss(t *testing.T) {
 	for _, tt := range checkAuthoritativeNssTests {
 		ok, _ := checkAuthoritativeNss(tt.fqdn, tt.value, tt.ns)
 		if ok != tt.ok {
-			t.Errorf("%s: got %t; want %t", tt.fqdn, tt.ok, tt.ok)
+			t.Errorf("%s: got %t; want %t", tt.fqdn, ok, tt.ok)
 		}
 	}
 }


### PR DESCRIPTION
ACME spec states that the contents of **one** of the TXT records should
match the digest value, not their concatenation.

I am looking at <https://ietf-wg-acme.github.io/acme/> section 7.5. We appear to be doing it wrongly at present? Am I looking at the right spec?