### PR TITLE
In case of conflict during registration, the old registration is now recovered

### DIFF
--- a/acme/client.go
+++ b/acme/client.go
@@ -173,7 +173,9 @@ func (c *Client) Register() (*RegistrationResource, error) {
 		remoteErr, ok := err.(RemoteError)
 		if ok && remoteErr.StatusCode == 409 {
 			regURI = hdr.Get("Location")
-			regMsg.Resource = "reg"
+			regMsg = registrationMessage{
+				Resource: "reg",
+			}
 			if hdr, err = postJSON(c.jws, regURI, regMsg, &serverReg); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
If a client tries to register and encounters a 409 (Conflict) response the client now uses the old registration provided in the Location header of the 409 response. This makes the registration a bit more robust.