### PR TITLE
Remove existing records in gcloud

### DIFF
--- a/providers/dns/googlecloud/googlecloud.go
+++ b/providers/dns/googlecloud/googlecloud.go
@@ -68,6 +68,16 @@ func (c *DNSProvider) Present(domain, token, keyAuth string) error {
 		Additions: []*dns.ResourceRecordSet{rec},
 	}
 
+	// Look for existing records.
+	list, err := c.client.ResourceRecordSets.List(c.project, zone).Name(fqdn).Type("TXT").Do()
+	if err != nil {
+		return err
+	}
+	if len(list.Rrsets) > 0 {
+		// Attempt to delete the existing records when adding our new one.
+		change.Deletions = list.Rrsets
+	}
+
 	chg, err := c.client.Changes.Create(c.project, zone, change).Do()
 	if err != nil {
 		return err

--- a/providers/dns/googlecloud/googlecloud_test.go
+++ b/providers/dns/googlecloud/googlecloud_test.go
@@ -70,6 +70,20 @@ func TestLiveGoogleCloudPresent(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestLiveGoogleCloudPresentMultiple(t *testing.T) {
+	if !gcloudLiveTest {
+		t.Skip("skipping live test")
+	}
+
+	provider, err := NewDNSProviderCredentials(gcloudProject)
+	assert.NoError(t, err)
+
+	// Check that we're able to create multiple entries
+	err = provider.Present(gcloudDomain, "1", "123d==")
+	err = provider.Present(gcloudDomain, "2", "123d==")
+	assert.NoError(t, err)
+}
+
 func TestLiveGoogleCloudCleanUp(t *testing.T) {
 	if !gcloudLiveTest {
 		t.Skip("skipping live test")


### PR DESCRIPTION
When record already exists in gcloud we can't add a new record without removing the other one first. This is a simple fix that doesn't attempt to create multiple entries for the record but just removes the previous data.

fixes #218
