### PR TITLE
Only try to parse JSON documents

### DIFF
--- a/acme/error.go
+++ b/acme/error.go
@@ -52,10 +52,14 @@ func (c challengeError) Error() string {
 
 func handleHTTPError(resp *http.Response) error {
 	var errorDetail RemoteError
-	decoder := json.NewDecoder(resp.Body)
-	err := decoder.Decode(&errorDetail)
-	if err != nil {
-		return err
+
+	// try to decode the content as JSON
+	if resp.Header.Get("Content-Type") == "application/json" {
+		decoder := json.NewDecoder(resp.Body)
+		err := decoder.Decode(&errorDetail)
+		if err != nil {
+			return err
+		}
 	}
 
 	errorDetail.StatusCode = resp.StatusCode


### PR DESCRIPTION
This patch adds code to only parse the HTTP response body as JSON if the content-type header advertises the content as JSON. In my case, the directory server was unavailable: it returned a 503 HTTP response code with an HTML document, and the only thing lego reported was:

    2016/04/04 19:12:56 Could not create client: get directory at 'https://acme-v01.api.letsencrypt.org/directory': invalid character '<' looking for beginning of value

This was caused by trying to parse the document body (HTML) as JSON, without looking at the content-type header and returning the JSON parse error.

Closes #181