### PR TITLE
Add ChallengeProviderTimeout type to acme package

### DIFF
--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -69,7 +69,15 @@ func (s *dnsChallenge) Solve(chlng challenge, domain string) error {
 
 	logf("[INFO][%s] Checking DNS record propagation...", domain)
 
-	err = WaitFor(60*time.Second, 2*time.Second, func() (bool, error) {
+	var timeout, interval time.Duration
+	switch provider := s.provider.(type) {
+	case ChallengeProviderTimeout:
+		timeout, interval = provider.Timeout()
+	default:
+		timeout, interval = 60*time.Second, 2*time.Second
+	}
+
+	err = WaitFor(timeout, interval, func() (bool, error) {
 		return preCheckDNS(fqdn, value)
 	})
 	if err != nil {

--- a/acme/provider.go
+++ b/acme/provider.go
@@ -1,5 +1,7 @@
 package acme
 
+import "time"
+
 // ChallengeProvider enables implementing a custom challenge
 // provider. Present presents the solution to a challenge available to
 // be solved. CleanUp will be called by the challenge if Present ends
@@ -7,4 +9,20 @@ package acme
 type ChallengeProvider interface {
 	Present(domain, token, keyAuth string) error
 	CleanUp(domain, token, keyAuth string) error
+}
+
+// ChallengeProviderTimeout allows for implementing a
+// ChallengeProvider where an unusually long timeout is required when
+// waiting for an ACME challenge to be satisfied, such as when
+// checking for DNS record progagation. If an implementor of a
+// ChallengeProvider provides a Timeout method, then the return values
+// of the Timeout method will be used when appropriate by the acme
+// package. The interval value is the time between checks.
+//
+// The default values used for timeout and interval are 60 seconds and
+// 2 seconds respectively. These are used when no Timeout method is
+// defined for the ChallengeProvider.
+type ChallengeProviderTimeout interface {
+	ChallengeProvider
+	Timeout() (timeout, interval time.Duration)
 }


### PR DESCRIPTION
There was what I perceived as a problem with my Gandi `ChallengeProvider` in #133. Because of Gandi's long DNS record propagation time (in my tests, up to 25 minutes), I had to alter the timeout the `acme` package used when checking for record propagation. However, this affected **all** the DNS providers, the remainder of which just require the existing 30 second timeout. Forcing them all to have a 40 minute timeout for the sake of Gandi seemed... wrong?

This PR adds a new `ChallengeProviderTimeout` type to the acme package which allows for implementing DNS providers that require an unsually long timeout when checking for record propagation. In fact, although it would only be necessary for DNS providers like Gandi at present, it need not be solely for DNS providers. There could be in the future some yet not-invented challenge type, for which the same problem occured.

The Gandi provider in #133 has been altered to use this new interface, so all the remaining DNS providers will now use the 30 second timeout again as normal.

Thoughts?

**EDIT**: This PR now sits on top of #144, due to new `WaitFor` semantics.