### PR TITLE
Add sleeps for new-authz rate limits

### DIFF
--- a/acme/client.go
+++ b/acme/client.go
@@ -23,8 +23,15 @@ var (
 	Logger *log.Logger
 )
 
-// maxBodySize is the maximum size of body that we will read.
-const maxBodySize = 1024 * 1024
+const (
+	// maxBodySize is the maximum size of body that we will read.
+	maxBodySize = 1024 * 1024
+
+	// overallRequestLimit is the overall number of request per second limited on the
+	// “new-reg”, “new-authz” and “new-cert” endpoints. From the documentation the
+	// limitation is 20 requests per second, but using 20 as value doesn't work but 18 do
+	overallRequestLimit = 18
+)
 
 // logf writes a log entry. It uses Logger if not
 // nil, otherwise it uses the default log.Logger.
@@ -522,7 +529,14 @@ func (c *Client) chooseSolvers(auth authorization, domain string) map[int]solver
 func (c *Client) getChallenges(domains []string) ([]authorizationResource, map[string]error) {
 	resc, errc := make(chan authorizationResource), make(chan domainError)
 
+	var delay time.Duration
+	if len(domains) > overallRequestLimit {
+		delay = time.Second / overallRequestLimit
+	}
+
 	for _, domain := range domains {
+		time.Sleep(delay)
+
 		go func(domain string) {
 			authMsg := authorization{Resource: "new-authz", Identifier: identifier{Type: "dns", Value: domain}}
 			var authz authorization


### PR DESCRIPTION
When creating bulk certificates, we often hit the acme rate limiting which is defined to 20 requests per second against the new-authz endpoint.

This PR add a workaround.

Note: letsencrypt set the limit to 20rps, but after some testing it seems that using a value of 18 work better.