### PR TITLE
reg: Add Query and Delete functions

### DIFF
--- a/acme/messages.go
+++ b/acme/messages.go
@@ -22,6 +22,7 @@ type recoveryKeyMessage struct {
 type registrationMessage struct {
 	Resource string   `json:"resource"`
 	Contact  []string `json:"contact"`
+	Delete   bool     `json:"delete,omitempty"`
 	//	RecoveryKey recoveryKeyMessage `json:"recoveryKey,omitempty"`
 }
 


### PR DESCRIPTION
This PR adds 2 new functions for registration support in `acme.Client`:

 * `QueryRegistration`: This performs a POST on the client
   registration's URI and gets the updated registration info.
 * `DeleteRegistration`: This deletes the registration as currently
   configured in the client.

The latter, while a part of the IETF draft, may not be 100% functional in LE yet, my tests showed that resources were still available after deletion. If anyone knows for sure would be nice to know :)