### PR TITLE
Users of an effective top-level domain can use the DNS challenge

### DIFF
--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
-	"golang.org/x/net/publicsuffix"
 )
 
 type preCheckDNSFunc func(fqdn, value string) (bool, error)
@@ -242,10 +241,6 @@ func FindZoneByFqdn(fqdn string, nameservers []string) (string, error) {
 	labelIndexes := dns.Split(fqdn)
 	for _, index := range labelIndexes {
 		domain := fqdn[index:]
-		// Give up if we have reached the TLD
-		if isTLD(domain) {
-			break
-		}
 
 		in, err := dnsQuery(domain, dns.TypeSOA, nameservers, true)
 		if err != nil {
@@ -271,14 +266,6 @@ func FindZoneByFqdn(fqdn string, nameservers []string) (string, error) {
 	}
 
 	return "", fmt.Errorf("Could not find the start of authority")
-}
-
-func isTLD(domain string) bool {
-	publicsuffix, _ := publicsuffix.PublicSuffix(UnFqdn(domain))
-	if publicsuffix == UnFqdn(domain) {
-		return true
-	}
-	return false
 }
 
 // ClearFqdnCache clears the cache of fqdn to zone mappings. Primarily used in testing.

--- a/acme/dns_challenge_test.go
+++ b/acme/dns_challenge_test.go
@@ -37,14 +37,6 @@ var lookupNameserversTestsErr = []struct {
 	{"_null.n0n0.",
 		"Could not determine the zone",
 	},
-	// invalid domain
-	{"_null.com.",
-		"Could not determine the zone",
-	},
-	// invalid domain
-	{"in-valid.co.uk.",
-		"Could not determine the zone",
-	},
 }
 
 var findZoneByFqdnTests = []struct {
@@ -53,6 +45,7 @@ var findZoneByFqdnTests = []struct {
 }{
 	{"mail.google.com.", "google.com."}, // domain is a CNAME
 	{"foo.google.com.", "google.com."},  // domain is a non-existent subdomain
+	{"example.com.ac.", "ac."},          // domain is a eTLD
 }
 
 var checkAuthoritativeNssTests = []struct {


### PR DESCRIPTION
They will not get anymore an error message saying
"Could not find the start of authority".

Finding the zone cut of a FQDN now only rely on the presence
of a SOA record. Indeed, in the context of an eTLD the
authority will be the eTLD itself so you need to continue
to recurse until you get an answer instead of cutting the search
when you find the public suffix of a domain.

Fixes #434