### PR TITLE
Fix zone detection for cross-zone cnames

### DIFF
--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -258,14 +258,7 @@ func FindZoneByFqdn(fqdn string, nameservers []string) (string, error) {
 
 			// CNAME records cannot/should not exist at the root of a zone.
 			// So we skip a domain when a CNAME is found.
-			hasCNAME := false
-			for _, ans := range in.Answer {
-				if _, ok := ans.(*dns.CNAME); ok {
-					hasCNAME = true
-					break
-				}
-			}
-			if hasCNAME {
+			if dnsMsgContainsCNAME(in) {
 				continue
 			}
 
@@ -280,6 +273,16 @@ func FindZoneByFqdn(fqdn string, nameservers []string) (string, error) {
 	}
 
 	return "", fmt.Errorf("Could not find the start of authority")
+}
+
+// dnsMsgContainsCNAME checks for a CNAME answer in msg
+func dnsMsgContainsCNAME(msg *dns.Msg) bool {
+	for _, ans := range msg.Answer {
+		if _, ok := ans.(*dns.CNAME); ok {
+			return true
+		}
+	}
+	return false
 }
 
 // ClearFqdnCache clears the cache of fqdn to zone mappings. Primarily used in testing.

--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -255,6 +255,20 @@ func FindZoneByFqdn(fqdn string, nameservers []string) (string, error) {
 
 		// Check if we got a SOA RR in the answer section
 		if in.Rcode == dns.RcodeSuccess {
+
+			// CNAME records cannot/should not exist at the root of a zone.
+			// So we skip a domain when a CNAME is found.
+			hasCNAME := false
+			for _, ans := range in.Answer {
+				if _, ok := ans.(*dns.CNAME); ok {
+					hasCNAME = true
+					break
+				}
+			}
+			if hasCNAME {
+				continue
+			}
+
 			for _, ans := range in.Answer {
 				if soa, ok := ans.(*dns.SOA); ok {
 					zone := soa.Hdr.Name

--- a/acme/dns_challenge_test.go
+++ b/acme/dns_challenge_test.go
@@ -43,9 +43,10 @@ var findZoneByFqdnTests = []struct {
 	fqdn string
 	zone string
 }{
-	{"mail.google.com.", "google.com."}, // domain is a CNAME
-	{"foo.google.com.", "google.com."},  // domain is a non-existent subdomain
-	{"example.com.ac.", "ac."},          // domain is a eTLD
+	{"mail.google.com.", "google.com."},             // domain is a CNAME
+	{"foo.google.com.", "google.com."},              // domain is a non-existent subdomain
+	{"example.com.ac.", "ac."},                      // domain is a eTLD
+	{"cross-zone-example.assets.sh.", "assets.sh."}, // domain is a cross-zone CNAME
 }
 
 var checkAuthoritativeNssTests = []struct {


### PR DESCRIPTION
CNAMEs cannot co-exist with SOA records so responses with
a CNAME should be skipped.

The `cross-zone-example.assets.sh.` is currently hosted by
me (@fd) and will continue to exist for as long as the assets.sh
domain exists. (The assets.sh domain is used as a CDN and is unlikely
to go away.)

See #330