### PR TITLE
Export DomainError and ChallengeError

### DIFF
--- a/acme/client.go
+++ b/acme/client.go
@@ -517,7 +517,7 @@ func (c *Client) chooseSolvers(auth authorization, domain string) map[int]solver
 
 // Get the challenges needed to proof our identifier to the ACME server.
 func (c *Client) getChallenges(domains []string) ([]authorizationResource, map[string]error) {
-	resc, errc := make(chan authorizationResource), make(chan domainError)
+	resc, errc := make(chan authorizationResource), make(chan DomainError)
 
 	for _, domain := range domains {
 		go func(domain string) {
@@ -525,7 +525,7 @@ func (c *Client) getChallenges(domains []string) ([]authorizationResource, map[s
 			var authz authorization
 			hdr, err := postJSON(c.jws, c.user.GetRegistration().NewAuthzURL, authMsg, &authz)
 			if err != nil {
-				errc <- domainError{Domain: domain, Error: err}
+				errc <- DomainError{Domain: domain, Error: err}
 				return
 			}
 

--- a/acme/error.go
+++ b/acme/error.go
@@ -30,17 +30,17 @@ type TOSError struct {
 	RemoteError
 }
 
-type domainError struct {
+type DomainError struct {
 	Domain string
 	Error  error
 }
 
-type challengeError struct {
+type ChallengeError struct {
 	RemoteError
 	records []validationRecord
 }
 
-func (c challengeError) Error() string {
+func (c ChallengeError) Error() string {
 
 	var errStr string
 	for _, validation := range c.records {
@@ -82,5 +82,5 @@ func handleHTTPError(resp *http.Response) error {
 }
 
 func handleChallengeError(chlng challenge) error {
-	return challengeError{chlng.Error, chlng.ValidationRecords}
+	return ChallengeError{chlng.Error, chlng.ValidationRecords}
 }


### PR DESCRIPTION
in order to allow type assertion on specific errors, eg.:
```
certificate, failures := s.client.ObtainCertificate(domains, true, nil)
for domain, failure := range failures {
        switch f := failure.(type) {
        case acme.ChallengeError:
                // Handle acme.ChallengeError
        case acme.RemoteError:
                // Handle acme.RemoteError
        default:
                // Handle other errors
        }
}
```