### PR TITLE
Report error from command line parser to user.

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -141,7 +141,10 @@ func main() {
 		},
 	}
 
-	app.Run(os.Args)
+	err = app.Run(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
 }
 
 func dnshelp(c *cli.Context) error {


### PR DESCRIPTION
When I made a typo in command line, e.g. `--emial` instead of `--email`. Lego printed general `Incorrect Usage.` message. I expected to see something more useful.

This patch report error from command line parser to log. In case above:
 `2016/05/14 18:19:20 flag provided but not defined: -emal
`