### PR TITLE
Allow setting "--path" even if os.Getwd() fails

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -41,11 +41,18 @@ func main() {
 
 	acme.UserAgent = "lego/" + app.Version
 
+	defaultPath := ""
 	cwd, err := os.Getwd()
-	if err != nil {
-		logger().Fatal("Could not determine current working directory. Please pass --path.")
+	if err == nil {
+		defaultPath = path.Join(cwd, ".lego")
 	}
-	defaultPath := path.Join(cwd, ".lego")
+
+	app.Before = func(c *cli.Context) error {
+		if c.GlobalString("path") == "" {
+			logger().Fatal("Could not determine current working directory. Please pass --path.")
+		}
+		return nil
+	}
 
 	app.Commands = []cli.Command{
 		{


### PR DESCRIPTION
If you run the lego binary with sudo in a directory the user has no access to os.Getwd() will fail with a very missleading error message. It is currently not possible to use --path to set the working directory because the os.Getwd() check fails before you get the chance. This pull request should fix that.

How to reproduce:
`
sudo -i


cd /root

sudo -u nobody /tmp/lego --path="/tmp"
`