### PR TITLE
Allow passing the program to the exec provider directly

### DIFF
--- a/providers/dns/exec/exec.go
+++ b/providers/dns/exec/exec.go
@@ -48,7 +48,13 @@ func NewDNSProvider() (*DNSProvider, error) {
 		return nil, errors.New("environment variable EXEC_PATH not set")
 	}
 
-	return &DNSProvider{program: s}, nil
+	return NewDNSProviderProgram(s)
+}
+
+// NewDNSProviderProgram returns a new DNS provider which runs the given program
+// for adding and removing the DNS record.
+func NewDNSProviderProgram(program string) (*DNSProvider, error) {
+	return &DNSProvider{program: program}, nil
 }
 
 // Present creates a TXT record to fulfil the dns-01 challenge.


### PR DESCRIPTION
This adds a function NewDNSProviderProgram() to the exec provider that allows to set the program to run directly instead of via the environment variable. This is similar to how other providers allow to set their credentials.