### PR TITLE
Gandi DNS: add live test

### DIFF
--- a/providers/dns/gandi/gandi_test.go
+++ b/providers/dns/gandi/gandi_test.go
@@ -1,14 +1,40 @@
 package gandi
 
 import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/xenolf/lego/acme"
 )
+
+// stagingServer is the Let's Encrypt staging server used by the live test
+const stagingServer = "https://acme-staging.api.letsencrypt.org/directory"
+
+// user implements acme.User and is used by the live test
+type user struct {
+	Email        string
+	Registration *acme.RegistrationResource
+	key          crypto.PrivateKey
+}
+
+func (u *user) GetEmail() string {
+	return u.Email
+}
+func (u *user) GetRegistration() *acme.RegistrationResource {
+	return u.Registration
+}
+func (u *user) GetPrivateKey() crypto.PrivateKey {
+	return u.key
+}
 
 // TestDNSProvider runs Present and CleanUp against a fake Gandi RPC
 // Server, whose responses are predetermined for particular requests.
@@ -59,6 +85,61 @@ func TestDNSProvider(t *testing.T) {
 	err = provider.CleanUp("abc.def.example.com", "", fakeKeyAuth)
 	if err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestDNSProviderLive performs a live test to obtain a certificate
+// using the Let's Encrypt staging server. It runs provided that both
+// the environment variables GANDI_API_KEY and GANDI_TEST_DOMAIN are
+// set. Otherwise the test is skipped.
+//
+// To complete this test, go test must be run with the -timeout=40m
+// flag, since the default timeout of 10m is insufficient.
+func TestDNSProviderLive(t *testing.T) {
+	apiKey := os.Getenv("GANDI_API_KEY")
+	domain := os.Getenv("GANDI_TEST_DOMAIN")
+	if apiKey == "" || domain == "" {
+		t.Skip("skipping live test")
+	}
+	// create a user.
+	const rsaKeySize = 2048
+	privateKey, err := rsa.GenerateKey(rand.Reader, rsaKeySize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	myUser := user{
+		Email: "test@example.com",
+		key:   privateKey,
+	}
+	// create a client using staging server
+	client, err := acme.NewClient(stagingServer, &myUser, acme.RSA2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	provider, err := NewDNSProviderCredentials(apiKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = client.SetChallengeProvider(acme.DNS01, provider)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client.ExcludeChallenges([]acme.Challenge{acme.HTTP01, acme.TLSSNI01})
+	// register and agree tos
+	reg, err := client.Register()
+	if err != nil {
+		t.Fatal(err)
+	}
+	myUser.Registration = reg
+	err = client.AgreeToTOS()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// complete the challenge
+	bundle := false
+	_, failures := client.ObtainCertificate([]string{domain}, bundle, nil)
+	if len(failures) > 0 {
+		t.Fatal(failures)
 	}
 }
 


### PR DESCRIPTION
This adds a live test to the Gandi provider. It runs provided that both the environment variables GANDI_API_KEY and GANDI_TEST_DOMAIN are set. Otherwise the test is skipped.

In terms of what it does, it more or less just executes the example code in the README, using the Let's Encrypt staging server, and checks for failures along the way.