### PR TITLE
Gandi DNS: Unexport Endpoint variable

### DIFF
--- a/providers/dns/gandi/gandi.go
+++ b/providers/dns/gandi/gandi.go
@@ -179,10 +179,8 @@ func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
 	return 40 * time.Minute, 60 * time.Second
 }
 
-// Endpoint is the Gandi XML-RPC endpoint used by Present and
-// CleanUp. It is exported only so it may be overridden during package
-// tests.
-var Endpoint = "https://rpc.gandi.net/xmlrpc/"
+// endpoint is the Gandi XML-RPC endpoint used by Present and CleanUp.
+var endpoint = "https://rpc.gandi.net/xmlrpc/"
 
 // types for XML-RPC method calls and parameters
 
@@ -297,7 +295,7 @@ func rpcCall(call *methodCall, resp response) error {
 	}
 	// post
 	b = append([]byte(`<?xml version="1.0"?>`+"\n"), b...)
-	respBody, err := httpPost(Endpoint, "text/xml", bytes.NewReader(b))
+	respBody, err := httpPost(endpoint, "text/xml", bytes.NewReader(b))
 	if err != nil {
 		return err
 	}

--- a/providers/dns/gandi/gandi_test.go
+++ b/providers/dns/gandi/gandi_test.go
@@ -45,11 +45,11 @@ func TestDNSProvider(t *testing.T) {
 	}))
 	defer fakeServer.Close()
 	// override gandi endpoint to point to fake server
-	savedEndpoint := Endpoint
+	savedEndpoint := endpoint
 	defer func() {
-		Endpoint = savedEndpoint
+		endpoint = savedEndpoint
 	}()
-	Endpoint = fakeServer.URL + "/"
+	endpoint = fakeServer.URL + "/"
 	// run Present
 	err = provider.Present("abc.def.example.com", "", fakeKeyAuth)
 	if err != nil {


### PR DESCRIPTION
Prior to 47219ad, the Gandi DNS tests ran in a separate package from the provider itself, called `gandi_test`. Following that commit they were changed to run in the provider's package.

The `Endpoint` variable was only exported in order to be usable from `gandi_test`. Since the tests now run in `gandi`, it should be unexported and its comment changed, since the comment is now inaccurate.