### PR TITLE
Add DNS Provider for NIFCLOUD DNS

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -217,6 +217,7 @@ Here is an example bash command using the CloudFlare DNS provider:
 	fmt.Fprintln(w, "\tmanual:\tnone")
 	fmt.Fprintln(w, "\tnamecheap:\tNAMECHEAP_API_USER, NAMECHEAP_API_KEY")
 	fmt.Fprintln(w, "\tnamedotcom:\tNAMECOM_USERNAME, NAMECOM_API_TOKEN")
+	fmt.Fprintln(w, "\tnifcloud:\tNIFCLOUD_ACCESS_KEY_ID, NIFCLOUD_SECRET_ACCESS_KEY")
 	fmt.Fprintln(w, "\trackspace:\tRACKSPACE_USER, RACKSPACE_API_KEY")
 	fmt.Fprintln(w, "\trfc2136:\tRFC2136_TSIG_KEY, RFC2136_TSIG_SECRET,\n\t\tRFC2136_TSIG_ALGORITHM, RFC2136_NAMESERVER")
 	fmt.Fprintln(w, "\troute53:\tAWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION, AWS_HOSTED_ZONE_ID")

--- a/providers/dns/dns_providers.go
+++ b/providers/dns/dns_providers.go
@@ -27,6 +27,7 @@ import (
 	"github.com/xenolf/lego/providers/dns/linode"
 	"github.com/xenolf/lego/providers/dns/namecheap"
 	"github.com/xenolf/lego/providers/dns/namedotcom"
+	"github.com/xenolf/lego/providers/dns/nifcloud"
 	"github.com/xenolf/lego/providers/dns/ns1"
 	"github.com/xenolf/lego/providers/dns/otc"
 	"github.com/xenolf/lego/providers/dns/ovh"
@@ -88,6 +89,8 @@ func NewDNSChallengeProviderByName(name string) (acme.ChallengeProvider, error) 
 		return namecheap.NewDNSProvider()
 	case "namedotcom":
 		return namedotcom.NewDNSProvider()
+	case "nifcloud":
+		return nifcloud.NewDNSProvider()
 	case "rackspace":
 		return rackspace.NewDNSProvider()
 	case "route53":

--- a/providers/dns/nifcloud/client.go
+++ b/providers/dns/nifcloud/client.go
@@ -1,0 +1,209 @@
+// Package nifcloud implements a DNS provider for solving the DNS-01 challenge
+// using NIFCLOUD DNS.
+package nifcloud
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	defaultEndpoint = "https://dns.api.cloud.nifty.com"
+	apiVersion      = "2012-12-12N2013-12-16"
+	xmlns           = "https://route53.amazonaws.com/doc/2012-12-12/"
+)
+
+// ChangeResourceRecordSetsRequest is a complex type that contains change information for the resource record set.
+type ChangeResourceRecordSetsRequest struct {
+	Xmlns       string      `xml:"xmlns,attr"`
+	ChangeBatch ChangeBatch `xml:"ChangeBatch"`
+}
+
+// ChangeResourceRecordSetsResponse is a complex type containing the response for the request.
+type ChangeResourceRecordSetsResponse struct {
+	ChangeInfo ChangeInfo `xml:"ChangeInfo"`
+}
+
+// GetChangeResponse is a complex type that contains the ChangeInfo element.
+type GetChangeResponse struct {
+	ChangeInfo ChangeInfo `xml:"ChangeInfo"`
+}
+
+// ErrorResponse is the information for any errors.
+type ErrorResponse struct {
+	Error struct {
+		Type    string `xml:"Type"`
+		Message string `xml:"Message"`
+		Code    string `xml:"Code"`
+	} `xml:"Error"`
+	RequestID string `xml:"RequestId"`
+}
+
+// ChangeBatch is the information for a change request.
+type ChangeBatch struct {
+	Changes Changes `xml:"Changes"`
+	Comment string  `xml:"Comment"`
+}
+
+// Changes is array of Change.
+type Changes struct {
+	Change []Change `xml:"Change"`
+}
+
+// Change is the information for each resource record set that you want to change.
+type Change struct {
+	Action            string            `xml:"Action"`
+	ResourceRecordSet ResourceRecordSet `xml:"ResourceRecordSet"`
+}
+
+// ResourceRecordSet is the information about the resource record set to create or delete.
+type ResourceRecordSet struct {
+	Name            string          `xml:"Name"`
+	Type            string          `xml:"Type"`
+	TTL             int             `xml:"TTL"`
+	ResourceRecords ResourceRecords `xml:"ResourceRecords"`
+}
+
+// ResourceRecords is array of ResourceRecord.
+type ResourceRecords struct {
+	ResourceRecord []ResourceRecord `xml:"ResourceRecord"`
+}
+
+// ResourceRecord is the information specific to the resource record.
+type ResourceRecord struct {
+	Value string `xml:"Value"`
+}
+
+// ChangeInfo is A complex type that describes change information about changes made to your hosted zone.
+type ChangeInfo struct {
+	ID          string `xml:"Id"`
+	Status      string `xml:"Status"`
+	SubmittedAt string `xml:"SubmittedAt"`
+}
+
+// Client client of NIFCLOUD DNS
+type Client struct {
+	accessKey string
+	secretKey string
+	endpoint  string
+}
+
+// ChangeResourceRecordSets Call ChangeResourceRecordSets API and return response.
+func (c *Client) ChangeResourceRecordSets(hostedZoneID string, input ChangeResourceRecordSetsRequest) (*ChangeResourceRecordSetsResponse, error) {
+	requestURL := fmt.Sprintf("%s/%s/hostedzone/%s/rrset", c.endpoint, apiVersion, hostedZoneID)
+
+	body := &bytes.Buffer{}
+	body.Write([]byte(xml.Header))
+	err := xml.NewEncoder(body).Encode(input)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, requestURL, body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", "text/xml; charset=utf-8")
+
+	err = c.sign(req)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		errResp := &ErrorResponse{}
+		err = xml.NewDecoder(res.Body).Decode(errResp)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf(errResp.Error.Message)
+	}
+
+	output := &ChangeResourceRecordSetsResponse{}
+	err = xml.NewDecoder(res.Body).Decode(output)
+	if err != nil {
+		return nil, err
+	}
+	return output, err
+}
+
+// GetChange Call GetChange API and return response.
+func (c *Client) GetChange(statusID string) (*GetChangeResponse, error) {
+	requestURL := fmt.Sprintf("%s/%s/change/%s", c.endpoint, apiVersion, statusID)
+
+	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	err = c.sign(req)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		errResp := &ErrorResponse{}
+		err = xml.NewDecoder(res.Body).Decode(errResp)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf(errResp.Error.Message)
+	}
+
+	output := &GetChangeResponse{}
+	err = xml.NewDecoder(res.Body).Decode(output)
+	if err != nil {
+		return nil, err
+	}
+	return output, nil
+}
+
+func (c *Client) sign(req *http.Request) error {
+	location, err := time.LoadLocation("GMT")
+	if err != nil {
+		return err
+	}
+
+	ts := time.Now().In(location).Format(time.RFC1123)
+
+	if req.Header.Get("Date") == "" {
+		req.Header.Set("Date", ts)
+	}
+
+	if req.URL.Path == "" {
+		req.URL.Path += "/"
+	}
+
+	mac := hmac.New(sha1.New, []byte(c.secretKey))
+	_, err = mac.Write([]byte(req.Header.Get("Date")))
+	if err != nil {
+		return err
+	}
+
+	hashed := mac.Sum(nil)
+	signature := base64.StdEncoding.EncodeToString(hashed)
+
+	req.Header.Set("X-Nifty-Authorization", "NIFTY3-HTTPS NiftyAccessKeyId="+c.accessKey+",Algorithm=HmacSHA1,Signature="+signature)
+	return err
+}

