### PR TITLE
Close response body in error case and close first one

### DIFF
--- a/acme/client.go
+++ b/acme/client.go
@@ -670,6 +670,7 @@ func (c *Client) requestCertificateForCsr(authz []authorizationResource, bundle 
 
 			break
 		default:
+			defer resp.Body.Close()
 			return CertificateResource{}, handleHTTPError(resp)
 		}
 

--- a/acme/client.go
+++ b/acme/client.go
@@ -23,6 +23,9 @@ var (
 	Logger *log.Logger
 )
 
+// maxBodySize is the maximum size of body that we will read.
+const maxBodySize = 1024 * 1024
+
 // logf writes a log entry. It uses Logger if not
 // nil, otherwise it uses the default log.Logger.
 func logf(format string, args ...interface{}) {
@@ -783,6 +786,3 @@ func validate(j *jws, domain, uri string, chlng challenge) error {
 		}
 	}
 }
-
-// maxBodySize is the maximum size of body that we will read.
-const maxBodySize = 1024 * 1024

--- a/acme/client.go
+++ b/acme/client.go
@@ -619,9 +619,6 @@ func (c *Client) requestCertificateForCsr(authz []authorizationResource, bundle 
 
 	maxChecks := 1000
 	for i := 0; i < maxChecks; i++ {
-		if i == maxChecks-1 {
-			return CertificateResource{}, fmt.Errorf("polled for certificate %d times; giving up", maxChecks)
-		}
 		done, err := c.checkCertResponse(resp, &certRes, bundle)
 		resp.Body.Close()
 		if err != nil {
@@ -629,6 +626,9 @@ func (c *Client) requestCertificateForCsr(authz []authorizationResource, bundle 
 		}
 		if done {
 			break
+		}
+		if i == maxChecks-1 {
+			return CertificateResource{}, fmt.Errorf("polled for certificate %d times; giving up", i)
 		}
 		resp, err = httpGet(certRes.CertURL)
 		if err != nil {

--- a/acme/client.go
+++ b/acme/client.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net"
+	"net/http"
 	"regexp"
 	"strconv"
 	"strings"
@@ -610,74 +611,95 @@ func (c *Client) requestCertificateForCsr(authz []authorizationResource, bundle 
 		return CertificateResource{}, err
 	}
 
-	cerRes := CertificateResource{
+	certRes := CertificateResource{
 		Domain:     commonName.Domain,
 		CertURL:    resp.Header.Get("Location"),
-		PrivateKey: privateKeyPem}
+		PrivateKey: privateKeyPem,
+	}
 
-	for {
-		switch resp.StatusCode {
-		case 201, 202:
-			cert, err := ioutil.ReadAll(limitReader(resp.Body, 1024*1024))
-			resp.Body.Close()
-			if err != nil {
-				return CertificateResource{}, err
-			}
-
-			// The server returns a body with a length of zero if the
-			// certificate was not ready at the time this request completed.
-			// Otherwise the body is the certificate.
-			if len(cert) > 0 {
-
-				cerRes.CertStableURL = resp.Header.Get("Content-Location")
-				cerRes.AccountRef = c.user.GetRegistration().URI
-
-				issuedCert := pemEncode(derCertificateBytes(cert))
-
-				// The issuer certificate link is always supplied via an "up" link
-				// in the response headers of a new certificate.
-				links := parseLinks(resp.Header["Link"])
-				issuerCert, err := c.getIssuerCertificate(links["up"])
-				if err != nil {
-					// If we fail to acquire the issuer cert, return the issued certificate - do not fail.
-					logf("[WARNING][%s] acme: Could not bundle issuer certificate: %v", commonName.Domain, err)
-				} else {
-					issuerCert = pemEncode(derCertificateBytes(issuerCert))
-
-					// If bundle is true, we want to return a certificate bundle.
-					// To do this, we append the issuer cert to the issued cert.
-					if bundle {
-						issuedCert = append(issuedCert, issuerCert...)
-					}
-				}
-
-				cerRes.Certificate = issuedCert
-				cerRes.IssuerCertificate = issuerCert
-				logf("[INFO][%s] Server responded with a certificate.", commonName.Domain)
-				return cerRes, nil
-			}
-
-			// The certificate was granted but is not yet issued.
-			// Check retry-after and loop.
-			ra := resp.Header.Get("Retry-After")
-			retryAfter, err := strconv.Atoi(ra)
-			if err != nil {
-				return CertificateResource{}, err
-			}
-
-			logf("[INFO][%s] acme: Server responded with status 202; retrying after %ds", commonName.Domain, retryAfter)
-			time.Sleep(time.Duration(retryAfter) * time.Second)
-
-			break
-		default:
-			defer resp.Body.Close()
-			return CertificateResource{}, handleHTTPError(resp)
+	maxChecks := 1000
+	for i := 0; i < maxChecks; i++ {
+		if i == maxChecks-1 {
+			return CertificateResource{}, fmt.Errorf("polled for certificate %d times; giving up", maxChecks)
 		}
-
-		resp, err = httpGet(cerRes.CertURL)
+		done, err := c.checkCertResponse(resp, &certRes, bundle)
+		resp.Body.Close()
 		if err != nil {
 			return CertificateResource{}, err
 		}
+		if done {
+			break
+		}
+		resp, err = httpGet(certRes.CertURL)
+		if err != nil {
+			return CertificateResource{}, err
+		}
+	}
+
+	return certRes, nil
+}
+
+// checkCertResponse checks resp to see if a certificate is contained in the
+// response, and if so, loads it into certRes and returns true. If the cert
+// is not yet ready, it returns false. This function honors the waiting period
+// required by the Retry-After header of the response, if specified. This
+// function may read from resp.Body but does NOT close it. The certRes input
+// should already have the Domain (common name) field populated. If bundle is
+// true, the certificate will be bundled with the issuer's cert.
+func (c *Client) checkCertResponse(resp *http.Response, certRes *CertificateResource, bundle bool) (bool, error) {
+	switch resp.StatusCode {
+	case 201, 202:
+		cert, err := ioutil.ReadAll(limitReader(resp.Body, maxBodySize))
+		if err != nil {
+			return false, err
+		}
+
+		// The server returns a body with a length of zero if the
+		// certificate was not ready at the time this request completed.
+		// Otherwise the body is the certificate.
+		if len(cert) > 0 {
+			certRes.CertStableURL = resp.Header.Get("Content-Location")
+			certRes.AccountRef = c.user.GetRegistration().URI
+
+			issuedCert := pemEncode(derCertificateBytes(cert))
+
+			// The issuer certificate link is always supplied via an "up" link
+			// in the response headers of a new certificate.
+			links := parseLinks(resp.Header["Link"])
+			issuerCert, err := c.getIssuerCertificate(links["up"])
+			if err != nil {
+				// If we fail to acquire the issuer cert, return the issued certificate - do not fail.
+				logf("[WARNING][%s] acme: Could not bundle issuer certificate: %v", certRes.Domain, err)
+			} else {
+				issuerCert = pemEncode(derCertificateBytes(issuerCert))
+
+				// If bundle is true, we want to return a certificate bundle.
+				// To do this, we append the issuer cert to the issued cert.
+				if bundle {
+					issuedCert = append(issuedCert, issuerCert...)
+				}
+			}
+
+			certRes.Certificate = issuedCert
+			certRes.IssuerCertificate = issuerCert
+			logf("[INFO][%s] Server responded with a certificate.", certRes.Domain)
+			return true, nil
+		}
+
+		// The certificate was granted but is not yet issued.
+		// Check retry-after and loop.
+		ra := resp.Header.Get("Retry-After")
+		retryAfter, err := strconv.Atoi(ra)
+		if err != nil {
+			return false, err
+		}
+
+		logf("[INFO][%s] acme: Server responded with status 202; retrying after %ds", certRes.Domain, retryAfter)
+		time.Sleep(time.Duration(retryAfter) * time.Second)
+
+		return false, nil
+	default:
+		return false, handleHTTPError(resp)
 	}
 }
 
@@ -690,7 +712,7 @@ func (c *Client) getIssuerCertificate(url string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	issuerBytes, err := ioutil.ReadAll(limitReader(resp.Body, 1024*1024))
+	issuerBytes, err := ioutil.ReadAll(limitReader(resp.Body, maxBodySize))
 	if err != nil {
 		return nil, err
 	}
@@ -761,3 +783,6 @@ func validate(j *jws, domain, uri string, chlng challenge) error {
 		}
 	}
 }
+
+// maxBodySize is the maximum size of body that we will read.
+const maxBodySize = 1024 * 1024

--- a/acme/error.go
+++ b/acme/error.go
@@ -8,9 +8,7 @@ import (
 	"strings"
 )
 
-const (
-	tosAgreementError = "Must agree to subscriber agreement before any further actions"
-)
+const tosAgreementError = "Must agree to subscriber agreement before any further actions"
 
 // RemoteError is the base type for all errors specific to the ACME protocol.
 type RemoteError struct {
@@ -61,7 +59,7 @@ func handleHTTPError(resp *http.Response) error {
 			return err
 		}
 	} else {
-		detailBytes, err := ioutil.ReadAll(limitReader(resp.Body, 1024*1024))
+		detailBytes, err := ioutil.ReadAll(limitReader(resp.Body, maxBodySize))
 		if err != nil {
 			return err
 		}

--- a/acme/error.go
+++ b/acme/error.go
@@ -54,11 +54,9 @@ func (c challengeError) Error() string {
 func handleHTTPError(resp *http.Response) error {
 	var errorDetail RemoteError
 
-	contenType := resp.Header.Get("Content-Type")
-	// try to decode the content as JSON
-	if contenType == "application/json" || contenType == "application/problem+json" {
-		decoder := json.NewDecoder(resp.Body)
-		err := decoder.Decode(&errorDetail)
+	contentType := resp.Header.Get("Content-Type")
+	if contentType == "application/json" || contentType == "application/problem+json" {
+		err := json.NewDecoder(resp.Body).Decode(&errorDetail)
 		if err != nil {
 			return err
 		}
@@ -67,7 +65,6 @@ func handleHTTPError(resp *http.Response) error {
 		if err != nil {
 			return err
 		}
-
 		errorDetail.Detail = string(detailBytes)
 	}
 

--- a/acme/jws.go
+++ b/acme/jws.go
@@ -32,7 +32,9 @@ func keyAsJWK(key interface{}) *jose.JsonWebKey {
 	}
 }
 
-// Posts a JWS signed message to the specified URL
+// Posts a JWS signed message to the specified URL.
+// It does NOT close the response body, so the caller must
+// do that if no error was returned.
 func (j *jws) post(url string, content []byte) (*http.Response, error) {
 	signedContent, err := j.signContent(content)
 	if err != nil {


### PR DESCRIPTION
I noticed that the response body is not closed in the error case of waiting for a certificate to be issued: https://sourcegraph.com/github.com/xenolf/lego@ce8fb060cb8361a9ff8b5fb7c2347fa907b6fcac/-/blob/acme/client.go#L673-674

AFAIK the response body needs to be closed even if there isn't one or it is not read. We close it above if the response code is 201 or 202, but not 200 or anything else. I think this will fix that problem.