### PR TITLE
Initial implementation of `--dns-propagation-time`.

### DIFF
--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -31,6 +31,9 @@ var defaultNameservers = []string{
 
 var RecursiveNameservers = getNameservers(defaultResolvConf, defaultNameservers)
 
+// DNSPropagationTimeout is used to override the DNS propagation timeout.
+var DNSPropagationTimeout time.Duration
+
 // DNSTimeout is used to override the default DNS timeout of 10 seconds.
 var DNSTimeout = 10 * time.Second
 
@@ -105,6 +108,9 @@ func (s *dnsChallenge) Solve(chlng challenge, domain string) error {
 		timeout, interval = provider.Timeout()
 	default:
 		timeout, interval = 60*time.Second, 2*time.Second
+	}
+	if DNSPropagationTimeout > 0 {
+		timeout = DNSPropagationTimeout
 	}
 
 	err = WaitFor(timeout, interval, func() (bool, error) {

--- a/cli.go
+++ b/cli.go
@@ -167,6 +167,10 @@ func main() {
 			Usage: "Set the HTTP timeout value to a specific value in seconds. The default is 10 seconds.",
 		},
 		cli.IntFlag{
+			Name:  "dns-propagation-timeout",
+			Usage: "Set the DNS propagation timeout value to a specific value in seconds. The default is provider-dependent.",
+		},
+		cli.IntFlag{
 			Name:  "dns-timeout",
 			Usage: "Set the DNS timeout value to a specific value in seconds. The default is 10 seconds.",
 		},

--- a/cli_handlers.go
+++ b/cli_handlers.go
@@ -33,6 +33,10 @@ func setup(c *cli.Context) (*Configuration, *Account, *acme.Client) {
 		acme.HTTPClient = http.Client{Timeout: time.Duration(c.GlobalInt("http-timeout")) * time.Second}
 	}
 
+	if c.GlobalIsSet("dns-propagation-timeout") {
+		acme.DNSPropagationTimeout = time.Duration(c.GlobalInt("dns-propagation-timeout")) * time.Second
+	}
+
 	if c.GlobalIsSet("dns-timeout") {
 		acme.DNSTimeout = time.Duration(c.GlobalInt("dns-timeout")) * time.Second
 	}


### PR DESCRIPTION
#474: this is an initial (WIP) implementation of allowing users to override DNS propagation time with a `--dns-propagation-time` command-line argument.