### PR TITLE
Export PreCheckDNS so library users can manage the DNS check in tests

### DIFF
--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -17,7 +17,9 @@ import (
 type preCheckDNSFunc func(fqdn, value string) (bool, error)
 
 var (
-	preCheckDNS preCheckDNSFunc = checkDNSPropagation
+	// PreCheckDNS checks DNS propagation before notifying ACME that
+	// the DNS challenge is ready.
+	PreCheckDNS preCheckDNSFunc = checkDNSPropagation
 	fqdnToZone                  = map[string]string{}
 )
 
@@ -84,7 +86,7 @@ func (s *dnsChallenge) Solve(chlng challenge, domain string) error {
 	}
 
 	err = WaitFor(timeout, interval, func() (bool, error) {
-		return preCheckDNS(fqdn, value)
+		return PreCheckDNS(fqdn, value)
 	})
 	if err != nil {
 		return err

--- a/acme/dns_challenge_test.go
+++ b/acme/dns_challenge_test.go
@@ -86,7 +86,7 @@ var checkAuthoritativeNssTestsErr = []struct {
 }
 
 func TestDNSValidServerResponse(t *testing.T) {
-	preCheckDNS = func(fqdn, value string) (bool, error) {
+	PreCheckDNS = func(fqdn, value string) (bool, error) {
 		return true, nil
 	}
 	privKey, _ := rsa.GenerateKey(rand.Reader, 512)
@@ -114,7 +114,7 @@ func TestDNSValidServerResponse(t *testing.T) {
 }
 
 func TestPreCheckDNS(t *testing.T) {
-	ok, err := preCheckDNS("acme-staging.api.letsencrypt.org", "fe01=")
+	ok, err := PreCheckDNS("acme-staging.api.letsencrypt.org", "fe01=")
 	if err != nil || !ok {
 		t.Errorf("preCheckDNS failed for acme-staging.api.letsencrypt.org")
 	}


### PR DESCRIPTION
This PR exports the PreCheckDNS variable so that library users can handle the DNS check before ACME is notified a DNS challenge is ready. This is especially useful in tests.

Additional discussion in https://github.com/xenolf/lego/issues/259