### PR TITLE
Support for DNS Provider: GoDaddy

### DIFF
--- a/providers/dns/dns_providers.go
+++ b/providers/dns/dns_providers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/xenolf/lego/providers/dns/dyn"
 	"github.com/xenolf/lego/providers/dns/exoscale"
 	"github.com/xenolf/lego/providers/dns/gandi"
+	"github.com/xenolf/lego/providers/dns/godaddy"
 	"github.com/xenolf/lego/providers/dns/googlecloud"
 	"github.com/xenolf/lego/providers/dns/linode"
 	"github.com/xenolf/lego/providers/dns/namecheap"
@@ -54,6 +55,8 @@ func NewDNSChallengeProviderByName(name string) (acme.ChallengeProvider, error) 
 		provider, err = gandi.NewDNSProvider()
 	case "gcloud":
 		provider, err = googlecloud.NewDNSProvider()
+	case "godaddy":
+		provider, err = godaddy.NewDNSProvider()
 	case "linode":
 		provider, err = linode.NewDNSProvider()
 	case "manual":

--- a/providers/dns/godaddy/godaddy.go
+++ b/providers/dns/godaddy/godaddy.go
@@ -1,0 +1,154 @@
+// Package godaddy implements a DNS provider for solving the DNS-01 challenge using godaddy DNS.
+package godaddy
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"bytes"
+	"encoding/json"
+	"github.com/xenolf/lego/acme"
+	"io/ioutil"
+	"strings"
+)
+
+// GoDaddyAPIURL represents the API endpoint to call.
+const apiURL = "https://api.godaddy.com"
+
+// DNSProvider is an implementation of the acme.ChallengeProvider interface
+type DNSProvider struct {
+	apiKey    string
+	apiSecret string
+}
+
+// NewDNSProvider returns a DNSProvider instance configured for godaddy.
+// Credentials must be passed in the environment variables: GODADDY_API_KEY
+// and GODADDY_API_SECRET.
+func NewDNSProvider() (*DNSProvider, error) {
+	apikey := os.Getenv("GODADDY_API_KEY")
+	secret := os.Getenv("GODADDY_API_SECRET")
+	return NewDNSProviderCredentials(apikey, secret)
+}
+
+// NewDNSProviderCredentials uses the supplied credentials to return a
+// DNSProvider instance configured for godaddy.
+func NewDNSProviderCredentials(apiKey, apiSecret string) (*DNSProvider, error) {
+	if apiKey == "" || apiSecret == "" {
+		return nil, fmt.Errorf("GoDaddy credentials missing")
+	}
+
+	return &DNSProvider{apiKey, apiSecret}, nil
+}
+
+// Timeout returns the timeout and interval to use when checking for DNS
+// propagation. Adjusting here to cope with spikes in propagation times.
+func (c *DNSProvider) Timeout() (timeout, interval time.Duration) {
+	return 120 * time.Second, 2 * time.Second
+}
+
+func (c *DNSProvider) extractRecordName(fqdn, domain string) string {
+	name := acme.UnFqdn(fqdn)
+	if idx := strings.Index(name, "."+domain); idx != -1 {
+		return name[:idx]
+	}
+	return name
+}
+
+// Present creates a TXT record to fulfil the dns-01 challenge
+func (c *DNSProvider) Present(domain, token, keyAuth string) error {
+	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
+	domainZone, err := c.getZone(fqdn)
+	if err != nil {
+		return err
+	}
+
+	if ttl < 600 {
+		ttl = 600
+	}
+
+	rec := DNSRecord{
+		Type: "TXT",
+		Name: c.extractRecordName(fqdn, domainZone),
+		Data: value,
+		Ttl:  ttl,
+	}
+
+	return c.updateRecord(rec, domainZone)
+}
+
+func (c *DNSProvider) updateRecord(record DNSRecord, domainZone string) error {
+	body, err := json.Marshal(record)
+	if err != nil {
+		return err
+	}
+
+	var resp *http.Response
+	resp, err = c.makeRequest("PUT", fmt.Sprintf("/v1/domains/%s/records/%s/%s", domainZone, record.Type, record.Name), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("Could not create record %v; Status: %v; Body: %s\n", string(body), resp.StatusCode, string(bodyBytes))
+	}
+	return nil
+}
+
+// CleanUp sets null value in the TXT DNS record as GoDaddy has no proper DELETE record method
+func (c *DNSProvider) CleanUp(domain, token, keyAuth string) error {
+	fqdn, _, ttl := acme.DNS01Record(domain, keyAuth)
+	domainZone, err := c.getZone(fqdn)
+	if err != nil {
+		return err
+	}
+
+	if ttl < 600 {
+		ttl = 600
+	}
+
+	rec := DNSRecord{
+		Type: "TXT",
+		Name: c.extractRecordName(fqdn, domainZone),
+		Data: "null",
+		Ttl:  ttl,
+	}
+
+	return c.updateRecord(rec, domainZone)
+}
+
+func (c *DNSProvider) getZone(fqdn string) (string, error) {
+	authZone, err := acme.FindZoneByFqdn(fqdn, acme.RecursiveNameservers)
+	if err != nil {
+		return "", err
+	}
+
+	return acme.UnFqdn(authZone), nil
+}
+
+func (c *DNSProvider) makeRequest(method, uri string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest(method, fmt.Sprintf("%s%s", apiURL, uri), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("sso-key %s:%s", c.apiKey, c.apiSecret))
+
+	client := http.Client{Timeout: 30 * time.Second}
+	return client.Do(req)
+}
+
+type DNSRecord struct {
+	Type     string `json:"type"`
+	Name     string `json:"name"`
+	Data     string `json:"data"`
+	Priority int    `json:"priority,omitempty"`
+	Ttl      int    `json:"ttl,omitempty"`
+}

--- a/providers/dns/godaddy/godaddy_test.go
+++ b/providers/dns/godaddy/godaddy_test.go
@@ -1,0 +1,60 @@
+package godaddy
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	godaddyAPIKey    string
+	godaddyAPISecret string
+	godaddyDomain    string
+	godaddyLiveTest  bool
+)
+
+func init() {
+	godaddyAPIKey = os.Getenv("GODADDY_API_KEY")
+	godaddyAPISecret = os.Getenv("GODADDY_API_SECRET")
+	godaddyDomain = os.Getenv("GODADDY_DOMAIN")
+
+	if len(godaddyAPIKey) > 0 && len(godaddyAPISecret) > 0 && len(godaddyDomain) > 0 {
+		godaddyLiveTest = true
+	}
+}
+
+func TestNewDNSProvider(t *testing.T) {
+	provider, err := NewDNSProvider()
+
+	if !godaddyLiveTest {
+		assert.Error(t, err)
+	} else {
+		assert.NotNil(t, provider)
+		assert.NoError(t, err)
+	}
+}
+
+func TestDNSProvider_Present(t *testing.T) {
+	if !godaddyLiveTest {
+		t.Skip("skipping live test")
+	}
+
+	provider, err := NewDNSProvider()
+	assert.NoError(t, err)
+
+	err = provider.Present(godaddyDomain, "", "123d==")
+	assert.NoError(t, err)
+}
+
+func TestDNSProvider_CleanUp(t *testing.T) {
+	if !godaddyLiveTest {
+		t.Skip("skipping live test")
+	}
+
+	provider, err := NewDNSProvider()
+	assert.NoError(t, err)
+
+	err = provider.CleanUp(godaddyDomain, "", "123d==")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
This PR adds support for the DNS Provider: GoDaddy

As the GoDaddy does not allow to safely delete records, the cleanup method will override the record data with "null" instead.