### PR TITLE
Updated timeout for cloudflare dns challenge

### DIFF
--- a/providers/dns/cloudflare/cloudflare.go
+++ b/providers/dns/cloudflare/cloudflare.go
@@ -175,7 +175,7 @@ func (c *DNSProvider) makeRequest(method, uri string, body io.Reader) (json.RawM
 	req.Header.Set("X-Auth-Key", c.authKey)
 	//req.Header.Set("User-Agent", userAgent())
 
-	client := http.Client{Timeout: 30 * time.Second}
+	client := http.Client{Timeout: 120 * time.Second}
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("Error querying API -> %v", err)


### PR DESCRIPTION
Updated timeout for cloudflare dns challenge record propagation to fix issue as described in https://github.com/xenolf/lego/issues/167

I haven't written a test, but the current value of 30 seconds isn't tested either. I'm not familiar enough with golang to do write it within reasonable time, so hope that's okay.