### PR TITLE
Change TLS SNI Challenge Cert function to return domain

### DIFF
--- a/acme/tls_sni_challenge.go
+++ b/acme/tls_sni_challenge.go
@@ -41,7 +41,7 @@ func (t *tlsSNIChallenge) Solve(chlng challenge, domain string) error {
 }
 
 // TLSSNI01ChallengeCert returns a certificate and target domain for the `tls-sni-01` challenge
-func TLSSNI01ChallengeCertDomain(keyAuth string) (tls.Certificate, string, error) {
+func TLSSNI01ChallengeCert(keyAuth string) (tls.Certificate, string, error) {
 	// generate a new RSA key for the certificates
 	tempPrivKey, err := generatePrivateKey(RSA2048)
 	if err != nil {
@@ -64,10 +64,4 @@ func TLSSNI01ChallengeCertDomain(keyAuth string) (tls.Certificate, string, error
 	}
 
 	return certificate, domain, nil
-}
-
-// TLSSNI01ChallengeCert returns a certificate for the `tls-sni-01` challenge
-func TLSSNI01ChallengeCert(keyAuth string) (tls.Certificate, error) {
-	cert, _, err := TLSSNI01ChallengeCertDomain(keyAuth)
-	return cert, err
 }

--- a/acme/tls_sni_challenge.go
+++ b/acme/tls_sni_challenge.go
@@ -40,12 +40,12 @@ func (t *tlsSNIChallenge) Solve(chlng challenge, domain string) error {
 	return t.validate(t.jws, domain, chlng.URI, challenge{Resource: "challenge", Type: chlng.Type, Token: chlng.Token, KeyAuthorization: keyAuth})
 }
 
-// TLSSNI01ChallengeCert returns a certificate for the `tls-sni-01` challenge
-func TLSSNI01ChallengeCert(keyAuth string) (tls.Certificate, error) {
+// TLSSNI01ChallengeCert returns a certificate and target domain for the `tls-sni-01` challenge
+func TLSSNI01ChallengeCertDomain(keyAuth string) (tls.Certificate, string, error) {
 	// generate a new RSA key for the certificates
 	tempPrivKey, err := generatePrivateKey(RSA2048)
 	if err != nil {
-		return tls.Certificate{}, err
+		return tls.Certificate{}, "", err
 	}
 	rsaPrivKey := tempPrivKey.(*rsa.PrivateKey)
 	rsaPrivPEM := pemEncode(rsaPrivKey)
@@ -55,13 +55,19 @@ func TLSSNI01ChallengeCert(keyAuth string) (tls.Certificate, error) {
 	domain := fmt.Sprintf("%s.%s.acme.invalid", z[:32], z[32:])
 	tempCertPEM, err := generatePemCert(rsaPrivKey, domain)
 	if err != nil {
-		return tls.Certificate{}, err
+		return tls.Certificate{}, "", err
 	}
 
 	certificate, err := tls.X509KeyPair(tempCertPEM, rsaPrivPEM)
 	if err != nil {
-		return tls.Certificate{}, err
+		return tls.Certificate{}, "", err
 	}
 
-	return certificate, nil
+	return certificate, domain, nil
+}
+
+// TLSSNI01ChallengeCert returns a certificate for the `tls-sni-01` challenge
+func TLSSNI01ChallengeCert(keyAuth string) (tls.Certificate, error) {
+	cert, _, err := TLSSNI01ChallengeCertDomain(keyAuth)
+	return cert, err
 }

--- a/acme/tls_sni_challenge_server.go
+++ b/acme/tls_sni_challenge_server.go
@@ -30,7 +30,7 @@ func (s *TLSProviderServer) Present(domain, token, keyAuth string) error {
 		s.port = "443"
 	}
 
-	cert, err := TLSSNI01ChallengeCert(keyAuth)
+	cert, _, err := TLSSNI01ChallengeCert(keyAuth)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Used by rsc.io/letsencrypt to get the challenge domain. Originally committed under rsc.io/letsencrypt/vendor and maintained original authorship as from https://github.com/rsc/letsencrypt/commit/2ba1dda8fd06c47af5847588616112a9bf93c346.

Addresses issues with vendoring rsc.io/letsencrypt, especially with godep, see
- #225 
- https://github.com/rsc/letsencrypt/issues/9
- https://github.com/docker/distribution/pull/1779