### PR TITLE
switch Docker LEGO_VERSION to build-arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.6
 
 ENV GOPATH /go
-ENV LEGO_VERSION tags/v0.4.1
+ARG LEGO_VERSION=tags/v0.4.1
 
 RUN apk update && apk add --no-cache --virtual run-dependencies ca-certificates && \
     apk add --no-cache --virtual build-dependencies go git musl-dev && \


### PR DESCRIPTION
Motivation for change: commit 4e330710a fixed the Azure integration but because the Dockerfile forcefully checks out a specific tag which predates that fix, the Dockerfile is currently broken, pending update.

Change: instead of using `ENV` which persists a value into the generated image and isn't easily overridden at build-time, use `ARG` which is not persisted in the image and is easily overridden at build-time, using the `--build-arg` flag.

With this change, this command-line works:

    docker build --build-arg LEGO_VERSION=master -t lego .

Docker version requirements: `ARG` appears to have been introduced to Docker in late 2015.  Any even-vaguely current Docker should work fine with this.