### PR TITLE
DNS Challenge: Fix handling of CNAMEs

### DIFF
--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -82,16 +82,14 @@ func checkDNSPropagation(fqdn, value string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if r.Rcode != dns.RcodeSuccess {
-		return false, fmt.Errorf("Could not resolve %s -> %s", fqdn, dns.RcodeToString[r.Rcode])
-	}
-
-	// If we see a CNAME here then use the alias
-	for _, rr := range r.Answer {
-		if cn, ok := rr.(*dns.CNAME); ok {
-			if cn.Hdr.Name == fqdn {
-				fqdn = cn.Target
-				break
+	if r.Rcode == dns.RcodeSuccess {
+		// If we see a CNAME here then use the alias
+		for _, rr := range r.Answer {
+			if cn, ok := rr.(*dns.CNAME); ok {
+				if cn.Hdr.Name == fqdn {
+					fqdn = cn.Target
+					break
+				}
 			}
 		}
 	}


### PR DESCRIPTION
In #133 I was seeing unnecessary delays in checking/confirming the DNS propagation for my Gandi challenge provider. 

When I examined `checkDNSPropagation` I found that it was exiting
early if the TXT record could not be found on the recursive
nameserver, and thus the authoritative nameservers were not being
queried until after the record showed up on the recursive nameserver
causing the delay.

If I am understanding things correctly (a big if!) if the recursive nameserver returns not found for the CNAME check we should just press on and examine the authoritative nameservers. This commit does that and it *appears* to fix my problem.

Is this correct? Thoughts?