### PR TITLE
Fixes #199

### DIFF
--- a/providers/dns/dyn/dyn.go
+++ b/providers/dns/dyn/dyn.go
@@ -172,12 +172,17 @@ func (d *DNSProvider) logout() error {
 
 // Present creates a TXT record using the specified parameters
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
-	err := d.login()
+	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
+
+	authZone, err := acme.FindZoneByFqdn(fqdn, acme.RecursiveNameservers)
 	if err != nil {
 		return err
 	}
 
-	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
+	err = d.login()
+	if err != nil {
+		return err
+	}
 
 	data := map[string]interface{}{
 		"rdata": map[string]string{
@@ -186,13 +191,13 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		"ttl": strconv.Itoa(ttl),
 	}
 
-	resource := fmt.Sprintf("TXTRecord/%s/%s/", domain, fqdn)
+	resource := fmt.Sprintf("TXTRecord/%s/%s/", authZone, fqdn)
 	_, err = d.sendRequest("POST", resource, data)
 	if err != nil {
 		return err
 	}
 
-	err = d.publish(domain, "Added TXT record for ACME dns-01 challenge using lego client")
+	err = d.publish(authZone, "Added TXT record for ACME dns-01 challenge using lego client")
 	if err != nil {
 		return err
 	}
@@ -205,14 +210,14 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	return nil
 }
 
-func (d *DNSProvider) publish(domain, notes string) error {
+func (d *DNSProvider) publish(zone, notes string) error {
 	type publish struct {
 		Publish bool   `json:"publish"`
 		Notes   string `json:"notes"`
 	}
 
 	pub := &publish{Publish: true, Notes: notes}
-	resource := fmt.Sprintf("Zone/%s/", domain)
+	resource := fmt.Sprintf("Zone/%s/", zone)
 	_, err := d.sendRequest("PUT", resource, pub)
 	if err != nil {
 		return err
@@ -223,14 +228,19 @@ func (d *DNSProvider) publish(domain, notes string) error {
 
 // CleanUp removes the TXT record matching the specified parameters
 func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
-	err := d.login()
+	fqdn, _, _ := acme.DNS01Record(domain, keyAuth)
+
+	authZone, err := acme.FindZoneByFqdn(fqdn, acme.RecursiveNameservers)
 	if err != nil {
 		return err
 	}
 
-	fqdn, _, _ := acme.DNS01Record(domain, keyAuth)
+	err = d.login()
+	if err != nil {
+		return err
+	}
 
-	resource := fmt.Sprintf("TXTRecord/%s/%s/", domain, fqdn)
+	resource := fmt.Sprintf("TXTRecord/%s/%s/", authZone, fqdn)
 	url := fmt.Sprintf("%s/%s", dynBaseURL, resource)
 	req, err := http.NewRequest("DELETE", url, nil)
 	if err != nil {
@@ -250,7 +260,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 		return fmt.Errorf("Dyn API request failed to delete TXT record HTTP status code %d", resp.StatusCode)
 	}
 
-	err = d.publish(domain, "Removed TXT record for ACME dns-01 challenge using lego client")
+	err = d.publish(authZone, "Removed TXT record for ACME dns-01 challenge using lego client")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Dyn provider was using incorrect zone in Present and Cleanup functions.
This uses FindZoneByFqdn() to find the correct zone for use in the
subsequent API calls.