### PR TITLE
Support setting DNS parameters in a file with godotenv

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -150,6 +150,10 @@ func main() {
 			Name:  "dns",
 			Usage: "Solve a DNS challenge using the specified provider. Disables all other challenges. Run 'lego dnshelp' for help on usage.",
 		},
+		cli.StringFlag{
+			Name:  "dns-env-file",
+			Usage: "Set DNS challenge parameters in a standard environment file. If an environment variable is already set, tthe value from this file is ignored.",
+		},
 		cli.IntFlag{
 			Name:  "http-timeout",
 			Usage: "Set the HTTP timeout value to a specific value in seconds. The default is 10 seconds.",
@@ -172,7 +176,7 @@ func main() {
 
 func dnshelp(c *cli.Context) error {
 	fmt.Printf(
-		`Credentials for DNS providers must be passed through environment variables.
+		`Credentials for DNS providers must be passed through environment variables, or the --dns-env-file flag.
 
 Here is an example bash command using the CloudFlare DNS provider:
 

--- a/cli_handlers.go
+++ b/cli_handlers.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/urfave/cli"
+	"github.com/joho/godotenv"
 	"github.com/xenolf/lego/acme"
 	"github.com/xenolf/lego/providers/dns/cloudflare"
 	"github.com/xenolf/lego/providers/dns/digitalocean"
@@ -103,6 +104,12 @@ func setup(c *cli.Context) (*Configuration, *Account, *acme.Client) {
 	if c.GlobalIsSet("dns") {
 		var err error
 		var provider acme.ChallengeProvider
+		if c.GlobalIsSet("dns-env-file") {
+			err = godotenv.Load(c.GlobalString("dns-env-file"))
+			if err != nil {
+				logger().Printf("Unable to parse dns-env-file: %s", err.Error())
+			}
+		}
 		switch c.GlobalString("dns") {
 		case "cloudflare":
 			provider, err = cloudflare.NewDNSProvider()


### PR DESCRIPTION
This uses godotenv.Load() which means that environment variables already
set take precedent, as opposed to godotenv.Overload(). No need for
errors to be fatal, so log and move on.
