### PR TITLE
cname dns challenge

### DIFF
--- a/providers/dns/dns_providers.go
+++ b/providers/dns/dns_providers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/xenolf/lego/acme"
 	"github.com/xenolf/lego/providers/dns/auroradns"
 	"github.com/xenolf/lego/providers/dns/azure"
+	"github.com/xenolf/lego/providers/dns/bind"
 	"github.com/xenolf/lego/providers/dns/cloudflare"
 	"github.com/xenolf/lego/providers/dns/cloudxns"
 	"github.com/xenolf/lego/providers/dns/digitalocean"
@@ -88,6 +89,8 @@ func NewDNSChallengeProviderByName(name string) (acme.ChallengeProvider, error) 
 		provider, err = ns1.NewDNSProvider()
 	case "otc":
 		provider, err = otc.NewDNSProvider()
+	case "bind":
+		provider, err = bind.NewDNSProvider()
 	default:
 		err = fmt.Errorf("Unrecognised DNS provider: %s", name)
 	}


### PR DESCRIPTION
This patch looks up cname records instead of only a records for _acme-challenge. If no cname is found, or an error is encountered when looking up cname, it will continue to use the same codepath as before. The lookup happens before the challenge is completed and will use the same verificiation code path, except that, if the cname lookup succeeds, it will update the nameserver serving the domain where the cname points to.
Example:
zonefile "singingcat.net":
www                            IN A     46.16.75.24
_acme-challenge.www            IN CNAME     acme6.acme.conradwood.net.

I dynamically update the domain "acme.conradwood.net" to complete the challenge and NOT singingcat.net.