### PR TITLE
Add optional support for .pem output (.crt + .key)

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -158,6 +158,10 @@ func main() {
 			Name:  "dns-timeout",
 			Usage: "Set the DNS timeout value to a specific value in seconds. The default is 10 seconds.",
 		},
+		cli.BoolFlag{
+			Name:  "pem",
+			Usage: "Generate a .pem file by concatanating the .key and .crt files together.",
+		},
 	}
 
 	err = app.Run(os.Args)


### PR DESCRIPTION
Using this with the default configuration of lighthttpd on an EdgeOS router from Ubiquiti that expects a .pem.  Adding a --pem option saves a few lines of script and directly generates the concatenated crt + key.

I could move the --pem option to under the run and renew commands.  Wasn't clear if there's a preference here.
