### PR TITLE
Use zone name when talking to DNS APIs

### DIFF
--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -21,7 +21,7 @@ var (
 	fqdnToZone                  = map[string]string{}
 )
 
-var recursiveNameserver = "google-public-dns-a.google.com:53"
+var RecursiveNameserver = "google-public-dns-a.google.com:53"
 
 // DNS01Record returns a DNS record which will fulfill the `dns-01` challenge
 func DNS01Record(domain, keyAuth string) (fqdn string, value string, ttl int) {
@@ -90,7 +90,7 @@ func (s *dnsChallenge) Solve(chlng challenge, domain string) error {
 // checkDNSPropagation checks if the expected TXT record has been propagated to all authoritative nameservers.
 func checkDNSPropagation(fqdn, value string) (bool, error) {
 	// Initial attempt to resolve at the recursive NS
-	r, err := dnsQuery(fqdn, dns.TypeTXT, recursiveNameserver, true)
+	r, err := dnsQuery(fqdn, dns.TypeTXT, RecursiveNameserver, true)
 	if err != nil {
 		return false, err
 	}
@@ -168,12 +168,12 @@ func dnsQuery(fqdn string, rtype uint16, nameserver string, recursive bool) (in 
 func lookupNameservers(fqdn string) ([]string, error) {
 	var authoritativeNss []string
 
-	zone, err := FindZoneByFqdn(fqdn, recursiveNameserver)
+	zone, err := FindZoneByFqdn(fqdn, RecursiveNameserver)
 	if err != nil {
 		return nil, err
 	}
 
-	r, err := dnsQuery(zone, dns.TypeNS, recursiveNameserver, true)
+	r, err := dnsQuery(zone, dns.TypeNS, RecursiveNameserver, true)
 	if err != nil {
 		return nil, err
 	}

--- a/acme/dns_challenge_manual.go
+++ b/acme/dns_challenge_manual.go
@@ -22,9 +22,16 @@ func NewDNSProviderManual() (*DNSProviderManual, error) {
 func (*DNSProviderManual) Present(domain, token, keyAuth string) error {
 	fqdn, value, ttl := DNS01Record(domain, keyAuth)
 	dnsRecord := fmt.Sprintf(dnsTemplate, fqdn, ttl, value)
-	logf("[INFO] acme: Please create the following TXT record in your DNS zone:")
+
+	authZone, err := FindZoneByFqdn(fqdn, RecursiveNameserver)
+	if err != nil {
+		return err
+	}
+
+	logf("[INFO] acme: Please create the following TXT record in your %s zone:", authZone)
 	logf("[INFO] acme: %s", dnsRecord)
 	logf("[INFO] acme: Press 'Enter' when you are done")
+
 	reader := bufio.NewReader(os.Stdin)
 	_, _ = reader.ReadString('\n')
 	return nil
@@ -34,7 +41,13 @@ func (*DNSProviderManual) Present(domain, token, keyAuth string) error {
 func (*DNSProviderManual) CleanUp(domain, token, keyAuth string) error {
 	fqdn, _, ttl := DNS01Record(domain, keyAuth)
 	dnsRecord := fmt.Sprintf(dnsTemplate, fqdn, ttl, "...")
-	logf("[INFO] acme: You can now remove this TXT record from your DNS zone:")
+
+	authZone, err := FindZoneByFqdn(fqdn, RecursiveNameserver)
+	if err != nil {
+		return err
+	}
+
+	logf("[INFO] acme: You can now remove this TXT record from your %s zone:", authZone)
 	logf("[INFO] acme: %s", dnsRecord)
 	return nil
 }

--- a/providers/dns/cloudflare/cloudflare.go
+++ b/providers/dns/cloudflare/cloudflare.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/xenolf/lego/acme"
@@ -92,31 +91,27 @@ func (c *DNSProvider) getHostedZoneID(fqdn string) (string, error) {
 		Name string `json:"name"`
 	}
 
-	result, err := c.makeRequest("GET", "/zones?per_page=1000", nil)
+	authZone, err := acme.FindZoneByFqdn(fqdn, acme.RecursiveNameserver)
 	if err != nil {
 		return "", err
 	}
 
-	var zones []HostedZone
-	err = json.Unmarshal(result, &zones)
+	result, err := c.makeRequest("GET", "/zones?name=" + acme.UnFqdn(authZone), nil)
 	if err != nil {
 		return "", err
 	}
 
-	var hostedZone HostedZone
-	for _, zone := range zones {
-		name := acme.ToFqdn(zone.Name)
-		if strings.HasSuffix(fqdn, name) {
-			if len(zone.Name) > len(hostedZone.Name) {
-				hostedZone = zone
-			}
-		}
-	}
-	if hostedZone.ID == "" {
-		return "", fmt.Errorf("No matching CloudFlare zone found for %s", fqdn)
+	var hostedZone []HostedZone
+	err = json.Unmarshal(result, &hostedZone)
+	if err != nil {
+		return "", err
 	}
 
-	return hostedZone.ID, nil
+	if len(hostedZone) != 1 {
+		return "", fmt.Errorf("Zone %s not found in CloudFlare for domain %s", authZone, fqdn)
+	}
+
+	return hostedZone[0].ID, nil
 }
 
 func (c *DNSProvider) findTxtRecord(fqdn string) (*cloudFlareRecord, error) {

--- a/providers/dns/dnsimple/dnsimple.go
+++ b/providers/dns/dnsimple/dnsimple.go
@@ -70,24 +70,30 @@ func (c *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 }
 
 func (c *DNSProvider) getHostedZone(domain string) (string, string, error) {
-	domains, _, err := c.client.Domains.List()
+	zones, _, err := c.client.Domains.List()
 	if err != nil {
 		return "", "", fmt.Errorf("DNSimple API call failed: %v", err)
 	}
 
-	var hostedDomain dnsimple.Domain
-	for _, d := range domains {
-		if strings.HasSuffix(domain, d.Name) {
-			if len(d.Name) > len(hostedDomain.Name) {
-				hostedDomain = d
-			}
-		}
-	}
-	if hostedDomain.Id == 0 {
-		return "", "", fmt.Errorf("No matching DNSimple domain found for domain %s", domain)
+
+	authZone, err := acme.FindZoneByFqdn(domain, acme.RecursiveNameserver)
+	if err != nil {
+		return "", "", err
 	}
 
-	return fmt.Sprintf("%v", hostedDomain.Id), hostedDomain.Name, nil
+	var hostedZone dnsimple.Domain
+	for _, zone := range zones {
+		if zone.Name == acme.UnFqdn(authZone) {
+			hostedZone = zone
+		}
+	}
+
+	if hostedZone.Id == 0 {
+		return "", "", fmt.Errorf("Zone %s not found in DNSimple for domain %s", authZone, domain)
+
+	}
+
+	return fmt.Sprintf("%v", hostedZone.Id), hostedZone.Name, nil
 }
 
 func (c *DNSProvider) findTxtRecords(domain, fqdn string) ([]dnsimple.Record, error) {

--- a/providers/dns/route53/route53.go
+++ b/providers/dns/route53/route53.go
@@ -104,16 +104,19 @@ func (r *DNSProvider) getHostedZoneID(fqdn string) (string, error) {
 		zones = append(zones, zoneResp.HostedZones...)
 	}
 
+	authZone, err := acme.FindZoneByFqdn(fqdn, acme.RecursiveNameserver)
+	if err != nil {
+		return "", err
+	}
+
 	var hostedZone route53.HostedZone
 	for _, zone := range zones {
-		if strings.HasSuffix(fqdn, zone.Name) {
-			if len(zone.Name) > len(hostedZone.Name) {
-				hostedZone = zone
-			}
+		if zone.Name == authZone {
+			hostedZone = zone
 		}
 	}
 	if hostedZone.ID == "" {
-		return "", fmt.Errorf("No Route53 hosted zone found for domain %s", fqdn)
+		return "", fmt.Errorf("Zone %s not found in Route53 for domain %s", authZone, fqdn)
 	}
 
 	return hostedZone.ID, nil


### PR DESCRIPTION
I noticed that the CloudFlare lookup didn't lookup directly based on the zone name (which seemed silly).

I Adjusting lookupNameservers() to return the fqdn at point it finds the NS as this seemed like a better idea vs. making a new function to repeat the same process.

I also changed the other providers to use the new method vs. the suffix method. I've adjusted where appropriate for differing uses of FQDNs in zone names.