### PR TITLE
Add sync.Mutex to lock and unlock j.nonces

### DIFF
--- a/acme/jws.go
+++ b/acme/jws.go
@@ -8,6 +8,7 @@ import (
 	"crypto/rsa"
 	"fmt"
 	"net/http"
+	"sync"
 
 	"gopkg.in/square/go-jose.v1"
 )
@@ -16,6 +17,7 @@ type jws struct {
 	directoryURL string
 	privKey      crypto.PrivateKey
 	nonces       []string
+	sync.Mutex
 }
 
 func keyAsJWK(key interface{}) *jose.JsonWebKey {
@@ -75,6 +77,8 @@ func (j *jws) signContent(content []byte) (*jose.JsonWebSignature, error) {
 }
 
 func (j *jws) getNonceFromResponse(resp *http.Response) error {
+	j.Lock()
+	defer j.Unlock()
 	nonce := resp.Header.Get("Replay-Nonce")
 	if nonce == "" {
 		return fmt.Errorf("Server did not respond with a proper nonce header.")
@@ -104,6 +108,8 @@ func (j *jws) Nonce() (string, error) {
 	if len(j.nonces) == 0 {
 		return "", fmt.Errorf("Can't get nonce")
 	}
+	j.Lock()
+	defer j.Unlock()
 	nonce, j.nonces = j.nonces[len(j.nonces)-1], j.nonces[:len(j.nonces)-1]
 	return nonce, nil
 }


### PR DESCRIPTION
This PR adds sync.Mutex to jws, and locks/unlocks methods where j.nonce is edited. This fixes the [data race](https://golang.org/doc/articles/race_detector.html) during tests for ObtainCertificate. 