### PR TITLE
Update README example section

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ A valid, but bare-bones example use of the acme package:
 type MyUser struct {
 	Email        string
 	Registration *acme.RegistrationResource
-	key          *rsa.PrivateKey
+	key          crypto.PrivateKey
 }
 func (u MyUser) GetEmail() string {
 	return u.Email
@@ -186,7 +186,7 @@ func (u MyUser) GetEmail() string {
 func (u MyUser) GetRegistration() *acme.RegistrationResource {
 	return u.Registration
 }
-func (u MyUser) GetPrivateKey() *rsa.PrivateKey {
+func (u MyUser) GetPrivateKey() crypto.PrivateKey {
 	return u.key
 }
 
@@ -203,7 +203,7 @@ myUser := MyUser{
 
 // A client facilitates communication with the CA server. This CA URL is
 // configured for a local dev instance of Boulder running in Docker in a VM.
-client, err := acme.NewClient("http://192.168.99.100:4000", &myUser, rsaKeySize)
+client, err := acme.NewClient("http://192.168.99.100:4000", &myUser, acme.RSA2048)
 if err != nil {
   log.Fatal(err)
 }


### PR DESCRIPTION
The example in README no longer compiles, due to new signature of `acme.NewClient` (taking a `KeyType`). This PR hopefully fixes that.