--- a/providers/dns/nifcloud/client_test.go
+++ b/providers/dns/nifcloud/client_test.go
@@ -1,0 +1,89 @@
+package nifcloud
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runTestServer(responseBody string, statusCode int) *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(statusCode)
+		fmt.Fprintln(w, responseBody)
+	}))
+	return server
+}
+
+func TestChangeResourceRecordSets(t *testing.T) {
+	responseBody := `<?xml version="1.0" encoding="UTF-8"?>
+<ChangeResourceRecordSetsResponse xmlns="https://route53.amazonaws.com/doc/2012-12-12/">
+  <ChangeInfo>
+    <Id>xxxxx</Id>
+    <Status>INSYNC</Status>
+    <SubmittedAt>2015-08-05T00:00:00.000Z</SubmittedAt>
+  </ChangeInfo>
+</ChangeResourceRecordSetsResponse>
+`
+	server := runTestServer(responseBody, http.StatusOK)
+	defer server.Close()
+
+	client := &Client{
+		endpoint: server.URL,
+	}
+
+	res, err := client.ChangeResourceRecordSets("example.com", ChangeResourceRecordSetsRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, "xxxxx", res.ChangeInfo.ID)
+	assert.Equal(t, "INSYNC", res.ChangeInfo.Status)
+	assert.Equal(t, "2015-08-05T00:00:00.000Z", res.ChangeInfo.SubmittedAt)
+}
+
+func TestGetChange(t *testing.T) {
+	responseBody := `<?xml version="1.0" encoding="UTF-8"?>
+<GetChangeResponse xmlns="https://route53.amazonaws.com/doc/2012-12-12/">
+  <ChangeInfo>
+    <Id>xxxxx</Id>
+    <Status>INSYNC</Status>
+    <SubmittedAt>2015-08-05T00:00:00.000Z</SubmittedAt>
+  </ChangeInfo>
+</GetChangeResponse>
+`
+	server := runTestServer(responseBody, http.StatusOK)
+	defer server.Close()
+
+	client := &Client{
+		endpoint: server.URL,
+	}
+
+	res, err := client.GetChange("12345")
+	require.NoError(t, err)
+	assert.Equal(t, "xxxxx", res.ChangeInfo.ID)
+	assert.Equal(t, "INSYNC", res.ChangeInfo.Status)
+	assert.Equal(t, "2015-08-05T00:00:00.000Z", res.ChangeInfo.SubmittedAt)
+}
+
+func TestErrorCase(t *testing.T) {
+	responseBody := `<?xml version="1.0" encoding="UTF-8"?>
+<ErrorResponse>
+  <Error>
+    <Type>Sender</Type>
+    <Code>AuthFailed</Code>
+    <Message>The request signature we calculated does not match the signature you provided.</Message>
+  </Error>
+</ErrorResponse>
+`
+	server := runTestServer(responseBody, http.StatusUnauthorized)
+	defer server.Close()
+
+	client := &Client{
+		endpoint: server.URL,
+	}
+
+	res, err := client.GetChange("12345")
+	assert.Nil(t, res)
+	assert.Equal(t, "The request signature we calculated does not match the signature you provided.", err.Error())
+}

