### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
-FROM alpine:3.6
+FROM golang:alpine3.7 as builder
 
-ENV GOPATH /go
-ENV LEGO_VERSION tags/v0.4.1
+ARG LEGO_VERSION=master
 
-RUN apk update && apk add --no-cache --virtual run-dependencies ca-certificates && \
-    apk add --no-cache --virtual build-dependencies go git musl-dev && \
+RUN apk update && \
+    apk add --no-cache --virtual git && \
     go get -u github.com/xenolf/lego && \
     cd ${GOPATH}/src/github.com/xenolf/lego && \
     git checkout ${LEGO_VERSION} && \
-    go build -o /usr/bin/lego . && \
-    apk del build-dependencies && \
-    rm -rf ${GOPATH}
+    go build -o /usr/bin/lego .
+
+FROM alpine:3.7
+RUN apk update && apk add --no-cache --virtual ca-certificates
+COPY --from=builder /usr/bin/lego /usr/bin/lego
 
 ENTRYPOINT [ "/usr/bin/lego" ]

--- a/README.md
+++ b/README.md
@@ -25,9 +25,10 @@ To build lego inside a Docker container, just run
 docker build -t lego .
 ```
 
-The container is, by default, built from `master`. This can be overriden by supplying a build argument containing a git SHA or reference.
-```
-docker build --build-arg LEGO_VERSION=tags/v0.4.1 -t lego .
+The container is, by default, built from `master`. 
+This can be overridden by supplying a build argument containing a git SHA or reference.
+```bash
+docker build --build-arg LEGO_VERSION=tags/v0.5.0 -t lego .
 ```
 
 ##### From the package manager

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ To build lego inside a Docker container, just run
 ```
 docker build -t lego .
 ```
+
+The container is, by default, built from `master`. This can be overriden by supplying a build argument containing a git SHA or reference.
+```
+docker build --build-arg LEGO_VERSION=tags/v0.4.1 -t lego .
+```
+
 ##### From the package manager
 - [ArchLinux (AUR)](https://aur.archlinux.org/packages/lego-git):
 ```


### PR DESCRIPTION
The Docker container cannot currently be built because of exoscale dependency updates, which were fixed in #468.

This updates the Dockerfile to use multi-stage builds and enables a build argument to specify which version or SHA is built.