### PR TITLE
Webroot cleanup

### DIFF
--- a/acme/jws.go
+++ b/acme/jws.go
@@ -101,7 +101,9 @@ func (j *jws) Nonce() (string, error) {
 		if err != nil {
 			return nonce, err
 		}
-		return "", errors.New("Can't get nonce")
+		if len(j.nonces) == 0 {
+			return "", errors.New("Can't get nonce")
+		}
 	}
 
 	nonce, j.nonces = j.nonces[len(j.nonces)-1], j.nonces[:len(j.nonces)-1]

--- a/acme/jws.go
+++ b/acme/jws.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 
 	"gopkg.in/square/go-jose.v1"
+	"errors"
 )
 
 type jws struct {
@@ -100,6 +101,7 @@ func (j *jws) Nonce() (string, error) {
 		if err != nil {
 			return nonce, err
 		}
+		return "", errors.New("Can't get nonce")
 	}
 
 	nonce, j.nonces = j.nonces[len(j.nonces)-1], j.nonces[:len(j.nonces)-1]

--- a/acme/jws.go
+++ b/acme/jws.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 
 	"gopkg.in/square/go-jose.v1"
-	"errors"
 )
 
 type jws struct {
@@ -100,9 +99,6 @@ func (j *jws) Nonce() (string, error) {
 		err := j.getNonce()
 		if err != nil {
 			return nonce, err
-		}
-		if len(j.nonces) == 0 {
-			return "", errors.New("Can't get nonce")
 		}
 	}
 

--- a/providers/http/webroot/webroot.go
+++ b/providers/http/webroot/webroot.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	"github.com/xenolf/lego/acme"
+	"path/filepath"
 )
 
 // HTTPProvider implements ChallengeProvider for `http-01` challenge
@@ -49,9 +50,13 @@ func (w *HTTPProvider) Present(domain, token, keyAuth string) error {
 // CleanUp removes the file created for the challenge
 func (w *HTTPProvider) CleanUp(domain, token, keyAuth string) error {
 	var err error
-	err = os.Remove(path.Join(w.path, acme.HTTP01ChallengePath(token)))
-	if err != nil {
-		return fmt.Errorf("Could not remove file in webroot after HTTP challenge -> %v", err)
+	p := filepath.Join(w.path, acme.HTTP01ChallengePath(token))
+	for len(p) > len(w.path) {
+		err = os.Remove(p)
+		if err != nil {
+			return fmt.Errorf("Could not remove file in webroot after HTTP challenge -> %v", err)
+		}
+		p = filepath.Dir(p)
 	}
 
 	return nil


### PR DESCRIPTION
webroot provides has bad cleanup: the provider create folders and token file, but remove token file only.

The patch remove created folders too (if they are empty).