--- a/providers/dns/nifcloud/nifcloud.go
+++ b/providers/dns/nifcloud/nifcloud.go
@@ -1,0 +1,104 @@
+// Package nifcloud implements a DNS provider for solving the DNS-01 challenge
+// using NIFCLOUD DNS.
+package nifcloud
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/xenolf/lego/acme"
+	"github.com/xenolf/lego/platform/config/env"
+)
+
+// DNSProvider implements the acme.ChallengeProvider interface
+type DNSProvider struct {
+	client *Client
+}
+
+// NewDNSProvider returns a DNSProvider instance configured for the NIFCLOUD DNS service.
+// Credentials must be passed in the environment variables: NIFCLOUD_ACCESS_KEY_ID and NIFCLOUD_SECRET_ACCESS_KEY.
+func NewDNSProvider() (*DNSProvider, error) {
+	values, err := env.Get("NIFCLOUD_ACCESS_KEY_ID", "NIFCLOUD_SECRET_ACCESS_KEY")
+	if err != nil {
+		return nil, fmt.Errorf("NIFCLOUD: %v", err)
+	}
+
+	endpoint := os.Getenv("NIFCLOUD_DNS_ENDPOINT")
+	if endpoint == "" {
+		endpoint = defaultEndpoint
+	}
+
+	return NewDNSProviderCredentials(endpoint, values["NIFCLOUD_ACCESS_KEY_ID"], values["NIFCLOUD_SECRET_ACCESS_KEY"])
+}
+
+// NewDNSProviderCredentials uses the supplied credentials to return a
+// DNSProvider instance configured for NIFCLOUD.
+func NewDNSProviderCredentials(endpoint, accessKey, secretKey string) (*DNSProvider, error) {
+	client := &Client{
+		accessKey: accessKey,
+		secretKey: secretKey,
+		endpoint:  endpoint,
+	}
+
+	return &DNSProvider{
+		client: client,
+	}, nil
+}
+
+// Present creates a TXT record using the specified parameters
+func (r *DNSProvider) Present(domain, token, keyAuth string) error {
+	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
+	return r.changeRecord("CREATE", fqdn, value, domain, ttl)
+}
+
+// CleanUp removes the TXT record matching the specified parameters
+func (r *DNSProvider) CleanUp(domain, token, keyAuth string) error {
+	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
+	return r.changeRecord("DELETE", fqdn, value, domain, ttl)
+}
+
+func (r *DNSProvider) changeRecord(action, fqdn, value, domain string, ttl int) error {
+	name := acme.UnFqdn(fqdn)
+
+	reqParams := ChangeResourceRecordSetsRequest{
+		Xmlns: xmlns,
+		ChangeBatch: ChangeBatch{
+			Comment: "Managed by Lego",
+			Changes: Changes{
+				Change: []Change{
+					{
+						Action: action,
+						ResourceRecordSet: ResourceRecordSet{
+							Name: name,
+							Type: "TXT",
+							TTL:  ttl,
+							ResourceRecords: ResourceRecords{
+								ResourceRecord: []ResourceRecord{
+									{
+										Value: value,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := r.client.ChangeResourceRecordSets(domain, reqParams)
+	if err != nil {
+		return fmt.Errorf("failed to change NIFCLOUD record set: %v", err)
+	}
+
+	statusID := resp.ChangeInfo.ID
+
+	return acme.WaitFor(120*time.Second, 4*time.Second, func() (bool, error) {
+		resp, err := r.client.GetChange(statusID)
+		if err != nil {
+			return false, fmt.Errorf("failed to query NIFCLOUD DNS change status: %v", err)
+		}
+		return resp.ChangeInfo.Status == "INSYNC", nil
+	})
+}

--- a/providers/dns/nifcloud/nifcloud_test.go
+++ b/providers/dns/nifcloud/nifcloud_test.go
@@ -1,0 +1,52 @@
+package nifcloud
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	nifcloudLiveTest  bool
+	nifcloudAccessKey string
+	nifcloudSecretKey string
+	nifcloudDomain    string
+)
+
+func init() {
+	nifcloudAccessKey = os.Getenv("NIFCLOUD_ACCESS_KEY_ID")
+	nifcloudSecretKey = os.Getenv("NIFCLOUD_SECRET_ACCESS_KEY")
+	nifcloudDomain = os.Getenv("NIFCLOUD_DOMAIN")
+
+	if len(nifcloudAccessKey) > 0 && len(nifcloudSecretKey) > 0 && len(nifcloudDomain) > 0 {
+		nifcloudLiveTest = true
+	}
+}
+
+func TestLivenifcloudPresent(t *testing.T) {
+	if !nifcloudLiveTest {
+		t.Skip("skipping live test")
+	}
+
+	provider, err := NewDNSProvider()
+	assert.NoError(t, err)
+
+	err = provider.Present(nifcloudDomain, "", "123d==")
+	assert.NoError(t, err)
+}
+
+func TestLivenifcloudCleanUp(t *testing.T) {
+	if !nifcloudLiveTest {
+		t.Skip("skipping live test")
+	}
+
+	time.Sleep(time.Second * 1)
+
+	provider, err := NewDNSProvider()
+	assert.NoError(t, err)
+
+	err = provider.CleanUp(nifcloudDomain, "", "123d==")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
###  SUMMARY

This PR adds [NIFCLOUD](https://cloud.nifty.com/service/dns.htm) as a provider for the DNS challenge.

Please review and merge it!

(NIFCLOUD is one of the most famous IaaS in Japan)