### PR TITLE
Fix broken DNSimple provider

### DIFF
--- a/providers/dns/dnsimple/dnsimple.go
+++ b/providers/dns/dnsimple/dnsimple.go
@@ -79,7 +79,7 @@ func (c *DNSProvider) getHostedZone(domain string) (string, string, error) {
 		return "", "", fmt.Errorf("DNSimple API call failed: %v", err)
 	}
 
-	authZone, err := acme.FindZoneByFqdn(domain, acme.RecursiveNameservers)
+	authZone, err := acme.FindZoneByFqdn(acme.ToFqdn(domain), acme.RecursiveNameservers)
 	if err != nil {
 		return "", "", err
 	}


### PR DESCRIPTION
Requesting a certificate using DNSimple provider results in the  following error:
> Error obtaining certificate: Error presenting token dns: domain must be fully qualified
