### PR TITLE
add an alternative parameter "zones" while NewDNSProvider (googlecloud)

### DIFF
--- a/providers/dns/googlecloud/googlecloud_test.go
+++ b/providers/dns/googlecloud/googlecloud_test.go
@@ -36,7 +36,7 @@ func TestNewDNSProviderValid(t *testing.T) {
 		t.Skip("skipping live test (requires credentials)")
 	}
 	os.Setenv("GCE_PROJECT", "")
-	_, err := NewDNSProviderCredentials("my-project")
+	_, err := NewDNSProviderCredentials("my-project", nil)
 	assert.NoError(t, err)
 	restoreGCloudEnv()
 }
@@ -46,14 +46,14 @@ func TestNewDNSProviderValidEnv(t *testing.T) {
 		t.Skip("skipping live test (requires credentials)")
 	}
 	os.Setenv("GCE_PROJECT", "my-project")
-	_, err := NewDNSProvider()
+	_, err := NewDNSProvider(nil)
 	assert.NoError(t, err)
 	restoreGCloudEnv()
 }
 
 func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	os.Setenv("GCE_PROJECT", "")
-	_, err := NewDNSProvider()
+	_, err := NewDNSProvider(nil)
 	assert.EqualError(t, err, "Google Cloud project name missing")
 	restoreGCloudEnv()
 }
@@ -63,7 +63,7 @@ func TestLiveGoogleCloudPresent(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	provider, err := NewDNSProviderCredentials(gcloudProject)
+	provider, err := NewDNSProviderCredentials(gcloudProject, nil)
 	assert.NoError(t, err)
 
 	err = provider.Present(gcloudDomain, "", "123d==")
@@ -77,7 +77,7 @@ func TestLiveGoogleCloudCleanUp(t *testing.T) {
 
 	time.Sleep(time.Second * 1)
 
-	provider, err := NewDNSProviderCredentials(gcloudProject)
+	provider, err := NewDNSProviderCredentials(gcloudProject, nil)
 	assert.NoError(t, err)
 
 	err = provider.CleanUp(gcloudDomain, "", "123d==")


### PR DESCRIPTION
Original google cloud dns provider use the input domain as the zone while dns challenge, and it will cause some issues. See below.

Ex. 1 (Success)
 challenge domain: test.com
 google zone: test.com

Ex. 2 (Failed)
 challenge domain: www.test.com
 google zone (X:  www.test.com 
 google zone (O:  test.com  

To solve this, I provide a parameter zones, while new provider. ("NewDNSProvider(zones map[string]string)".
By this to maintain the relation between challenge domains and zones. 

> Original (error: No matching GoogleCloud domain found for domain www.test.com 

`p, _ := NewDNSProvider()`
`certificates, failures := client.ObtainCertificate([]string{"test.com", "www.test.com"} , true, nil)`

> After ( if there is no mapping zone provided, use the domain as default zone

`zones := map[string]string{ "www.test.com": "test.com"}`
`p, _ := NewDNSProvider(zones)`
`certificates, failures := client.ObtainCertificate([]string{"test.com", "www.test.com"} , true, nil)`