### PR TITLE
Log authorization urls

### DIFF
--- a/acme/client.go
+++ b/acme/client.go
@@ -560,10 +560,18 @@ func (c *Client) getChallenges(domains []string) ([]authorizationResource, map[s
 		}
 	}
 
+	logAuthz(challenges)
+
 	close(resc)
 	close(errc)
 
 	return challenges, failures
+}
+
+func logAuthz(authz []authorizationResource) {
+	for _, auth := range authz {
+		logf("[INFO][%s] AuthURL: %s", auth.Domain, auth.AuthURL)
+	}
 }
 
 func (c *Client) requestCertificate(authz []authorizationResource, bundle bool, privKey crypto.PrivateKey, mustStaple bool) (CertificateResource, error) {


### PR DESCRIPTION
https://letsencrypt.org/docs/rate-limits/ says:

> The pending authorization objects are represented by URLs of the form https://acme-v01.api.letsencrypt.org/acme/authz/XYZ, and should show up in your client logs.