### PR TITLE
acme: Export separate authorization and certificate generation steps

### DIFF
--- a/acme/messages.go
+++ b/acme/messages.go
@@ -48,7 +48,8 @@ type RegistrationResource struct {
 	TosURL      string       `json:"terms_of_service,omitempty"`
 }
 
-type authorizationResource struct {
+// AuthorizationResource represents an ACME authorization resource.
+type AuthorizationResource struct {
 	Body       authorization
 	Domain     string
 	NewCertURL string


### PR DESCRIPTION
Export the following functions: getChallenges, solveChallenges,
requestCertificateForCsr, and requestCertificate (the last one for
consistency). Also, as a consequence of these functions being exported,
authorizationResource has been exported as well.

This allows for more granular use of the API, namely the de-coupling of
the authorization process from the certificate request process.