### PR TITLE
cli: Correct help text for --dns-resolvers default

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -172,7 +172,7 @@ func main() {
 		},
 		cli.StringSliceFlag{
 			Name:  "dns-resolvers",
-			Usage: "Set the resolvers to use for performing recursive DNS queries. Supported: host:port. The default is to use Google's DNS resolvers.",
+			Usage: "Set the resolvers to use for performing recursive DNS queries. Supported: host:port. The default is to use the system resolvers, or Google's DNS resolvers if the system's cannot be determined.",
 		},
 		cli.BoolFlag{
 			Name:  "pem",


### PR DESCRIPTION
`getNameservers` in `dns_challenge.go` attempts to determine the system resolvers from `/etc/resolv.conf` before using the Google DNS servers. Correct the help text to reflect this.

I discovered this as part of investigating #461 (which turns out not to be a valid bug).