### PR TITLE
Route 53: Make sure we don't provision to a private hosted zone

### DIFF
--- a/providers/dns/route53/route53.go
+++ b/providers/dns/route53/route53.go
@@ -84,7 +84,7 @@ func (r *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 func (r *DNSProvider) changeRecord(action, fqdn, value string, ttl int) error {
 	hostedZoneID, err := r.getHostedZoneID(fqdn)
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to determine Route 53 hosted zone ID: %v", err)
 	}
 
 	recordSet := newTXTRecordSet(fqdn, value, ttl)
@@ -103,7 +103,7 @@ func (r *DNSProvider) changeRecord(action, fqdn, value string, ttl int) error {
 
 	resp, err := r.client.ChangeResourceRecordSets(reqParams)
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to change Route 53 record set: %v", err)
 	}
 
 	statusID := resp.ChangeInfo.Id
@@ -114,7 +114,7 @@ func (r *DNSProvider) changeRecord(action, fqdn, value string, ttl int) error {
 		}
 		resp, err := r.client.GetChange(reqParams)
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("Failed to query Route 53 change status: %v", err)
 		}
 		if *resp.ChangeInfo.Status == route53.ChangeStatusInsync {
 			return true, nil
@@ -131,25 +131,31 @@ func (r *DNSProvider) getHostedZoneID(fqdn string) (string, error) {
 
 	// .DNSName should not have a trailing dot
 	reqParams := &route53.ListHostedZonesByNameInput{
-		DNSName:  aws.String(acme.UnFqdn(authZone)),
-		MaxItems: aws.String("1"),
+		DNSName: aws.String(acme.UnFqdn(authZone)),
 	}
 	resp, err := r.client.ListHostedZonesByName(reqParams)
 	if err != nil {
 		return "", err
 	}
 
-	// .Name has a trailing dot
-	if len(resp.HostedZones) == 0 || *resp.HostedZones[0].Name != authZone {
-		return "", fmt.Errorf("Zone %s not found in Route53 for domain %s", authZone, fqdn)
+	var hostedZoneID string
+	for _, hostedZone := range resp.HostedZones {
+		// .Name has a trailing dot
+		if !*hostedZone.Config.PrivateZone && *hostedZone.Name == authZone {
+			hostedZoneID = *hostedZone.Id
+			break
+		}
 	}
 
-	zoneID := *resp.HostedZones[0].Id
-	if strings.HasPrefix(zoneID, "/hostedzone/") {
-		zoneID = strings.TrimPrefix(zoneID, "/hostedzone/")
+	if len(hostedZoneID) == 0 {
+		return "", fmt.Errorf("Zone %s not found in Route 53 for domain %s", authZone, fqdn)
 	}
 
-	return zoneID, nil
+	if strings.HasPrefix(hostedZoneID, "/hostedzone/") {
+		hostedZoneID = strings.TrimPrefix(hostedZoneID, "/hostedzone/")
+	}
+
+	return hostedZoneID, nil
 }
 
 func newTXTRecordSet(fqdn, value string, ttl int) *route53.ResourceRecordSet {


### PR DESCRIPTION
Fixes #192 
Route 53 allows multiple zones with the same name to co-exist in an account. The most common use case is a split-view DNS with one private and one public zone for the same domain name. This patch makes sure we don’t ever provision the authorization record to the private zone.
The other case where there are multiple public zones with the same name in the account is not covered here since this would require a bigger code change. It's also unclear whether that's a thing people actually do, so waiting for relevant issue reports before addressing this.