### PR TITLE
Extract from CLI the name -> DNS provider mapping

### DIFF
--- a/cli_handlers.go
+++ b/cli_handlers.go
@@ -15,26 +15,7 @@ import (
 
 	"github.com/urfave/cli"
 	"github.com/xenolf/lego/acme"
-	"github.com/xenolf/lego/providers/dns/auroradns"
-	"github.com/xenolf/lego/providers/dns/azure"
-	"github.com/xenolf/lego/providers/dns/cloudflare"
-	"github.com/xenolf/lego/providers/dns/digitalocean"
-	"github.com/xenolf/lego/providers/dns/dnsimple"
-	"github.com/xenolf/lego/providers/dns/dnsmadeeasy"
-	"github.com/xenolf/lego/providers/dns/dnspod"
-	"github.com/xenolf/lego/providers/dns/dyn"
-	"github.com/xenolf/lego/providers/dns/exoscale"
-	"github.com/xenolf/lego/providers/dns/gandi"
-	"github.com/xenolf/lego/providers/dns/googlecloud"
-	"github.com/xenolf/lego/providers/dns/linode"
-	"github.com/xenolf/lego/providers/dns/namecheap"
-	"github.com/xenolf/lego/providers/dns/ns1"
-	"github.com/xenolf/lego/providers/dns/ovh"
-	"github.com/xenolf/lego/providers/dns/pdns"
-	"github.com/xenolf/lego/providers/dns/rackspace"
-	"github.com/xenolf/lego/providers/dns/rfc2136"
-	"github.com/xenolf/lego/providers/dns/route53"
-	"github.com/xenolf/lego/providers/dns/vultr"
+	"github.com/xenolf/lego/providers/dns"
 	"github.com/xenolf/lego/providers/http/memcached"
 	"github.com/xenolf/lego/providers/http/webroot"
 )
