### PR TITLE
Expose some internals to allow building webui.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 lego.exe
 lego
 .lego
+.idea

--- a/acme/client.go
+++ b/acme/client.go
@@ -42,10 +42,10 @@ type User interface {
 
 // Interface for all challenge solvers to implement.
 type solver interface {
-	Solve(challenge challenge, domain string) error
+	Solve(challenge IDChallenge, domain string) error
 }
 
-type validateFunc func(j *jws, domain, uri string, chlng challenge) error
+type validateFunc func(j *jws, domain, uri string, chlng IDChallenge) error
 
 // Client is the user-friendy way to ACME
 type Client struct {
@@ -230,7 +230,7 @@ func (c *Client) ObtainCertificate(domains []string, bundle bool, privKey crypto
 
 	logf("[INFO][%s] acme: Validations succeeded; requesting certificates", strings.Join(domains, ", "))
 
-	cert, err := c.requestCertificate(challenges, bundle, privKey)
+	cert, err := c.RequestCertificate(challenges, bundle, privKey)
 	if err != nil {
 		for _, chln := range challenges {
 			failures[chln.Domain] = err
@@ -445,7 +445,7 @@ func (c *Client) getChallenges(domains []string) ([]authorizationResource, map[s
 	return challenges, failures
 }
 
-func (c *Client) requestCertificate(authz []authorizationResource, bundle bool, privKey crypto.PrivateKey) (CertificateResource, error) {
+func (c *Client) RequestCertificate(authz []authorizationResource, bundle bool, privKey crypto.PrivateKey) (CertificateResource, error) {
 	if len(authz) == 0 {
 		return CertificateResource{}, errors.New("Passed no authorizations to requestCertificate!")
 	}
@@ -601,8 +601,8 @@ func parseLinks(links []string) map[string]string {
 
 // validate makes the ACME server start validating a
 // challenge response, only returning once it is done.
-func validate(j *jws, domain, uri string, chlng challenge) error {
-	var challengeResponse challenge
+func validate(j *jws, domain, uri string, chlng IDChallenge) error {
+	var challengeResponse IDChallenge
 
 	hdr, err := postJSON(j, uri, chlng, &challengeResponse)
 	if err != nil {

--- a/acme/client_test.go
+++ b/acme/client_test.go
@@ -129,12 +129,12 @@ func TestValidate(t *testing.T) {
 		case "POST":
 			st := statuses[0]
 			statuses = statuses[1:]
-			writeJSONResponse(w, &challenge{Type: "http-01", Status: st, URI: "http://example.com/", Token: "token"})
+			writeJSONResponse(w, &IDChallenge{Type: "http-01", Status: st, URI: "http://example.com/", Token: "token"})
 
 		case "GET":
 			st := statuses[0]
 			statuses = statuses[1:]
-			writeJSONResponse(w, &challenge{Type: "http-01", Status: st, URI: "http://example.com/", Token: "token"})
+			writeJSONResponse(w, &IDChallenge{Type: "http-01", Status: st, URI: "http://example.com/", Token: "token"})
 
 		default:
 			http.Error(w, r.Method, http.StatusMethodNotAllowed)
@@ -160,7 +160,7 @@ func TestValidate(t *testing.T) {
 
 	for _, tst := range tsts {
 		statuses = tst.statuses
-		if err := validate(j, "example.com", ts.URL, challenge{Type: "http-01", Token: "token"}); err == nil && tst.want != "" {
+		if err := validate(j, "example.com", ts.URL, IDChallenge{Type: "http-01", Token: "token"}); err == nil && tst.want != "" {
 			t.Errorf("[%s] validate: got error %v, want something with %q", tst.name, err, tst.want)
 		} else if err != nil && !strings.Contains(err.Error(), tst.want) {
 			t.Errorf("[%s] validate: got error %v, want something with %q", tst.name, err, tst.want)
@@ -183,7 +183,7 @@ func writeJSONResponse(w http.ResponseWriter, body interface{}) {
 }
 
 // stubValidate is like validate, except it does nothing.
-func stubValidate(j *jws, domain, uri string, chlng challenge) error {
+func stubValidate(j *jws, domain, uri string, chlng IDChallenge) error {
 	return nil
 }
 

--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -17,7 +17,7 @@ import (
 type preCheckDNSFunc func(fqdn, value string) (bool, error)
 
 var (
-	preCheckDNS preCheckDNSFunc = checkDNSPropagation
+	preCheckDNS preCheckDNSFunc = CheckDNSPropagation
 	fqdnToZone                  = map[string]string{}
 )
 
@@ -44,7 +44,7 @@ type dnsChallenge struct {
 	provider ChallengeProvider
 }
 
-func (s *dnsChallenge) Solve(chlng challenge, domain string) error {
+func (s *dnsChallenge) Solve(chlng IDChallenge, domain string) error {
 	logf("[INFO][%s] acme: Trying to solve DNS-01", domain)
 
 	if s.provider == nil {
@@ -87,11 +87,11 @@ func (s *dnsChallenge) Solve(chlng challenge, domain string) error {
 		return err
 	}
 
-	return s.validate(s.jws, domain, chlng.URI, challenge{Resource: "challenge", Type: chlng.Type, Token: chlng.Token, KeyAuthorization: keyAuth})
+	return s.validate(s.jws, domain, chlng.URI, IDChallenge{Resource: "challenge", Type: chlng.Type, Token: chlng.Token, KeyAuthorization: keyAuth})
 }
 
-// checkDNSPropagation checks if the expected TXT record has been propagated to all authoritative nameservers.
-func checkDNSPropagation(fqdn, value string) (bool, error) {
+// CheckDNSPropagation checks if the expected TXT record has been propagated to all authoritative nameservers.
+func CheckDNSPropagation(fqdn, value string) (bool, error) {
 	// Initial attempt to resolve at the recursive NS
 	r, err := dnsQuery(fqdn, dns.TypeTXT, RecursiveNameservers, true)
 	if err != nil {

--- a/acme/dns_challenge_test.go
+++ b/acme/dns_challenge_test.go
@@ -91,7 +91,7 @@ func TestDNSValidServerResponse(t *testing.T) {
 	manualProvider, _ := NewDNSProviderManual()
 	jws := &jws{privKey: privKey, directoryURL: ts.URL}
 	solver := &dnsChallenge{jws: jws, validate: validate, provider: manualProvider}
-	clientChallenge := challenge{Type: "dns01", Status: "pending", URI: ts.URL, Token: "http8"}
+	clientChallenge := IDChallenge{Type: "dns01", Status: "pending", URI: ts.URL, Token: "http8"}
 
 	go func() {
 		time.Sleep(time.Second * 2)

--- a/acme/error.go
+++ b/acme/error.go
@@ -81,6 +81,6 @@ func handleHTTPError(resp *http.Response) error {
 	return errorDetail
 }
 
-func handleChallengeError(chlng challenge) error {
+func handleChallengeError(chlng IDChallenge) error {
 	return challengeError{chlng.Error, chlng.ValidationRecords}
 }

--- a/acme/http_challenge.go
+++ b/acme/http_challenge.go
@@ -16,7 +16,7 @@ func HTTP01ChallengePath(token string) string {
 	return "/.well-known/acme-challenge/" + token
 }
 
-func (s *httpChallenge) Solve(chlng challenge, domain string) error {
+func (s *httpChallenge) Solve(chlng IDChallenge, domain string) error {
 
 	logf("[INFO][%s] acme: Trying to solve HTTP-01", domain)
 
@@ -37,5 +37,5 @@ func (s *httpChallenge) Solve(chlng challenge, domain string) error {
 		}
 	}()
 
-	return s.validate(s.jws, domain, chlng.URI, challenge{Resource: "challenge", Type: chlng.Type, Token: chlng.Token, KeyAuthorization: keyAuth})
+	return s.validate(s.jws, domain, chlng.URI, IDChallenge{Resource: "challenge", Type: chlng.Type, Token: chlng.Token, KeyAuthorization: keyAuth})
 }

--- a/acme/http_challenge_test.go
+++ b/acme/http_challenge_test.go
@@ -11,8 +11,8 @@ import (
 func TestHTTPChallenge(t *testing.T) {
 	privKey, _ := rsa.GenerateKey(rand.Reader, 512)
 	j := &jws{privKey: privKey}
-	clientChallenge := challenge{Type: HTTP01, Token: "http1"}
-	mockValidate := func(_ *jws, _, _ string, chlng challenge) error {
+	clientChallenge := IDChallenge{Type: HTTP01, Token: "http1"}
+	mockValidate := func(_ *jws, _, _ string, chlng IDChallenge) error {
 		uri := "http://localhost:23457/.well-known/acme-challenge/" + chlng.Token
 		resp, err := httpGet(uri)
 		if err != nil {
@@ -46,7 +46,7 @@ func TestHTTPChallenge(t *testing.T) {
 func TestHTTPChallengeInvalidPort(t *testing.T) {
 	privKey, _ := rsa.GenerateKey(rand.Reader, 128)
 	j := &jws{privKey: privKey}
-	clientChallenge := challenge{Type: HTTP01, Token: "http2"}
+	clientChallenge := IDChallenge{Type: HTTP01, Token: "http2"}
 	solver := &httpChallenge{jws: j, validate: stubValidate, provider: &HTTPProviderServer{port: "123456"}}
 
 	if err := solver.Solve(clientChallenge, "localhost:123456"); err == nil {

--- a/acme/messages.go
+++ b/acme/messages.go
@@ -55,12 +55,12 @@ type authorizationResource struct {
 }
 
 type authorization struct {
-	Resource     string      `json:"resource,omitempty"`
-	Identifier   identifier  `json:"identifier"`
-	Status       string      `json:"status,omitempty"`
-	Expires      time.Time   `json:"expires,omitempty"`
-	Challenges   []challenge `json:"challenges,omitempty"`
-	Combinations [][]int     `json:"combinations,omitempty"`
+	Resource     string        `json:"resource,omitempty"`
+	Identifier   identifier    `json:"identifier"`
+	Status       string        `json:"status,omitempty"`
+	Expires      time.Time     `json:"expires,omitempty"`
+	Challenges   []IDChallenge `json:"challenges,omitempty"`
+	Combinations [][]int       `json:"combinations,omitempty"`
 }
 
 type identifier struct {
@@ -76,7 +76,7 @@ type validationRecord struct {
 	UsedAddress       string   `json:"addressUsed,omitempty"`
 }
 
-type challenge struct {
+type IDChallenge struct {
 	Resource          string             `json:"resource,omitempty"`
 	Type              Challenge          `json:"type,omitempty"`
 	Status            string             `json:"status,omitempty"`

--- a/acme/tls_sni_challenge.go
+++ b/acme/tls_sni_challenge.go
@@ -15,7 +15,7 @@ type tlsSNIChallenge struct {
 	provider ChallengeProvider
 }
 
-func (t *tlsSNIChallenge) Solve(chlng challenge, domain string) error {
+func (t *tlsSNIChallenge) Solve(chlng IDChallenge, domain string) error {
 	// FIXME: https://github.com/ietf-wg-acme/acme/pull/22
 	// Currently we implement this challenge to track boulder, not the current spec!
 
@@ -37,7 +37,7 @@ func (t *tlsSNIChallenge) Solve(chlng challenge, domain string) error {
 			log.Printf("[%s] error cleaning up: %v", domain, err)
 		}
 	}()
-	return t.validate(t.jws, domain, chlng.URI, challenge{Resource: "challenge", Type: chlng.Type, Token: chlng.Token, KeyAuthorization: keyAuth})
+	return t.validate(t.jws, domain, chlng.URI, IDChallenge{Resource: "challenge", Type: chlng.Type, Token: chlng.Token, KeyAuthorization: keyAuth})
 }
 
 // TLSSNI01ChallengeCert returns a certificate for the `tls-sni-01` challenge

--- a/acme/tls_sni_challenge_test.go
+++ b/acme/tls_sni_challenge_test.go
@@ -14,8 +14,8 @@ import (
 func TestTLSSNIChallenge(t *testing.T) {
 	privKey, _ := rsa.GenerateKey(rand.Reader, 512)
 	j := &jws{privKey: privKey}
-	clientChallenge := challenge{Type: TLSSNI01, Token: "tlssni1"}
-	mockValidate := func(_ *jws, _, _ string, chlng challenge) error {
+	clientChallenge := IDChallenge{Type: TLSSNI01, Token: "tlssni1"}
+	mockValidate := func(_ *jws, _, _ string, chlng IDChallenge) error {
 		conn, err := tls.Dial("tcp", "localhost:23457", &tls.Config{
 			InsecureSkipVerify: true,
 		})
@@ -54,7 +54,7 @@ func TestTLSSNIChallenge(t *testing.T) {
 func TestTLSSNIChallengeInvalidPort(t *testing.T) {
 	privKey, _ := rsa.GenerateKey(rand.Reader, 128)
 	j := &jws{privKey: privKey}
-	clientChallenge := challenge{Type: TLSSNI01, Token: "tlssni2"}
+	clientChallenge := IDChallenge{Type: TLSSNI01, Token: "tlssni2"}
 	solver := &tlsSNIChallenge{jws: j, validate: stubValidate, provider: &TLSProviderServer{port: "123456"}}
 
 	if err := solver.Solve(clientChallenge, "localhost:123456"); err == nil {


### PR DESCRIPTION
Hi,
We would like to build a webui around DNS challenge type. The idea is that users will be able to see the DNS challenges they need to configure manually in a web page instead of from command line. A background process can periodically check for DNS record and call Validate() when `CheckDNSPropagation()` is successful.

It will be great if you can give some feedback on this pull request. I can cleanup the comments if the pull request is directionally ok.

Thanks.