### PR TITLE
Fix out of range

### DIFF
--- a/acme/jws.go
+++ b/acme/jws.go
@@ -101,7 +101,9 @@ func (j *jws) Nonce() (string, error) {
 		if err != nil {
 			return nonce, err
 		}
-		return "", errors.New("Can't get nonce")
+		if len(j.nonces) == 0 {
+			return "", errors.New("Can't get nonce")
+		}
 	}
 
 	nonce, j.nonces = j.nonces[len(j.nonces)-1], j.nonces[:len(j.nonces)-1]

--- a/acme/jws.go
+++ b/acme/jws.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 
 	"gopkg.in/square/go-jose.v1"
+	"errors"
 )
 
 type jws struct {
@@ -100,6 +101,7 @@ func (j *jws) Nonce() (string, error) {
 		if err != nil {
 			return nonce, err
 		}
+		return "", errors.New("Can't get nonce")
 	}
 
 	nonce, j.nonces = j.nonces[len(j.nonces)-1], j.nonces[:len(j.nonces)-1]

--- a/acme/jws.go
+++ b/acme/jws.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 
 	"gopkg.in/square/go-jose.v1"
+	"errors"
 )
 
 type jws struct {
@@ -99,6 +100,9 @@ func (j *jws) Nonce() (string, error) {
 		err := j.getNonce()
 		if err != nil {
 			return nonce, err
+		}
+		if len(j.nonces) == 0 {
+			return "", errors.New("Can't get nonce")
 		}
 	}
 

--- a/acme/jws.go
+++ b/acme/jws.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 
 	"gopkg.in/square/go-jose.v1"
-	"errors"
 )
 
 type jws struct {
@@ -100,9 +99,6 @@ func (j *jws) Nonce() (string, error) {
 		err := j.getNonce()
 		if err != nil {
 			return nonce, err
-		}
-		if len(j.nonces) == 0 {
-			return "", errors.New("Can't get nonce")
 		}
 	}
 

--- a/acme/jws.go
+++ b/acme/jws.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"net/http"
 
-	"gopkg.in/square/go-jose.v1"
 	"errors"
+	"gopkg.in/square/go-jose.v1"
 	"time"
 )
 
@@ -110,8 +110,8 @@ func (j *jws) Nonce() (string, error) {
 				// get nonce ok and can continue
 				break
 			}
-			if(i < TRY_COUNT -1) {
-				time.Sleep(RETRY_PAUSE);
+			if i < TRY_COUNT-1 {
+				time.Sleep(RETRY_PAUSE)
 			}
 		}
 	}

--- a/acme/jws.go
+++ b/acme/jws.go
@@ -110,7 +110,9 @@ func (j *jws) Nonce() (string, error) {
 				// get nonce ok and can continue
 				break
 			}
-			time.Sleep(RETRY_PAUSE);
+			if(i < TRY_COUNT -1) {
+				time.Sleep(RETRY_PAUSE);
+			}
 		}
 	}
 	if len(j.nonces) == 0 {

--- a/acme/jws.go
+++ b/acme/jws.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 
 	"gopkg.in/square/go-jose.v1"
-	"errors"
 )
 
 type jws struct {
@@ -103,7 +102,7 @@ func (j *jws) Nonce() (string, error) {
 		}
 	}
 	if len(j.nonces) == 0 {
-		return "", errors.New("Can't get nonce")
+		return "", fmt.Errorf("Can't get nonce")
 	}
 	nonce, j.nonces = j.nonces[len(j.nonces)-1], j.nonces[:len(j.nonces)-1]
 	return nonce, nil

--- a/acme/jws.go
+++ b/acme/jws.go
@@ -9,13 +9,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"errors"
 	"gopkg.in/square/go-jose.v1"
-	"time"
+	"errors"
 )
-
-const TRY_COUNT = 10
-const RETRY_PAUSE = time.Second
 
 type jws struct {
 	directoryURL string
@@ -101,24 +97,14 @@ func (j *jws) getNonce() error {
 func (j *jws) Nonce() (string, error) {
 	nonce := ""
 	if len(j.nonces) == 0 {
-		for i := 0; i < TRY_COUNT; i++ {
-			err := j.getNonce()
-			if err != nil {
-				return nonce, err
-			}
-			if len(j.nonces) != 0 {
-				// get nonce ok and can continue
-				break
-			}
-			if i < TRY_COUNT-1 {
-				time.Sleep(RETRY_PAUSE)
-			}
+		err := j.getNonce()
+		if err != nil {
+			return nonce, err
 		}
 	}
 	if len(j.nonces) == 0 {
 		return "", errors.New("Can't get nonce")
 	}
-
 	nonce, j.nonces = j.nonces[len(j.nonces)-1], j.nonces[:len(j.nonces)-1]
 	return nonce, nil
 }


### PR DESCRIPTION
Some time (near once per 50-100 certificates) lego fails with stack:
panic: runtime error: index out of range

goroutine 1906 [running]:
panic(0x8781a0, 0xc8200100b0)
        C:/Go/src/runtime/panic.go:464 +0x3e6
github.com/xenolf/lego/acme.(*jws).Nonce(0xc820374300, 0x0, 0x0, 0x0, 0x0)
        c:/Users/Tim/Documents/go/src/github.com/xenolf/lego/acme/jws.go:105 +0x176
gopkg.in/square/go-jose%2ev1.(*genericSigner).Sign(0xc8203923c0, 0xc8205a6240, 0x6b, 0x8b, 0x6d0778650c48, 0x0, 0x0)
        c:/Users/Tim/Documents/go/src/gopkg.in/square/go-jose.v1/signing.go:157 +0x376
github.com/xenolf/lego/acme.(*jws).signContent(0xc820374300, 0xc8205a6240, 0x6b, 0x8b, 0x481c4b, 0x0, 0x0)
        c:/Users/Tim/Documents/go/src/github.com/xenolf/lego/acme/jws.go:70 +0x1f5
github.com/xenolf/lego/acme.(*jws).post(0xc820374300, 0xc8200144c0, 0x33, 0xc8205a6240, 0x6b, 0x8b, 0x0, 0x0, 0x0)
        c:/Users/Tim/Documents/go/src/github.com/xenolf/lego/acme/jws.go:35 +0x69
github.com/xenolf/lego/acme.postJSON(0xc820374300, 0xc8200144c0, 0x33, 0x8bd040, 0xc8205a61b0, 0x79dc80, 0xc8205a6120, 0x0, 0x0, 0x0)
        c:/Users/Tim/Documents/go/src/github.com/xenolf/lego/acme/http.go:96 +0x1df
github.com/xenolf/lego/acme.(*Client).getChallenges.func1(0xc820024510, 0xc82022c780, 0xc82022c720, 0xc8204342b9, 0xb)
        c:/Users/Tim/Documents/go/src/github.com/xenolf/lego/acme/client.go:408 +0x1a7
created by github.com/xenolf/lego/acme.(*Client).getChallenges
        c:/Users/Tim/Documents/go/src/github.com/xenolf/lego/acme/client.go:421 +0x17c