### PR TITLE
fix azure dns provider: added authorization to dns zones client

### DIFF
--- a/providers/dns/azure/azure.go
+++ b/providers/dns/azure/azure.go
@@ -125,11 +125,10 @@ func (c *DNSProvider) getHostedZoneID(fqdn string) (string, error) {
 	}
 
 	// Now we want to to Azure and get the zone.
-	dc := dns.NewZonesClient(c.subscriptionId)
-
-	rsc := dns.NewRecordSetsClient(c.subscriptionId)
 	spt, err := c.newServicePrincipalTokenFromCredentials(azure.PublicCloud.ResourceManagerEndpoint)
-	rsc.Authorizer = autorest.NewBearerAuthorizer(spt)
+
+	dc := dns.NewZonesClient(c.subscriptionId)
+	dc.Authorizer = autorest.NewBearerAuthorizer(spt)
 
 	zone, err := dc.Get(c.resourceGroup, acme.UnFqdn(authZone))
 


### PR DESCRIPTION
Azure DNS provider was failing because the authorization header was not provided when getting the zone information. 
- Removed the recordset client 
- Added BearerAuthorizer to the ZonesClient