### PR TITLE
Move nonce retry from jws to http

### DIFF
--- a/acme/jws.go
+++ b/acme/jws.go
@@ -44,24 +44,10 @@ func (j *jws) post(url string, content []byte) (*http.Response, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to HTTP POST to %s -> %s", url, err.Error())
 	}
-	
-	// Even in case of an error, the response should still contain a nonce.
+
 	nonce, nonceErr := getNonceFromResponse(resp)
 	if nonceErr == nil {
 		j.nonces.Push(nonce)
-	}
-
-	if err != nil {
-		switch err.(type) {
-		case NonceError:
-			// In case of a nonce error - retry once
-			resp, err = httpPost(url, "application/jose+json", bytes.NewBuffer([]byte(signedContent.FullSerialize())))
-			if err != nil {
-				return nil, fmt.Errorf("Failed to HTTP POST to %s -> %s", url, err.Error())
-			}
-		default:
-			return nil, fmt.Errorf("Failed to HTTP POST to %s -> %s", url, err.Error())
-		}
 	}
 
 	return resp, nil


### PR DESCRIPTION
The error raised by an "invalid nonce" response never appeared inside `jws.go`, but instead it was handled at `http.go`, so it makes sense to move the retry logic to that file. The previous code from `jws.go` had no effect and did not solve issues related to invalid nonces.