### PR TITLE
Digital Ocean: use TTL when creating DNS entry

### DIFF
--- a/providers/dns/digitalocean/digitalocean.go
+++ b/providers/dns/digitalocean/digitalocean.go
@@ -49,6 +49,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		RecordType string `json:"type"`
 		Name       string `json:"name"`
 		Data       string `json:"data"`
+		Ttl        int    `json:"ttl"`
 	}
 
 	// txtRecordResponse represents a response from DO's API after making a TXT record
@@ -61,7 +62,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		} `json:"domain_record"`
 	}
 
-	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
+	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
 
 	authZone, err := acme.FindZoneByFqdn(acme.ToFqdn(domain), acme.RecursiveNameservers)
 	if err != nil {
@@ -71,7 +72,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	authZone = acme.UnFqdn(authZone)
 
 	reqURL := fmt.Sprintf("%s/v2/domains/%s/records", digitalOceanBaseURL, authZone)
-	reqData := txtRecordRequest{RecordType: "TXT", Name: fqdn, Data: value}
+	reqData := txtRecordRequest{RecordType: "TXT", Name: fqdn, Data: value, Ttl: ttl}
 	body, err := json.Marshal(reqData)
 	if err != nil {
 		return err

--- a/providers/dns/digitalocean/digitalocean_test.go
+++ b/providers/dns/digitalocean/digitalocean_test.go
@@ -33,7 +33,7 @@ func TestDigitalOceanPresent(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Error reading request body: %v", err)
 		}
-		if got, want := string(reqBody), `{"type":"TXT","name":"_acme-challenge.example.com.","data":"w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI"}`; got != want {
+		if got, want := string(reqBody), `{"type":"TXT","name":"_acme-challenge.example.com.","data":"w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI","ttl":120}`; got != want {
 			t.Errorf("Expected body data to be: `%s` but got `%s`", want, got)
 		}
 


### PR DESCRIPTION
hi,

when creating a DNS entry with the digitalocean API the default TTL used by digitalocean will be 1800secs. Although letsencrypt will use a shorter TTL when query'ing the enttry it is longer than the default value of 120secs.

This PR appends a TTL to the digitalocean API when creating the TXT record.

