### PR TITLE
Add OVH DNS provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 lego.exe
 lego
 .lego
+.idea

--- a/cli.go
+++ b/cli.go
@@ -188,6 +188,7 @@ Here is an example bash command using the CloudFlare DNS provider:
 	fmt.Fprintln(w, "\troute53:\tAWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION")
 	fmt.Fprintln(w, "\tdyn:\tDYN_CUSTOMER_NAME, DYN_USER_NAME, DYN_PASSWORD")
 	fmt.Fprintln(w, "\tvultr:\tVULTR_API_KEY")
+	fmt.Fprintln(w, "\tovh:\tOVH_ENDPOINT, OVH_APPLICATION_KEY, OVH_APPLICATION_SECRET, OVH_CONSUMER_KEY")
 	w.Flush()
 
 	fmt.Println(`

--- a/cli_handlers.go
+++ b/cli_handlers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/xenolf/lego/providers/dns/rfc2136"
 	"github.com/xenolf/lego/providers/dns/route53"
 	"github.com/xenolf/lego/providers/dns/vultr"
+	"github.com/xenolf/lego/providers/dns/ovh"
 	"github.com/xenolf/lego/providers/http/webroot"
 )
 
@@ -120,6 +121,8 @@ func setup(c *cli.Context) (*Configuration, *Account, *acme.Client) {
 			provider, err = rfc2136.NewDNSProvider()
 		case "vultr":
 			provider, err = vultr.NewDNSProvider()
+		case "ovh":
+			provider, err = ovh.NewDNSProvider()
 		}
 
 		if err != nil {

--- a/cli_handlers.go
+++ b/cli_handlers.go
@@ -18,10 +18,10 @@ import (
 	"github.com/xenolf/lego/providers/dns/gandi"
 	"github.com/xenolf/lego/providers/dns/googlecloud"
 	"github.com/xenolf/lego/providers/dns/namecheap"
+	"github.com/xenolf/lego/providers/dns/ovh"
 	"github.com/xenolf/lego/providers/dns/rfc2136"
 	"github.com/xenolf/lego/providers/dns/route53"
 	"github.com/xenolf/lego/providers/dns/vultr"
-	"github.com/xenolf/lego/providers/dns/ovh"
 	"github.com/xenolf/lego/providers/http/webroot"
 )
 

--- a/providers/dns/ovh/ovh.go
+++ b/providers/dns/ovh/ovh.go
@@ -1,0 +1,169 @@
+// Package OVH implements a DNS provider for solving the DNS-01
+// challenge using OVH DNS.
+package ovh
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"strings"
+
+	"github.com/xenolf/lego/acme"
+	"github.com/ovh/go-ovh/ovh"
+)
+
+// OVH API reference:       https://eu.api.ovh.com/
+// Create a Token:					https://eu.api.ovh.com/createToken/
+
+
+// DNSProvider is an implementation of the acme.ChallengeProvider interface
+// that uses OVH's REST API to manage TXT records for a domain.
+type DNSProvider struct {
+	client *ovh.Client
+	recordIDs    map[string]int
+	recordIDsMu  sync.Mutex
+}
+
+
+// NewDNSProvider returns a DNSProvider instance configured for OVH
+// Credentials must be passed in the environment variable:
+// OVH_ENDPOINT : it must be ovh-eu or ovh-ca
+// OVH_APPLICATION_KEY
+// OVH_APPLICATION_SECRET
+// OVH_CONSUMER_KEY
+func NewDNSProvider() (*DNSProvider, error) {
+	apiEndpoint := os.Getenv("OVH_ENDPOINT")
+	applicationKey := os.Getenv("OVH_APPLICATION_KEY")
+	applicationSecret := os.Getenv("OVH_APPLICATION_SECRET")
+	consumerKey := os.Getenv("OVH_CONSUMER_KEY")
+	return NewDNSProviderCredentials(apiEndpoint, applicationKey, applicationSecret, consumerKey)
+}
+
+
+// NewDNSProviderCredentials uses the supplied credentials to return a
+// DNSProvider instance configured for OVH.
+func NewDNSProviderCredentials(apiEndpoint, applicationKey, applicationSecret, consumerKey string) (*DNSProvider, error) {
+	if apiEndpoint == "" || applicationKey == "" || applicationSecret == "" || consumerKey == "" {
+		return nil, fmt.Errorf("OVH credentials missing")
+	}
+
+	ovhClient, _ := ovh.NewClient(
+        apiEndpoint,
+        applicationKey,
+        applicationSecret,
+        consumerKey,
+  )
+
+	return &DNSProvider{
+		client: ovhClient,
+		recordIDs:    make(map[string]int),
+	}, nil
+}
+
+
+// Present creates a TXT record to fulfil the dns-01 challenge.
+func (d *DNSProvider) Present(domain, token, keyAuth string) error {
+
+  // txtRecordRequest represents the request body to DO's API to make a TXT record
+	type txtRecordRequest struct {
+		FieldType 			string `json:"fieldType"`
+		SubDomain       string `json:"subDomain"`
+		Target       		string `json:"target"`
+		TTL 						int `json:"ttl"`
+	}
+
+	// txtRecordResponse represents a response from DO's API after making a TXT record
+	type txtRecordResponse struct {
+			ID   int    `json:"id"`
+			FieldType string `json:"fieldType"`
+			SubDomain string `json:"subDomain"`
+			Target string `json:"target"`
+		  TTL int `json:"ttl"`
+			Zone string `json:"zone"`
+	}
+
+	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
+
+	// Parse domain name
+	authZone, err := acme.FindZoneByFqdn(acme.ToFqdn(domain), acme.RecursiveNameservers)
+	if err != nil {
+		return fmt.Errorf("Could not determine zone for domain: '%s'. %s", domain, err)
+	}
+
+	authZone = acme.UnFqdn(authZone)
+	subDomain := d.extractRecordName(fqdn, authZone)
+
+
+	reqURL := fmt.Sprintf("/domain/zone/%s/record", authZone)
+	reqData := txtRecordRequest{FieldType: "TXT", SubDomain: subDomain, Target: value, TTL: ttl}
+	var respData txtRecordResponse
+
+	// Create TXT record
+	err = d.client.Post(reqURL, reqData, &respData)
+	if err != nil {
+		fmt.Printf("Error when call OVH api to add record : %q \n", err)
+		return err
+	}
+
+	// Apply the change
+	reqURL = fmt.Sprintf("/domain/zone/%s/refresh", authZone)
+	err = d.client.Post(reqURL, nil, nil)
+	if err != nil {
+		fmt.Printf("Error when call OVH api to refresh zone : %q \n", err)
+		return err
+	}
+
+	d.recordIDsMu.Lock()
+	d.recordIDs[fqdn] = respData.ID
+	d.recordIDsMu.Unlock()
+
+
+
+	return nil
+}
+
+
+// CleanUp removes the TXT record matching the specified parameters
+func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
+	fqdn, _, _ := acme.DNS01Record(domain, keyAuth)
+
+	// get the record's unique ID from when we created it
+	d.recordIDsMu.Lock()
+	recordID, ok := d.recordIDs[fqdn]
+	d.recordIDsMu.Unlock()
+	if !ok {
+		return fmt.Errorf("unknown record ID for '%s'", fqdn)
+	}
+
+
+	authZone, err := acme.FindZoneByFqdn(acme.ToFqdn(domain), acme.RecursiveNameservers)
+	if err != nil {
+		return fmt.Errorf("Could not determine zone for domain: '%s'. %s", domain, err)
+	}
+
+	authZone = acme.UnFqdn(authZone)
+
+	reqURL := fmt.Sprintf("/domain/zone/%s/record/%d",authZone, recordID)
+
+	err = d.client.Delete(reqURL, nil)
+	if err != nil {
+		fmt.Printf("Error when call OVH api to delete challenge record : %q \n", err)
+		return err
+	}
+
+
+	// Delete record ID from map
+	d.recordIDsMu.Lock()
+	delete(d.recordIDs, fqdn)
+	d.recordIDsMu.Unlock()
+
+	return nil
+}
+
+func (d *DNSProvider) extractRecordName(fqdn, domain string) string {
+	name := acme.UnFqdn(fqdn)
+	if idx := strings.Index(name, "."+domain); idx != -1 {
+		return name[:idx]
+	}
+	return name
+}

--- a/providers/dns/ovh/ovh_test.go
+++ b/providers/dns/ovh/ovh_test.go
@@ -9,12 +9,12 @@ import (
 )
 
 var (
-	liveTest bool
-	apiEndpoint string
-	applicationKey string
+	liveTest          bool
+	apiEndpoint       string
+	applicationKey    string
 	applicationSecret string
-	consumerKey string
-	domain   string
+	consumerKey       string
+	domain            string
 )
 
 func init() {
@@ -51,7 +51,6 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	_, err := NewDNSProvider()
 	assert.EqualError(t, err, "OVH credentials missing")
 
-
 	os.Setenv("OVH_ENDPOINT", "ovh-eu")
 	os.Setenv("OVH_APPLICATION_KEY", "")
 	os.Setenv("OVH_APPLICATION_SECRET", "5678")
@@ -59,7 +58,6 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	defer restoreEnv()
 	_, err = NewDNSProvider()
 	assert.EqualError(t, err, "OVH credentials missing")
-
 
 	os.Setenv("OVH_ENDPOINT", "ovh-eu")
 	os.Setenv("OVH_APPLICATION_KEY", "1234")

--- a/providers/dns/ovh/ovh_test.go
+++ b/providers/dns/ovh/ovh_test.go
@@ -1,0 +1,105 @@
+package ovh
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	liveTest bool
+	apiEndpoint string
+	applicationKey string
+	applicationSecret string
+	consumerKey string
+	domain   string
+)
+
+func init() {
+	apiEndpoint = os.Getenv("OVH_ENDPOINT")
+	applicationKey = os.Getenv("OVH_APPLICATION_KEY")
+	applicationSecret = os.Getenv("OVH_APPLICATION_SECRET")
+	consumerKey = os.Getenv("OVH_CONSUMER_KEY")
+	liveTest = len(apiEndpoint) > 0 && len(applicationKey) > 0 && len(applicationSecret) > 0 && len(consumerKey) > 0
+}
+
+func restoreEnv() {
+	os.Setenv("OVH_ENDPOINT", apiEndpoint)
+	os.Setenv("OVH_APPLICATION_KEY", applicationKey)
+	os.Setenv("OVH_APPLICATION_SECRET", applicationSecret)
+	os.Setenv("OVH_CONSUMER_KEY", consumerKey)
+}
+
+func TestNewDNSProviderValidEnv(t *testing.T) {
+	os.Setenv("OVH_ENDPOINT", "ovh-eu")
+	os.Setenv("OVH_APPLICATION_KEY", "1234")
+	os.Setenv("OVH_APPLICATION_SECRET", "5678")
+	os.Setenv("OVH_CONSUMER_KEY", "abcde")
+	defer restoreEnv()
+	_, err := NewDNSProvider()
+	assert.NoError(t, err)
+}
+
+func TestNewDNSProviderMissingCredErr(t *testing.T) {
+	os.Setenv("OVH_ENDPOINT", "")
+	os.Setenv("OVH_APPLICATION_KEY", "1234")
+	os.Setenv("OVH_APPLICATION_SECRET", "5678")
+	os.Setenv("OVH_CONSUMER_KEY", "abcde")
+	defer restoreEnv()
+	_, err := NewDNSProvider()
+	assert.EqualError(t, err, "OVH credentials missing")
+
+
+	os.Setenv("OVH_ENDPOINT", "ovh-eu")
+	os.Setenv("OVH_APPLICATION_KEY", "")
+	os.Setenv("OVH_APPLICATION_SECRET", "5678")
+	os.Setenv("OVH_CONSUMER_KEY", "abcde")
+	defer restoreEnv()
+	_, err = NewDNSProvider()
+	assert.EqualError(t, err, "OVH credentials missing")
+
+
+	os.Setenv("OVH_ENDPOINT", "ovh-eu")
+	os.Setenv("OVH_APPLICATION_KEY", "1234")
+	os.Setenv("OVH_APPLICATION_SECRET", "")
+	os.Setenv("OVH_CONSUMER_KEY", "abcde")
+	defer restoreEnv()
+	_, err = NewDNSProvider()
+	assert.EqualError(t, err, "OVH credentials missing")
+
+	os.Setenv("OVH_ENDPOINT", "ovh-eu")
+	os.Setenv("OVH_APPLICATION_KEY", "1234")
+	os.Setenv("OVH_APPLICATION_SECRET", "5678")
+	os.Setenv("OVH_CONSUMER_KEY", "")
+	defer restoreEnv()
+	_, err = NewDNSProvider()
+	assert.EqualError(t, err, "OVH credentials missing")
+}
+
+func TestLivePresent(t *testing.T) {
+	if !liveTest {
+		t.Skip("skipping live test")
+	}
+
+	provider, err := NewDNSProvider()
+	assert.NoError(t, err)
+
+	err = provider.Present(domain, "", "123d==")
+	assert.NoError(t, err)
+}
+
+func TestLiveCleanUp(t *testing.T) {
+	if !liveTest {
+		t.Skip("skipping live test")
+	}
+
+	time.Sleep(time.Second * 1)
+
+	provider, err := NewDNSProvider()
+	assert.NoError(t, err)
+
+	err = provider.CleanUp(domain, "", "123d==")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
We add OVH DNS Provider.
To do that we use the official GO librairy https://github.com/ovh/go-ovh

To use the new extention, we must add the folowwing environment variable :
* OVH_ENDPOINT the endpoint API you should to call
* OVH_APPLICATION_KEY the application key
* OVH_APPLICATION_SECRET the application key
* OVH_CONSUMER_KEY the consumer key

To key all, you must to go on "https://eu.api.ovh.com/createToken/" and you must add some right:
* POST /domain/zone/*
* DELETE /domain/zone/*

All the API is documented here: https://api.ovh.com/console/#/domain