### PR TITLE
Allow to disable authz by url

### DIFF
--- a/acme/client.go
+++ b/acme/client.go
@@ -596,10 +596,18 @@ func logAuthz(authz []authorizationResource) {
 	}
 }
 
+func (c *Client) DisableAuthzForURL(authURL string) error {
+	var disabledAuth authorization
+	_, err := postJSON(c.jws, authURL, deactivateAuthMessage{Resource: "authz", Status: "deactivated"}, &disabledAuth)
+	return err
+}
+
 // cleanAuthz loops through the passed in slice and disables any auths which are not "valid"
 func (c *Client) disableAuthz(auth authorizationResource) error {
-	var disabledAuth authorization
-	_, err := postJSON(c.jws, auth.AuthURL, deactivateAuthMessage{Resource: "authz", Status: "deactivated"}, &disabledAuth)
+	err := c.DisableAuthzForURL(auth.AuthURL)
+	if err != nil {
+		logf("[INFO][%s] Failed to disable authorization %s: %v", auth.Domain, auth.AuthURL, err)
+	}
 	return err
 }
 

--- a/acme/client.go
+++ b/acme/client.go
@@ -599,6 +599,9 @@ func logAuthz(authz []authorizationResource) {
 func (c *Client) DisableAuthzForURL(authURL string) error {
 	var disabledAuth authorization
 	_, err := postJSON(c.jws, authURL, deactivateAuthMessage{Resource: "authz", Status: "deactivated"}, &disabledAuth)
+	if err != nil && strings.Contains(err.Error(), "only valid and pending authorizations can be deactivated") {
+		err = nil
+	}
 	return err
 }
 


### PR DESCRIPTION
After #400 is merged - this will allow to post-process and easily disable pending authorizations.
Fetching the authorization can be easily done without any keys/jws stuff - so it can be easily implemented outside of the library.