### PR TITLE
Use NewSessionWithOptions instead of deprecated New. Fixes #458.

### DIFF
--- a/providers/dns/route53/route53.go
+++ b/providers/dns/route53/route53.go
@@ -70,7 +70,11 @@ func NewDNSProvider() (*DNSProvider, error) {
 	r := customRetryer{}
 	r.NumMaxRetries = maxRetries
 	config := request.WithRetryer(aws.NewConfig(), r)
-	client := route53.New(session.New(config))
+	session, err := session.NewSessionWithOptions(session.Options{Config: *config})
+	if err != nil {
+		return nil, err
+	}
+	client := route53.New(session)
 
 	return &DNSProvider{
 		client:       client,


### PR DESCRIPTION
Hi,

After encountering #458 in the context of https://github.com/vancluever/terraform-provider-acme, I've traced the cause back to the use of the deprecated session.New in route53. Using NewSessionWithOptions instead fixes the problem. (You still need to set AWS_SDK_LOAD_CONFIG=1, AWS_REGION and AWS_PROFILE, if applicable).

Cheers,
Johannes