### PR TITLE
Build with go-jose.v1 (instead of master)

### DIFF
--- a/acme/jws.go
+++ b/acme/jws.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/square/go-jose"
+	"gopkg.in/square/go-jose.v1"
 )
 
 type jws struct {

--- a/acme/messages.go
+++ b/acme/messages.go
@@ -3,7 +3,7 @@ package acme
 import (
 	"time"
 
-	"github.com/square/go-jose"
+	"gopkg.in/square/go-jose.v1"
 )
 
 type directory struct {


### PR DESCRIPTION
Changes the import path for go-jose to pin to the `v1` branch (via gopkg.in). I maintain backwards-compatibility for the `v1` branch, whereas `master` can diverge over time. This is to make sure I don't end up breaking your build :-). Thanks. 