### PR TITLE
Adding output of which envvars are missing in Cloudflare and Azure

### DIFF
--- a/providers/dns/azure/azure.go
+++ b/providers/dns/azure/azure.go
@@ -28,7 +28,7 @@ type DNSProvider struct {
 	tenantId       string
 	resourceGroup  string
 
-	context        context.Context
+	context context.Context
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for azure.
@@ -47,7 +47,13 @@ func NewDNSProvider() (*DNSProvider, error) {
 // DNSProvider instance configured for azure.
 func NewDNSProviderCredentials(clientId, clientSecret, subscriptionId, tenantId, resourceGroup string) (*DNSProvider, error) {
 	if clientId == "" || clientSecret == "" || subscriptionId == "" || tenantId == "" || resourceGroup == "" {
-		return nil, fmt.Errorf("Azure configuration missing")
+		missingEnvVars := []string{}
+		for _, envVar := range []string{"AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET", "AZURE_SUBSCRIPTION_ID", "AZURE_TENANT_ID", "AZURE_RESOURCE_GROUP"} {
+			if os.Getenv(envVar) == "" {
+				missingEnvVars = append(missingEnvVars, envVar)
+			}
+		}
+		return nil, fmt.Errorf("Azure configuration missing: %s", strings.Join(missingEnvVars, ","))
 	}
 
 	return &DNSProvider{
@@ -57,7 +63,7 @@ func NewDNSProviderCredentials(clientId, clientSecret, subscriptionId, tenantId,
 		tenantId:       tenantId,
 		resourceGroup:  resourceGroup,
 		// TODO: A timeout can be added here for cancellation purposes.
-		context:        context.Background(),
+		context: context.Background(),
 	}, nil
 }
 

--- a/providers/dns/azure/azure_test.go
+++ b/providers/dns/azure/azure_test.go
@@ -58,7 +58,7 @@ func TestNewDNSProviderValidEnv(t *testing.T) {
 func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	os.Setenv("AZURE_SUBSCRIPTION_ID", "")
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "Azure configuration missing")
+	assert.EqualError(t, err, "Azure configuration missing: AZURE_CLIENT_ID,AZURE_CLIENT_SECRET,AZURE_TENANT_ID,AZURE_RESOURCE_GROUP,AZURE_DOMAIN")
 	restoreAzureEnv()
 }
 

--- a/providers/dns/azure/azure_test.go
+++ b/providers/dns/azure/azure_test.go
@@ -58,7 +58,7 @@ func TestNewDNSProviderValidEnv(t *testing.T) {
 func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	os.Setenv("AZURE_SUBSCRIPTION_ID", "")
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "Azure configuration missing: AZURE_CLIENT_ID,AZURE_CLIENT_SECRET,AZURE_TENANT_ID,AZURE_RESOURCE_GROUP,AZURE_DOMAIN")
+	assert.EqualError(t, err, "Azure configuration missing: AZURE_CLIENT_ID,AZURE_CLIENT_SECRET,AZURE_SUBSCRIPTION_ID,AZURE_TENANT_ID,AZURE_RESOURCE_GROUP,AZURE_DOMAIN")
 	restoreAzureEnv()
 }
 

--- a/providers/dns/azure/azure_test.go
+++ b/providers/dns/azure/azure_test.go
@@ -58,7 +58,7 @@ func TestNewDNSProviderValidEnv(t *testing.T) {
 func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	os.Setenv("AZURE_SUBSCRIPTION_ID", "")
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "Azure configuration missing: AZURE_CLIENT_ID,AZURE_CLIENT_SECRET,AZURE_SUBSCRIPTION_ID,AZURE_TENANT_ID,AZURE_RESOURCE_GROUP,AZURE_DOMAIN")
+	assert.EqualError(t, err, "Azure configuration missing: AZURE_CLIENT_ID,AZURE_CLIENT_SECRET,AZURE_SUBSCRIPTION_ID,AZURE_TENANT_ID,AZURE_RESOURCE_GROUP")
 	restoreAzureEnv()
 }
 

--- a/providers/dns/cloudflare/cloudflare.go
+++ b/providers/dns/cloudflare/cloudflare.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
-  "strings"
+	"strings"
 	"time"
 
 	"github.com/xenolf/lego/acme"
@@ -38,14 +38,14 @@ func NewDNSProvider() (*DNSProvider, error) {
 // DNSProvider instance configured for cloudflare.
 func NewDNSProviderCredentials(email, key string) (*DNSProvider, error) {
 	if email == "" || key == "" {
-    missingEnvVars := []string{}
-    if email == "" {
-      missingEnvVars = append(missingEnvVars, "CLOUDFLARE_EMAIL")
-    }
-    if key == "" {
-      missingEnvVars = append(missingEnvVars,  "CLOUDFLARE_API_KEY")
-    }
-    return nil, fmt.Errorf("CloudFlare credentials missing: %s",  strings.Join(missingEnvVars, ","))
+		missingEnvVars := []string{}
+		if email == "" {
+			missingEnvVars = append(missingEnvVars, "CLOUDFLARE_EMAIL")
+		}
+		if key == "" {
+			missingEnvVars = append(missingEnvVars, "CLOUDFLARE_API_KEY")
+		}
+		return nil, fmt.Errorf("CloudFlare credentials missing: %s", strings.Join(missingEnvVars, ","))
 	}
 
 	return &DNSProvider{

--- a/providers/dns/cloudflare/cloudflare.go
+++ b/providers/dns/cloudflare/cloudflare.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+  "strings"
 	"time"
 
 	"github.com/xenolf/lego/acme"
@@ -37,7 +38,14 @@ func NewDNSProvider() (*DNSProvider, error) {
 // DNSProvider instance configured for cloudflare.
 func NewDNSProviderCredentials(email, key string) (*DNSProvider, error) {
 	if email == "" || key == "" {
-		return nil, fmt.Errorf("CloudFlare credentials missing")
+    missingEnvVars := []string{}
+    if email == "" {
+      missingEnvVars = append(missingEnvVars, "CLOUDFLARE_EMAIL")
+    }
+    if key == "" {
+      missingEnvVars = append(missingEnvVars,  "CLOUDFLARE_API_KEY")
+    }
+    return nil, fmt.Errorf("CloudFlare credentials missing: %s",  strings.Join(missingEnvVars, ","))
 	}
 
 	return &DNSProvider{

--- a/providers/dns/cloudflare/cloudflare_test.go
+++ b/providers/dns/cloudflare/cloudflare_test.go
@@ -49,8 +49,15 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	os.Setenv("CLOUDFLARE_EMAIL", "")
 	os.Setenv("CLOUDFLARE_API_KEY", "")
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "CloudFlare credentials missing")
+  assert.EqualError(t, err, "CloudFlare credentials missing: CLOUDFLARE_EMAIL,CLOUDFLARE_API_KEY")
 	restoreCloudFlareEnv()
+}
+
+func TestNewDNSProviderMissingCredErrSingle(t *testing.T){
+  os.Setenv("CLOUDFLARE_EMAIL", "awesome@possum.com")
+  _, err:= NewDNSProvider()
+  assert.EqualError(t, err, "CloudFlare credentials missing: CLOUDFLARE_API_KEY")
+  restoreCloudFlareEnv()
 }
 
 func TestCloudFlarePresent(t *testing.T) {


### PR DESCRIPTION
Just had a pretty rough time trying to determine which envvars were being surfaced to Caddy and which weren't when using systemd.

Thought that something like this might forgo someone the pain if they go through the same headache. 