@@ -133,53 +114,7 @@ func setup(c *cli.Context) (*Configuration, *Account, *acme.Client) {
 	}
 
 	if c.GlobalIsSet("dns") {
-		var err error
-		var provider acme.ChallengeProvider
-		switch c.GlobalString("dns") {
-		case "azure":
-			provider, err = azure.NewDNSProvider()
-		case "auroradns":
-			provider, err = auroradns.NewDNSProvider()
-		case "cloudflare":
-			provider, err = cloudflare.NewDNSProvider()
-		case "digitalocean":
-			provider, err = digitalocean.NewDNSProvider()
-		case "dnsimple":
-			provider, err = dnsimple.NewDNSProvider()
-		case "dnsmadeeasy":
-			provider, err = dnsmadeeasy.NewDNSProvider()
-		case "exoscale":
-			provider, err = exoscale.NewDNSProvider()
-		case "dyn":
-			provider, err = dyn.NewDNSProvider()
-		case "gandi":
-			provider, err = gandi.NewDNSProvider()
-		case "gcloud":
-			provider, err = googlecloud.NewDNSProvider()
-		case "linode":
-			provider, err = linode.NewDNSProvider()
-		case "manual":
-			provider, err = acme.NewDNSProviderManual()
-		case "namecheap":
-			provider, err = namecheap.NewDNSProvider()
-		case "rackspace":
-			provider, err = rackspace.NewDNSProvider()
-		case "route53":
-			provider, err = route53.NewDNSProvider()
-		case "rfc2136":
-			provider, err = rfc2136.NewDNSProvider()
-		case "vultr":
-			provider, err = vultr.NewDNSProvider()
-		case "ovh":
-			provider, err = ovh.NewDNSProvider()
-		case "pdns":
-			provider, err = pdns.NewDNSProvider()
-		case "ns1":
-			provider, err = ns1.NewDNSProvider()
-		case "dnspod":
-			provider, err = dnspod.NewDNSProvider()
-		}
-
+    provider, err := dns.NewDNSChallengeProviderByName(c.GlobalString("dns"))
 		if err != nil {
 			logger().Fatal(err)
 		}

--- a/providers/dns/dns_providers.go
+++ b/providers/dns/dns_providers.go
@@ -1,0 +1,80 @@
+// Factory for DNS providers
+package dns
+
+import (
+	"fmt"
+
+	"github.com/xenolf/lego/acme"
+	"github.com/xenolf/lego/providers/dns/auroradns"
+	"github.com/xenolf/lego/providers/dns/azure"
+	"github.com/xenolf/lego/providers/dns/cloudflare"
+	"github.com/xenolf/lego/providers/dns/digitalocean"
+	"github.com/xenolf/lego/providers/dns/dnsimple"
+	"github.com/xenolf/lego/providers/dns/dnsmadeeasy"
+	"github.com/xenolf/lego/providers/dns/dnspod"
+	"github.com/xenolf/lego/providers/dns/dyn"
+	"github.com/xenolf/lego/providers/dns/exoscale"
+	"github.com/xenolf/lego/providers/dns/gandi"
+	"github.com/xenolf/lego/providers/dns/googlecloud"
+	"github.com/xenolf/lego/providers/dns/linode"
+	"github.com/xenolf/lego/providers/dns/namecheap"
+	"github.com/xenolf/lego/providers/dns/ns1"
+	"github.com/xenolf/lego/providers/dns/ovh"
+	"github.com/xenolf/lego/providers/dns/pdns"
+	"github.com/xenolf/lego/providers/dns/rackspace"
+	"github.com/xenolf/lego/providers/dns/rfc2136"
+	"github.com/xenolf/lego/providers/dns/route53"
+	"github.com/xenolf/lego/providers/dns/vultr"
+)
+
+func NewDNSChallengeProviderByName(name string) (acme.ChallengeProvider, error) {
+	var err error
+	var provider acme.ChallengeProvider
+	switch name {
+	case "azure":
+		provider, err = azure.NewDNSProvider()
+	case "auroradns":
+		provider, err = auroradns.NewDNSProvider()
+	case "cloudflare":
+		provider, err = cloudflare.NewDNSProvider()
+	case "digitalocean":
+		provider, err = digitalocean.NewDNSProvider()
+	case "dnsimple":
+		provider, err = dnsimple.NewDNSProvider()
+	case "dnsmadeeasy":
+		provider, err = dnsmadeeasy.NewDNSProvider()
+	case "dnspod":
+		provider, err = dnspod.NewDNSProvider()
+	case "dyn":
+		provider, err = dyn.NewDNSProvider()
+	case "exoscale":
+		provider, err = exoscale.NewDNSProvider()		
+	case "gandi":
+		provider, err = gandi.NewDNSProvider()
+	case "gcloud":
+		provider, err = googlecloud.NewDNSProvider()
+	case "linode":
+		provider, err = linode.NewDNSProvider()
+	case "manual":
+		provider, err = acme.NewDNSProviderManual()
+	case "namecheap":
+		provider, err = namecheap.NewDNSProvider()
+	case "rackspace":
+		provider, err = rackspace.NewDNSProvider()
+	case "route53":
+		provider, err = route53.NewDNSProvider()
+	case "rfc2136":
+		provider, err = rfc2136.NewDNSProvider()
+	case "vultr":
+		provider, err = vultr.NewDNSProvider()
+	case "ovh":
+		provider, err = ovh.NewDNSProvider()
+	case "pdns":
+		provider, err = pdns.NewDNSProvider()
+	case "ns1":
+		provider, err = ns1.NewDNSProvider()
+	default:
+		err = fmt.Errorf("Unrecognised DNS provider: %s", name)
+	}
+	return provider, err
+}

--- a/providers/dns/dns_providers_test.go
+++ b/providers/dns/dns_providers_test.go
@@ -2,9 +2,11 @@ package dns
 
 import (
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/xenolf/lego/providers/dns/exoscale"
 )
 
 var (
@@ -28,6 +30,9 @@ func TestKnownDNSProviderSuccess(t *testing.T) {
 	provider, err := NewDNSChallengeProviderByName("exoscale")
 	assert.NoError(t, err)
 	assert.NotNil(t, provider)
+	if reflect.TypeOf(provider) != reflect.TypeOf(&exoscale.DNSProvider{}) {
+		t.Errorf("Not loaded correct DNS proviver: %v is not *exoscale.DNSProvider", reflect.TypeOf(provider))
+	}
 	restoreExoscaleEnv()
 }
 

--- a/providers/dns/dns_providers_test.go
+++ b/providers/dns/dns_providers_test.go
@@ -1,0 +1,45 @@
+package dns
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	apiKey    string
+	apiSecret string
+)
+
+func init() {
+	apiSecret = os.Getenv("EXOSCALE_API_SECRET")
+	apiKey = os.Getenv("EXOSCALE_API_KEY")
+}
+
+func restoreExoscaleEnv() {
+	os.Setenv("EXOSCALE_API_KEY", apiKey)
+	os.Setenv("EXOSCALE_API_SECRET", apiSecret)
+}
+
+func TestKnownDNSProviderSuccess(t *testing.T) {
+	os.Setenv("EXOSCALE_API_KEY", "abc")
+	os.Setenv("EXOSCALE_API_SECRET", "123")
+	provider, err := NewDNSChallengeProviderByName("exoscale")
+	assert.NoError(t, err)
+	assert.NotNil(t, provider)
+	restoreExoscaleEnv()
+}
+
+func TestKnownDNSProviderError(t *testing.T) {
+	os.Setenv("EXOSCALE_API_KEY", "")
+	os.Setenv("EXOSCALE_API_SECRET", "")
+	_, err := NewDNSChallengeProviderByName("exoscale")
+	assert.Error(t, err)
+	restoreExoscaleEnv()
+}
+
+func TestUnknownDNSProvider(t *testing.T) {
+	_, err := NewDNSChallengeProviderByName("foobar")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
This avoids duplication of this mapping in lib clients 
Ex : https://github.com/containous/traefik/pull/738#issuecomment-258810469