### PR TITLE
Add manual validation for http-01 challenge

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,14 @@ When using the standard `--path` option, all certificates and account configurat
 
 #### Sudo
 The CLI does not require root permissions but needs to bind to port 80 and 443 for certain challenges. 
-To run the CLI without sudo, you have three options:
+To run the CLI without sudo, you have five options:
 
 - Use setcap 'cap_net_bind_service=+ep' /path/to/program
 - Pass the `--http` or/and the `--tls` option and specify a custom port to bind to. In this case you have to forward port 80/443 to these custom ports (see [Port Usage](#port-usage)).
 - Pass the `--webroot` option and specify the path to your webroot folder. In this case the challenge will be written in a file in `.well-known/acme-challenge/` inside your webroot.
+- Pass the `--manual` option. In this case, instructions for
+fulfilling the http-01 challenge manually will be output to the screen.
+- Pass the `--dns` option and specify a dns provider.
 
 #### Port Usage
 By default lego assumes it is able to bind to ports 80 and 443 to solve challenges.
@@ -89,6 +92,7 @@ GLOBAL OPTIONS:
    --path "${CWD}/.lego"	Directory to use for storing the data
    --exclude, -x [--exclude option --exclude option]			Explicitly disallow solvers by name from being used. Solvers: "http-01", "tls-sni-01".
    --webroot 								Set the webroot folder to use for HTTP based challenges to write directly in a file in .well-known/acme-challenge
+   --manual								Give instructions for fulfilling HTTP based challenges manually
    --http 								Set the port and interface to use for HTTP based challenges to listen on. Supported: interface:port or :port
    --tls 								Set the port and interface to use for TLS based challenges to listen on. Supported: interface:port or :port
    --dns 								Solve a DNS challenge using the specified provider. Disables all other solvers.

--- a/cli.go
+++ b/cli.go
@@ -120,6 +120,10 @@ func main() {
 			Name:  "webroot",
 			Usage: "Set the webroot folder to use for HTTP based challenges to write directly in a file in .well-known/acme-challenge",
 		},
+		cli.BoolFlag{
+			Name:  "manual",
+			Usage: "Give instructions for fulfilling HTTP based challenges manually",
+		},
 		cli.StringFlag{
 			Name:  "http",
 			Usage: "Set the port and interface to use for HTTP based challenges to listen on. Supported: interface:port or :port",

--- a/cli_handlers.go
+++ b/cli_handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/xenolf/lego/providers/dns/gandi"
 	"github.com/xenolf/lego/providers/dns/rfc2136"
 	"github.com/xenolf/lego/providers/dns/route53"
+	"github.com/xenolf/lego/providers/http/manual"
 	"github.com/xenolf/lego/providers/http/webroot"
 )
 
@@ -62,8 +63,20 @@ func setup(c *cli.Context) (*Configuration, *Account, *acme.Client) {
 		}
 
 		client.SetChallengeProvider(acme.HTTP01, provider)
-		
+
 		// --webroot=foo indicates that the user specifically want to do a HTTP challenge
+		// infer that the user also wants to exclude all other challenges
+		client.ExcludeChallenges([]acme.Challenge{acme.DNS01, acme.TLSSNI01})
+	}
+	if c.GlobalIsSet("manual") {
+		provider, err := manual.NewHTTPProvider()
+		if err != nil {
+			logger().Fatal(err)
+		}
+
+		client.SetChallengeProvider(acme.HTTP01, provider)
+
+		// --manual indicates that the user specifically want to do a HTTP challenge
 		// infer that the user also wants to exclude all other challenges
 		client.ExcludeChallenges([]acme.Challenge{acme.DNS01, acme.TLSSNI01})
 	}

--- a/providers/http/manual/manual.go
+++ b/providers/http/manual/manual.go
@@ -1,0 +1,52 @@
+// Package manual implements an HTTP provider for solving the HTTP-01
+// challenge by displaying instructions necessary to manually satisfy
+// the challenge.
+package manual
+
+import (
+	"bufio"
+	"log"
+	"os"
+
+	"github.com/xenolf/lego/acme"
+)
+
+// logf writes a log entry. It uses acme.Logger if not
+// nil, otherwise it uses the default log.Logger.
+func logf(format string, args ...interface{}) {
+	if acme.Logger != nil {
+		acme.Logger.Printf(format, args...)
+	} else {
+		log.Printf(format, args...)
+	}
+}
+
+// HTTPProvider is an implementation of the acme.ChallengeProvider
+// interface.
+type HTTPProvider struct{}
+
+// NewHTTPProvider returns an HTTPProvider instance.
+func NewHTTPProvider() (*HTTPProvider, error) {
+	return &HTTPProvider{}, nil
+}
+
+// Present prints instructions for manually configuring a web server
+// for the http-01 challenge.
+func (*HTTPProvider) Present(domain, token, keyAuth string) error {
+	logf("[INFO] acme: Please configure your web server so that an HTTP GET request to")
+	logf("[INFO] acme: http://%s%s", domain, acme.HTTP01ChallengePath(token))
+	logf("[INFO] acme: returns the following string in the response body")
+	logf("[INFO] acme: %s", keyAuth)
+	logf("[INFO] acme: Press 'Enter' when you are done")
+	reader := bufio.NewReader(os.Stdin)
+	_, _ = reader.ReadString('\n')
+	return nil
+}
+
+// CleanUp prints instructions for manually configuring a web server
+// once the http-01 challenge is completed.
+func (*HTTPProvider) CleanUp(domain, token, keyAuth string) error {
+	logf("[INFO] acme: You can now remove the following URL from your server configuration")
+	logf("[INFO] acme: http://%s%s", domain, acme.HTTP01ChallengePath(token))
+	return nil
+}


### PR DESCRIPTION
Since it didn't seem like a lot of code, I added support for manual validation for http-01. The requesting issue (#60) has two +1s.

I based the file `http_challenge_manual.go` on `dns_challenge_manual.go`.
