### PR TITLE
googlecloud dns: Make package name match import path

### DIFF
--- a/cli_handlers.go
+++ b/cli_handlers.go
@@ -99,7 +99,7 @@ func setup(c *cli.Context) (*Configuration, *Account, *acme.Client) {
 			apiKey := os.Getenv("GANDI_API_KEY")
 			provider, err = gandi.NewDNSProvider(apiKey)
 		case "gcloud":
-			provider, err = googleclouddns.NewDNSProvider("")
+			provider, err = googlecloud.NewDNSProvider("")
 		case "namecheap":
 			provider, err = namecheap.NewDNSProvider("", "")
 		case "route53":

--- a/providers/dns/googlecloud/googlecloud.go
+++ b/providers/dns/googlecloud/googlecloud.go
@@ -1,4 +1,6 @@
-package googleclouddns
+// Package googlecloud implements a DNS provider for solving the DNS-01
+// challenge using Google Cloud DNS.
+package googlecloud
 
 import (
 	"fmt"

--- a/providers/dns/googlecloud/googlecloud_test.go
+++ b/providers/dns/googlecloud/googlecloud_test.go
@@ -1,4 +1,4 @@
-package googleclouddns
+package googlecloud
 
 import (
 	"os"


### PR DESCRIPTION
Conventionally, the package name matches the last component of the import path.

Also, add package description.