### PR TITLE
Add `/directory` to example `NewClient` caDirURL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ myUser := MyUser{
 
 // A client facilitates communication with the CA server. This CA URL is
 // configured for a local dev instance of Boulder running in Docker in a VM.
-client, err := acme.NewClient("http://192.168.99.100:4000", &myUser, acme.RSA2048)
+client, err := acme.NewClient("http://192.168.99.100:4000/directory", &myUser, acme.RSA2048)
 if err != nil {
   log.Fatal(err)
 }


### PR DESCRIPTION
The `acme.NewClient` function's `caDirURL` argument is expected to be
the full path to the ACME server's directory endpoint. In the README
example of using Lego programmatically against a Boulder instance only
the hostname & port are provided but not the directory path:

   `"http://192.168.99.100:4000"`

This produces an error like:

```
2018/01/15 14:34:06 get directory at 'http://192.168.99.100:4000': invalid
character '<' looking for beginning of value
```

when used verbatim with a Boulder container since the `/directory` path
is missing and the "What is an ACME server" HTML index page is 
returned instead of the JSON directory contents.

This commit updates the example to use:

 `"http://192.168.99.100:4000/directory"`

Which allows the example code to work with Boulder as-intended.