### PR TITLE
ACME HTTP: Allow customizing HTTP client x509.CertPool

### DIFF
--- a/acme/http.go
+++ b/acme/http.go
@@ -23,7 +23,7 @@ var (
 	// HTTPClient is an HTTP client with a reasonable timeout value and
 	// potentially a custom *x509.CertPool based on the caCertificateEnvVar
 	// environment variable (see the `initCertPool` function)
-	HTTPClient http.Client = http.Client{
+	HTTPClient = http.Client{
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			Dial: (&net.Dialer{

--- a/acme/http.go
+++ b/acme/http.go
@@ -64,13 +64,13 @@ func initCertPool() *x509.CertPool {
 	if customCACertsPath := os.Getenv(caCertificatesEnvVar); customCACertsPath != "" {
 		customCAs, err := ioutil.ReadFile(customCACertsPath)
 		if err != nil {
-			panic(fmt.Sprintf("error reading %s=%q: %s",
-				caCertificatesEnvVar, customCACertsPath, err.Error()))
+			panic(fmt.Sprintf("error reading %s=%q: %v",
+				caCertificatesEnvVar, customCACertsPath, err))
 		}
 		certPool := x509.NewCertPool()
 		if ok := certPool.AppendCertsFromPEM(customCAs); !ok {
-			panic(fmt.Sprintf("error creating x509 cert pool from %s=%q: %s",
-				caCertificatesEnvVar, customCACertsPath, err.Error()))
+			panic(fmt.Sprintf("error creating x509 cert pool from %s=%q: %v",
+				caCertificatesEnvVar, customCACertsPath, err))
 		}
 		return certPool
 	}

--- a/acme/http_test.go
+++ b/acme/http_test.go
@@ -1,8 +1,10 @@
 package acme
 
 import (
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 )
@@ -96,5 +98,95 @@ func TestUserAgent(t *testing.T) {
 	}
 	if !strings.Contains(ua, UserAgent) {
 		t.Errorf("Expected custom UA to contain %s, got '%s'", UserAgent, ua)
+	}
+}
+
+// TestInitCertPool tests the http.go initCertPool function for customizing the
+// HTTP Client *x509.CertPool with an environment variable.
+func TestInitCertPool(t *testing.T) {
+	// writeTemp creates a temp file with the given contents & prefix and returns
+	// the file path. If an error occurs, t.Fatalf is called to end the test run.
+	writeTemp := func(t *testing.T, contents, prefix string) string {
+		tmpFile, err := ioutil.TempFile("", prefix)
+		if err != nil {
+			t.Fatalf("Unable to create tempfile: %s", err.Error())
+		}
+		err = ioutil.WriteFile(tmpFile.Name(), []byte(contents), 0700)
+		if err != nil {
+			t.Fatalf("Unable to write tempfile contents: %s", err.Error())
+		}
+		return tmpFile.Name()
+	}
+
+	invalidFileContents := "not a certificate"
+	invalidFile := writeTemp(t, invalidFileContents, "invalid.pem")
+
+	// validFileContents is lifted from Pebble[0]. Generate your own CA cert with
+	// MiniCA[1].
+	// [0]: https://github.com/letsencrypt/pebble/blob/de6fa233ea1f283eeb9751d42c8e1ae72718c44e/test/certs/pebble.minica.pem
+	// [1]: https://github.com/jsha/minica
+	validFileContents := `
+-----BEGIN CERTIFICATE-----
+MIIDCTCCAfGgAwIBAgIIJOLbes8sTr4wDQYJKoZIhvcNAQELBQAwIDEeMBwGA1UE
+AxMVbWluaWNhIHJvb3QgY2EgMjRlMmRiMCAXDTE3MTIwNjE5NDIxMFoYDzIxMTcx
+MjA2MTk0MjEwWjAgMR4wHAYDVQQDExVtaW5pY2Egcm9vdCBjYSAyNGUyZGIwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC5WgZNoVJandj43kkLyU50vzCZ
+alozvdRo3OFiKoDtmqKPNWRNO2hC9AUNxTDJco51Yc42u/WV3fPbbhSznTiOOVtn
+Ajm6iq4I5nZYltGGZetGDOQWr78y2gWY+SG078MuOO2hyDIiKtVc3xiXYA+8Hluu
+9F8KbqSS1h55yxZ9b87eKR+B0zu2ahzBCIHKmKWgc6N13l7aDxxY3D6uq8gtJRU0
+toumyLbdzGcupVvjbjDP11nl07RESDWBLG1/g3ktJvqIa4BWgU2HMh4rND6y8OD3
+Hy3H8MY6CElL+MOCbFJjWqhtOxeFyZZV9q3kYnk9CAuQJKMEGuN4GU6tzhW1AgMB
+AAGjRTBDMA4GA1UdDwEB/wQEAwIChDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYB
+BQUHAwIwEgYDVR0TAQH/BAgwBgEB/wIBADANBgkqhkiG9w0BAQsFAAOCAQEAF85v
+d40HK1ouDAtWeO1PbnWfGEmC5Xa478s9ddOd9Clvp2McYzNlAFfM7kdcj6xeiNhF
+WPIfaGAi/QdURSL/6C1KsVDqlFBlTs9zYfh2g0UXGvJtj1maeih7zxFLvet+fqll
+xseM4P9EVJaQxwuK/F78YBt0tCNfivC6JNZMgxKF59h0FBpH70ytUSHXdz7FKwix
+Mfn3qEb9BXSk0Q3prNV5sOV3vgjEtB4THfDxSz9z3+DepVnW3vbbqwEbkXdk3j82
+2muVldgOUgTwK8eT+XdofVdntzU/kzygSAtAQwLJfn51fS1GvEcYGBc1bDryIqmF
+p9BI7gVKtWSZYegicA==
+-----END CERTIFICATE-----
+	`
+	validFile := writeTemp(t, validFileContents, "valid.pem")
+
+	testCases := []struct {
+		Name      string
+		EnvVar    string
+		ExpectNil bool
+	}{
+		{
+			Name:      "No env var",
+			EnvVar:    "",
+			ExpectNil: true,
+		},
+		{
+			Name:      "Env var with missing file",
+			EnvVar:    "not.a.real.file.pem",
+			ExpectNil: true,
+		},
+		{
+			Name:      "Env var with invalid content",
+			EnvVar:    invalidFile,
+			ExpectNil: true,
+		},
+		{
+			Name:      "Env var with valid content",
+			EnvVar:    validFile,
+			ExpectNil: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			os.Setenv(caCertificateEnvVar, tc.EnvVar)
+			defer os.Setenv(caCertificateEnvVar, "")
+
+			result := initCertPool()
+
+			if result == nil && !tc.ExpectNil {
+				t.Errorf("initCertPool() returned nil, expected non-nil")
+			} else if result != nil && tc.ExpectNil {
+				t.Errorf("initCertPool() returned non-nil, expected nil")
+			}
+		})
 	}
 }

--- a/acme/http_test.go
+++ b/acme/http_test.go
@@ -109,11 +109,11 @@ func TestInitCertPool(t *testing.T) {
 	writeTemp := func(t *testing.T, contents, prefix string) string {
 		tmpFile, err := ioutil.TempFile("", prefix)
 		if err != nil {
-			t.Fatalf("Unable to create tempfile: %s", err.Error())
+			t.Fatalf("Unable to create tempfile: %v", err)
 		}
 		err = ioutil.WriteFile(tmpFile.Name(), []byte(contents), 0700)
 		if err != nil {
-			t.Fatalf("Unable to write tempfile contents: %s", err.Error())
+			t.Fatalf("Unable to write tempfile contents: %v", err)
 		}
 		return tmpFile.Name()
 	}

--- a/acme/http_test.go
+++ b/acme/http_test.go
@@ -107,6 +107,7 @@ func TestInitCertPool(t *testing.T) {
 	// writeTemp creates a temp file with the given contents & prefix and returns
 	// the file path. If an error occurs, t.Fatalf is called to end the test run.
 	writeTemp := func(t *testing.T, contents, prefix string) string {
+		t.Helper()
 		tmpFile, err := ioutil.TempFile("", prefix)
 		if err != nil {
 			t.Fatalf("Unable to create tempfile: %v", err)


### PR DESCRIPTION
This PR updates `acme/http.go` to allow customizing the `*x509.CertPool` used by the `HTTPClient` by specifying the filepath of one or more custom CA certificates via the `LEGO_CA_CERTIFICATES` environment variable.

This allows developers to easily trust a non-standard CA when interacting with an ACME test server (e.g. [Pebble](https://github.com/letsencrypt/pebble)):

```
LEGO_CA_CERTIFICATES=~/go/src/github.com/letsencrypt/pebble/test/certs/pebble.minica.pem \
lego \
  --server https://localhost:14000/dir \
  --email foo@bar.com \
  -d example.com \
  run
```

Resolves #569