### PR TITLE
Improve wording of ChallengeProvider comment

### DIFF
--- a/acme/provider.go
+++ b/acme/provider.go
@@ -1,7 +1,9 @@
 package acme
 
-// ChallengeProvider presents the solution to a challenge available to be solved
-// CleanUp will be called by the challenge if Present ends in a non-error state.
+// ChallengeProvider enables implementing a custom challenge
+// provider. Present presents the solution to a challenge available to
+// be solved. CleanUp will be called by the challenge if Present ends
+// in a non-error state.
 type ChallengeProvider interface {
 	Present(domain, token, keyAuth string) error
 	CleanUp(domain, token, keyAuth string) error


### PR DESCRIPTION
Just a tiny change to the comment for `ChallengeProvider`. There was a missing period in-between the sentences. While I was at it, I also added a small introductory sentence.