### PR TITLE
optional authoritative precheck

### DIFF
--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -34,6 +34,8 @@ var RecursiveNameservers = getNameservers(defaultResolvConf, defaultNameservers)
 // DNSTimeout is used to override the default DNS timeout of 10 seconds.
 var DNSTimeout = 10 * time.Second
 
+var DNSNoAuthoritCheck = false
+
 // getNameservers attempts to get systems nameservers before falling back to the defaults
 func getNameservers(path string, defaults []string) []string {
 	config, err := dns.ClientConfigFromFile(path)
@@ -141,7 +143,12 @@ func checkDNSPropagation(fqdn, value string) (bool, error) {
 		return false, err
 	}
 
-	return checkAuthoritativeNss(fqdn, value, authoritativeNss)
+	if !DNSNoAuthoritCheck {
+		logf("[INFO][%s] Checking DNS record propagation near authoritative nameservers", fqdn)
+		return checkAuthoritativeNss(fqdn, value, authoritativeNss)
+	}
+
+	return true, nil
 }
 
 // checkAuthoritativeNss queries each of the given nameservers for the expected TXT record.

--- a/acme/http.go
+++ b/acme/http.go
@@ -18,6 +18,7 @@ var UserAgent string
 // HTTPClient is an HTTP client with a reasonable timeout value.
 var HTTPClient = http.Client{
 	Transport: &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		Dial: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,

--- a/cli.go
+++ b/cli.go
@@ -178,6 +178,10 @@ func main() {
 			Name:  "pem",
 			Usage: "Generate a .pem file by concatanating the .key and .crt files together.",
 		},
+		cli.BoolFlag{
+			Name:  "dns-no-authoritative-precheck",
+			Usage: "Disable authoritative dns precheck before firing le challenge check.",
+		},
 	}
 
 	err = app.Run(os.Args)

--- a/cli_handlers.go
+++ b/cli_handlers.go
@@ -48,6 +48,10 @@ func setup(c *cli.Context) (*Configuration, *Account, *acme.Client) {
 		acme.RecursiveNameservers = resolvers
 	}
 
+	if c.GlobalBool("dns-no-authoritative-precheck") {
+		acme.DNSNoAuthoritCheck = true
+	}
+
 	err := checkFolder(c.GlobalString("path"))
 	if err != nil {
 		logger().Fatalf("Could not check/create path: %s", err.Error())


### PR DESCRIPTION
Hi guy,
Here at Blablacar, servers in charge of cert management can make http/https outgoing calls only though proxies (exaproxy), concerning DNS resolution, it only can speak udp with recursive internal dns, not with outside authoritative dns directly.
I think we are not alone to have such restrictions, in another hand, if my recursive DNS are up to date it means that they got refreshed by the fact authoritatives one are updated.
So I propose to make the authoritative checking optional.

Thx,
Tony.


