### PR TITLE
providers/azure: Refactor to work with new Azure SDK version.

### DIFF
--- a/providers/dns/azure/azure.go
+++ b/providers/dns/azure/azure.go
@@ -4,11 +4,12 @@
 package azure
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
 
-	"github.com/Azure/azure-sdk-for-go/arm/dns"
+	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2017-09-01/dns"
 
 	"strings"
 
@@ -26,6 +27,8 @@ type DNSProvider struct {
 	subscriptionId string
 	tenantId       string
 	resourceGroup  string
+
+	context        context.Context
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for azure.
@@ -53,6 +56,8 @@ func NewDNSProviderCredentials(clientId, clientSecret, subscriptionId, tenantId,
 		subscriptionId: subscriptionId,
 		tenantId:       tenantId,
 		resourceGroup:  resourceGroup,
+		// TODO: A timeout can be added here for cancellation purposes.
+		context:        context.Background(),
 	}, nil
 }
 
@@ -82,7 +87,7 @@ func (c *DNSProvider) Present(domain, token, keyAuth string) error {
 			TxtRecords: &[]dns.TxtRecord{dns.TxtRecord{Value: &[]string{value}}},
 		},
 	}
-	_, err = rsc.CreateOrUpdate(c.resourceGroup, zone, relative, dns.TXT, rec, "", "")
+	_, err = rsc.CreateOrUpdate(c.context, c.resourceGroup, zone, relative, dns.TXT, rec, "", "")
 
 	if err != nil {
 		return err
@@ -109,7 +114,7 @@ func (c *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	rsc := dns.NewRecordSetsClient(c.subscriptionId)
 	spt, err := c.newServicePrincipalTokenFromCredentials(azure.PublicCloud.ResourceManagerEndpoint)
 	rsc.Authorizer = autorest.NewBearerAuthorizer(spt)
-	_, err = rsc.Delete(c.resourceGroup, zone, relative, dns.TXT, "")
+	_, err = rsc.Delete(c.context, c.resourceGroup, zone, relative, dns.TXT, "")
 	if err != nil {
 		return err
 	}
@@ -130,7 +135,7 @@ func (c *DNSProvider) getHostedZoneID(fqdn string) (string, error) {
 	dc := dns.NewZonesClient(c.subscriptionId)
 	dc.Authorizer = autorest.NewBearerAuthorizer(spt)
 
-	zone, err := dc.Get(c.resourceGroup, acme.UnFqdn(authZone))
+	zone, err := dc.Get(c.context, c.resourceGroup, acme.UnFqdn(authZone))
 
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Needs testing.
Attempts to fix https://github.com/xenolf/lego/issues/489

`go get` will not work on this repository until this PR is merged.
If you want to test it on my fork, you have to do some manual commands before `go get` in order to get the imports to work correctly. This works for me:

```
mkdir -p $GOPATH/src/github.com/xenolf && \
cd $GOPATH/src/github.com/xenolf && \
    git clone https://github.com/jammm/lego && \
    cd lego && \
    go get ./
```