### PR TITLE
Switch route53 provider to the official AWS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,14 +143,19 @@ Replace `<INSERT_YOUR_HOSTED_ZONE_ID_HERE>` with the Route 53 zone ID of the dom
     "Statement": [
         {
             "Effect": "Allow",
-            "Action": [ "route53:ListHostedZones", "route53:GetChange" ],
+            "Action": [
+                "route53:GetChange",
+                "route53:ListHostedZonesByName"
+            ],
             "Resource": [
                 "*"
             ]
         },
         {
             "Effect": "Allow",
-            "Action": ["route53:ChangeResourceRecordSets"],
+            "Action": [
+                "route53:ChangeResourceRecordSets"
+            ],
             "Resource": [
                 "arn:aws:route53:::hostedzone/<INSERT_YOUR_HOSTED_ZONE_ID_HERE>"
             ]

--- a/providers/dns/route53/fixtures_test.go
+++ b/providers/dns/route53/fixtures_test.go
@@ -1,0 +1,39 @@
+package route53
+
+var ChangeResourceRecordSetsResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<ChangeResourceRecordSetsResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+<ChangeInfo>
+   <Id>/change/123456</Id>
+   <Status>PENDING</Status>
+   <SubmittedAt>2016-02-10T01:36:41.958Z</SubmittedAt>
+</ChangeInfo>
+</ChangeResourceRecordSetsResponse>`
+
+var ListHostedZonesByNameResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<ListHostedZonesByNameResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+   <HostedZones>
+      <HostedZone>
+         <Id>/hostedzone/ABCDEFG</Id>
+         <Name>example.com.</Name>
+         <CallerReference>D2224C5B-684A-DB4A-BB9A-E09E3BAFEA7A</CallerReference>
+         <Config>
+            <Comment>Test comment</Comment>
+            <PrivateZone>false</PrivateZone>
+         </Config>
+         <ResourceRecordSetCount>10</ResourceRecordSetCount>
+      </HostedZone>
+   </HostedZones>
+   <IsTruncated>true</IsTruncated>
+   <NextDNSName>example2.com</NextDNSName>
+   <NextHostedZoneId>ZLT12321321124</NextHostedZoneId>
+   <MaxItems>1</MaxItems>
+</ListHostedZonesByNameResponse>`
+
+var GetChangeResponse = `<?xml version="1.0" encoding="UTF-8"?>
+<GetChangeResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+   <ChangeInfo>
+      <Id>123456</Id>
+      <Status>INSYNC</Status>
+      <SubmittedAt>2016-02-10T01:36:41.958Z</SubmittedAt>
+   </ChangeInfo>
+</GetChangeResponse>`

--- a/providers/dns/route53/route53_test.go
+++ b/providers/dns/route53/route53_test.go
@@ -1,160 +1,87 @@
 package route53
 
 import (
-	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
-	"time"
 
-	"github.com/mitchellh/goamz/aws"
-	"github.com/mitchellh/goamz/route53"
-	"github.com/mitchellh/goamz/testutil"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/stretchr/testify/assert"
 )
 
 var (
-	route53Secret     string
-	route53Key        string
-	awsCredentialFile string
-	homeDir           string
-	testServer        *testutil.HTTPServer
+	route53Secret string
+	route53Key    string
+	route53Region string
 )
-
-var ChangeResourceRecordSetsAnswer = `<?xml version="1.0" encoding="UTF-8"?>
-<ChangeResourceRecordSetsResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
-   <ChangeInfo>
-      <Id>/change/asdf</Id>
-      <Status>PENDING</Status>
-      <SubmittedAt>2014</SubmittedAt>
-   </ChangeInfo>
-</ChangeResourceRecordSetsResponse>`
-
-var ListHostedZonesAnswer = `<?xml version="1.0" encoding="utf-8"?>
-<ListHostedZonesResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
-    <HostedZones>
-        <HostedZone>
-            <Id>/hostedzone/Z2K123214213123</Id>
-            <Name>example.com.</Name>
-            <CallerReference>D2224C5B-684A-DB4A-BB9A-E09E3BAFEA7A</CallerReference>
-            <Config>
-                <Comment>Test comment</Comment>
-            </Config>
-            <ResourceRecordSetCount>10</ResourceRecordSetCount>
-        </HostedZone>
-        <HostedZone>
-            <Id>/hostedzone/ZLT12321321124</Id>
-            <Name>sub.example.com.</Name>
-            <CallerReference>A970F076-FCB1-D959-B395-96474CC84EB8</CallerReference>
-            <Config>
-                <Comment>Test comment for subdomain host</Comment>
-            </Config>
-            <ResourceRecordSetCount>4</ResourceRecordSetCount>
-        </HostedZone>
-    </HostedZones>
-    <IsTruncated>false</IsTruncated>
-    <MaxItems>100</MaxItems>
-</ListHostedZonesResponse>`
-
-var GetChangeAnswer = `<?xml version="1.0" encoding="UTF-8"?>
-<GetChangeResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
-   <ChangeInfo>
-      <Id>/change/asdf</Id>
-      <Status>INSYNC</Status>
-      <SubmittedAt>2016-02-03T01:36:41.958Z</SubmittedAt>
-   </ChangeInfo>
-</GetChangeResponse>`
-
-var serverResponseMap = testutil.ResponseMap{
-	"/2013-04-01/hostedzone/":                      testutil.Response{Status: 200, Headers: nil, Body: ListHostedZonesAnswer},
-	"/2013-04-01/hostedzone/Z2K123214213123/rrset": testutil.Response{Status: 200, Headers: nil, Body: ChangeResourceRecordSetsAnswer},
-	"/2013-04-01/change/asdf":                      testutil.Response{Status: 200, Headers: nil, Body: GetChangeAnswer},
-}
 
 func init() {
 	route53Key = os.Getenv("AWS_ACCESS_KEY_ID")
 	route53Secret = os.Getenv("AWS_SECRET_ACCESS_KEY")
-	awsCredentialFile = os.Getenv("AWS_CREDENTIAL_FILE")
-	homeDir = os.Getenv("HOME")
-	testServer = testutil.NewHTTPServer()
-	testServer.Start()
+	route53Region = os.Getenv("AWS_REGION")
 }
 
 func restoreRoute53Env() {
 	os.Setenv("AWS_ACCESS_KEY_ID", route53Key)
 	os.Setenv("AWS_SECRET_ACCESS_KEY", route53Secret)
-	os.Setenv("AWS_CREDENTIAL_FILE", awsCredentialFile)
-	os.Setenv("HOME", homeDir)
+	os.Setenv("AWS_REGION", route53Region)
 }
 
-func makeRoute53TestServer() *testutil.HTTPServer {
-	testServer.Flush()
-	return testServer
-}
+func makeRoute53Provider(ts *httptest.Server) *DNSProvider {
+	config := &aws.Config{
+		Credentials: credentials.NewStaticCredentials("abc", "123", " "),
+		Endpoint:    aws.String(ts.URL),
+		Region:      aws.String("mock-region"),
+		MaxRetries:  aws.Int(1),
+	}
 
-func makeRoute53Provider(server *testutil.HTTPServer) *DNSProvider {
-	auth := aws.Auth{AccessKey: "abc", SecretKey: "123", Token: ""}
-	client := route53.NewWithClient(auth, aws.Region{Route53Endpoint: server.URL}, testutil.DefaultClient)
+	client := route53.New(session.New(config))
 	return &DNSProvider{client: client}
 }
 
-func TestNewDNSProviderValid(t *testing.T) {
-	os.Setenv("AWS_ACCESS_KEY_ID", "")
-	os.Setenv("AWS_SECRET_ACCESS_KEY", "")
-	os.Setenv("AWS_REGION", "")
-	_, err := NewDNSProviderCredentials("123", "123", "us-east-1")
-	assert.NoError(t, err)
-	restoreRoute53Env()
-}
-
-func TestNewDNSProviderValidEnv(t *testing.T) {
+func TestCredentialsFromEnv(t *testing.T) {
 	os.Setenv("AWS_ACCESS_KEY_ID", "123")
 	os.Setenv("AWS_SECRET_ACCESS_KEY", "123")
 	os.Setenv("AWS_REGION", "us-east-1")
-	_, err := NewDNSProvider()
-	assert.NoError(t, err)
+
+	config := &aws.Config{
+		CredentialsChainVerboseErrors: aws.Bool(true),
+	}
+
+	sess := session.New(config)
+	_, err := sess.Config.Credentials.Get()
+	assert.NoError(t, err, "Expected credentials to be set from environment")
+
 	restoreRoute53Env()
 }
 
-func TestNewDNSProviderMissingAuthErr(t *testing.T) {
-	os.Setenv("AWS_ACCESS_KEY_ID", "")
-	os.Setenv("AWS_SECRET_ACCESS_KEY", "")
-	os.Setenv("AWS_CREDENTIAL_FILE", "") // in case test machine has this variable set
-	os.Setenv("HOME", "/")               // in case test machine has ~/.aws/credentials
+func TestRegionFromEnv(t *testing.T) {
+	os.Setenv("AWS_REGION", "us-east-1")
 
-	// The default AWS HTTP client retries three times with a deadline of 10 seconds.
-	// Replace the default HTTP client with one that does not retry and has a low timeout.
-	awsClient := aws.RetryingClient
-	aws.RetryingClient = &http.Client{Timeout: time.Millisecond}
+	sess := session.New(aws.NewConfig())
+	assert.Equal(t, "us-east-1", *sess.Config.Region, "Expected Region to be set from environment")
 
-	_, err := NewDNSProviderCredentials("", "", "us-east-1")
-	assert.EqualError(t, err, "No valid AWS authentication found")
 	restoreRoute53Env()
-
-	// restore default AWS HTTP client
-	aws.RetryingClient = awsClient
-}
-
-func TestNewDNSProviderInvalidRegionErr(t *testing.T) {
-	_, err := NewDNSProviderCredentials("123", "123", "us-east-3")
-	assert.EqualError(t, err, "Invalid AWS region name us-east-3")
 }
 
 func TestRoute53Present(t *testing.T) {
-	assert := assert.New(t)
-	testServer := makeRoute53TestServer()
-	provider := makeRoute53Provider(testServer)
-	testServer.ResponseMap(3, serverResponseMap)
+	mockResponses := MockResponseMap{
+		"/2013-04-01/hostedzonesbyname":         MockResponse{StatusCode: 200, Body: ListHostedZonesByNameResponse},
+		"/2013-04-01/hostedzone/ABCDEFG/rrset/": MockResponse{StatusCode: 200, Body: ChangeResourceRecordSetsResponse},
+		"/2013-04-01/change/123456":             MockResponse{StatusCode: 200, Body: GetChangeResponse},
+	}
+
+	ts := newMockServer(t, mockResponses)
+	defer ts.Close()
+
+	provider := makeRoute53Provider(ts)
 
 	domain := "example.com"
 	keyAuth := "123456d=="
 
 	err := provider.Present(domain, "", keyAuth)
-	assert.NoError(err, "Expected Present to return no error")
-
-	httpReqs := testServer.WaitRequests(3)
-	httpReq := httpReqs[1]
-
-	assert.Equal("/2013-04-01/hostedzone/Z2K123214213123/rrset", httpReq.URL.Path,
-		"Expected Present to select the correct hostedzone")
-
+	assert.NoError(t, err, "Expected Present to return no error")
 }

--- a/providers/dns/route53/testutil_test.go
+++ b/providers/dns/route53/testutil_test.go
@@ -1,0 +1,38 @@
+package route53
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// MockResponse represents a predefined response used by a mock server
+type MockResponse struct {
+	StatusCode int
+	Body       string
+}
+
+// MockResponseMap maps request paths to responses
+type MockResponseMap map[string]MockResponse
+
+func newMockServer(t *testing.T, responses MockResponseMap) *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		resp, ok := responses[path]
+		if !ok {
+			msg := fmt.Sprintf("Requested path not found in response map: %s", path)
+			require.FailNow(t, msg)
+		}
+
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(resp.StatusCode)
+		w.Write([]byte(resp.Body))
+	}))
+
+	time.Sleep(100 * time.Millisecond)
+	return ts
+}


### PR DESCRIPTION
Fully backwards compatible in terms of credential mechanisms
(environment variables, shared credentials file, EC2 metadata).
If a custom AWS IAM policy is in use it needs to be updated with permissions
for the route53:ListHostedZonesByName action.

- [x] Rewrite provider
- [x] Rewrite tests