### PR TITLE
Added 'processing' status as valid challenge status

### DIFF
--- a/acme/client.go
+++ b/acme/client.go
@@ -822,6 +822,7 @@ func validate(j *jws, domain, uri string, c challenge) error {
 			log.Printf("[INFO][%s] The server validated our request", domain)
 			return nil
 		case "pending":
+		case "processing":
 		case "invalid":
 			return handleChallengeError(chlng)
 		default:


### PR DESCRIPTION
In ACME draft 10+, section 8 lists the valid challenge status' as:

`status (required, string):  The status of this challenge.  Possible
      values are: "pending", "processing", "valid", and "invalid".`

In acme/client.go the "processing" status is missing as a possible return value.