### PR TITLE
Shift CI test to newer Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-- 1.5.3
-- 1.6
+- 1.6.3
+- 1.7
 - tip
 install:
 - go get -t ./...


### PR DESCRIPTION
Some dependencies evidently require Go 1.6 and newer; also Go 1.7 is out.