### PR TITLE
Allow custom DNS resolvers

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -158,6 +158,10 @@ func main() {
 			Name:  "dns-timeout",
 			Usage: "Set the DNS timeout value to a specific value in seconds. The default is 10 seconds.",
 		},
+		cli.StringSliceFlag{
+			Name:  "dns-resolvers",
+			Usage: "Set the resolvers to use for performing recursive DNS queries. Supported: host:port. The default is to use Google's DNS resolvers.",
+		},
 		cli.BoolFlag{
 			Name:  "pem",
 			Usage: "Generate a .pem file by concatanating the .key and .crt files together.",

--- a/cli_handlers.go
+++ b/cli_handlers.go
@@ -47,6 +47,17 @@ func setup(c *cli.Context) (*Configuration, *Account, *acme.Client) {
 		acme.DNSTimeout = time.Duration(c.GlobalInt("dns-timeout")) * time.Second
 	}
 
+	if len(c.GlobalStringSlice("dns-resolvers")) > 0 {
+		resolvers := []string{}
+		for _, resolver := range c.GlobalStringSlice("dns-resolvers") {
+			if !strings.Contains(resolver, ":") {
+				resolver += ":53"
+			}
+			resolvers = append(resolvers, resolver)
+		}
+		acme.RecursiveNameservers = resolvers
+	}
+
 	err := checkFolder(c.GlobalString("path"))
 	if err != nil {
 		logger().Fatalf("Could not check/create path: %s", err.Error())


### PR DESCRIPTION
Closes #219 

The way urfave/cli handles slice arguments is a bit clumsy. ~~I've called the new flag `--dns-resolver` (singular) as you specify it multiple times on the command line e.g. `--dns-resolver="8.8.8.8:53" --dns-resolver="8.8.4.4:53"`~~
EDIT: on second thoughts, changed to `--dns-resolvers` to make it consistent with the other multi-value flags