### PR TITLE
Optimized Dockerfile for smaller image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,12 @@ FROM alpine:3.3
 ENV GOPATH /go
 
 RUN apk update && apk add ca-certificates go git && \
-    rm -rf /var/cache/apk/*
-
-COPY . /go/src/github.com/xenolf/lego
-
-RUN cd /go/src/github.com/xenolf/lego && \
-	go get ./... && \
-	go build -o /usr/bin/lego . && \
-	apk del ca-certificates go git && \
-	rm -rf /var/cache/apk/* && \
-	rm -rf /go
+    rm -rf /var/cache/apk/* && \
+    go get -u github.com/xenolf/lego && \
+    cd /go/src/github.com/xenolf/lego && \
+    go build -o /usr/bin/lego . && \
+    apk del ca-certificates go git && \
+    rm -rf /var/cache/apk/* && \
+    rm -rf /go
 
 ENTRYPOINT [ "/usr/bin/lego" ]


### PR DESCRIPTION
I have modified the official Dockerfile and made two changes

- Each RUN instruction creates an additional layer in the docker image. Adding files in one RUN instruction and deleting it in another RUN instruction will not reduce the size of the image. I used a single RUN command so that all the package/file removal happens in the same command in which the package installation happens, so that no additional layers are created.
- Similar to RUN statement, ADD instruction also creates an additional layer. Using git clone in the RUN statement and deleting it within the same statement ensures that an additional layer with source files is not added.