### PR TITLE
Fix duplicate json tag in recoveryKeyMessage

### DIFF
--- a/acme/messages.go
+++ b/acme/messages.go
@@ -13,17 +13,10 @@ type directory struct {
 	RevokeCertURL string `json:"revoke-cert"`
 }
 
-type recoveryKeyMessage struct {
-	Length int             `json:"length,omitempty"`
-	Client jose.JsonWebKey `json:"client,omitempty"`
-	Server jose.JsonWebKey `json:"client,omitempty"`
-}
-
 type registrationMessage struct {
 	Resource string   `json:"resource"`
 	Contact  []string `json:"contact"`
 	Delete   bool     `json:"delete,omitempty"`
-	//	RecoveryKey recoveryKeyMessage `json:"recoveryKey,omitempty"`
 }
 
 // Registration is returned by the ACME server after the registration
@@ -36,7 +29,6 @@ type Registration struct {
 	Agreement      string          `json:"agreement,omitempty"`
 	Authorizations string          `json:"authorizations,omitempty"`
 	Certificates   string          `json:"certificates,omitempty"`
-	//	RecoveryKey    recoveryKeyMessage `json:"recoveryKey,omitempty"`
 }
 
 // RegistrationResource represents all important informations about a registration


### PR DESCRIPTION
Fixed issue by removing unused recoveryKeyMessage struct

Issue appears in Go 1.8+ due to this improvement to vet:
https://go-review.googlesource.com/#/c/16704/