### PR TITLE
Optional Logger Interface

### DIFF
--- a/acme/client.go
+++ b/acme/client.go
@@ -161,7 +161,7 @@ func (c *Client) Register() (*RegistrationResource, error) {
 	if c == nil || c.user == nil {
 		return nil, errors.New("acme: cannot register a nil client or user")
 	}
-	logf("[INFO] acme: Registering account for %s", c.user.GetEmail())
+	logf("[INFO] acme: Registering account for \"%s\"", c.user.GetEmail())
 
 	regMsg := registrationMessage{
 		Resource: "new-reg",

--- a/acme/client.go
+++ b/acme/client.go
@@ -17,9 +17,15 @@ import (
 	"time"
 )
 
+// LoggerInterface usually used for *log.Logger, but allows support for
+// custom loggers such as Logrus
+type LoggerInterface interface {
+	Printf(string, ...interface{})
+}
+
 var (
 	// Logger is an optional custom logger.
-	Logger *log.Logger
+	Logger LoggerInterface
 )
 
 // logf writes a log entry. It uses Logger if not


### PR DESCRIPTION
Having the optional logger as an interface allows plugging in custom logging libraries such as logrus, and allows integration with an app's custom logging machinery.

Also added quotes around user registration log, since without them it isn't clear that when generating an anonymous user it is just using empty string.