### PR TITLE
add CNAME support for creating dns-01 TXT challenge

### DIFF
--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -171,6 +171,19 @@ func (s *dnsChallenge) CleanUp(chlng challenge, domain string) error {
 	return s.provider.CleanUp(domain, chlng.Token, keyAuth)
 }
 
+// Update FQDN with CNAME if any
+func updateDomainWithCName(r *dns.Msg, fqdn string) string {
+	for _, rr := range r.Answer {
+		if cn, ok := rr.(*dns.CNAME); ok {
+			if cn.Hdr.Name == fqdn {
+				fqdn = cn.Target
+				break
+			}
+		}
+	}
+	return fqdn
+}
+
 // checkDNSPropagation checks if the expected TXT record has been propagated to all authoritative nameservers.
 func checkDNSPropagation(fqdn, value string) (bool, error) {
 	// Initial attempt to resolve at the recursive NS

--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -159,8 +159,16 @@ func updateDomainWithCName(r *dns.Msg, fqdn string) string {
 			}
 		}
 	}
+}
 
 	return fqdn
+// CleanUp cleans the challenge
+func (s *dnsChallenge) CleanUp(chlng challenge, domain string) error {
+	keyAuth, err := getKeyAuthorization(chlng.Token, s.jws.privKey)
+	if err != nil {
+		return err
+	}
+	return s.provider.CleanUp(domain, chlng.Token, keyAuth)
 }
 
 // checkDNSPropagation checks if the expected TXT record has been propagated to all authoritative nameservers.

--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -159,28 +159,6 @@ func updateDomainWithCName(r *dns.Msg, fqdn string) string {
 			}
 		}
 	}
-}
-
-	return fqdn
-// CleanUp cleans the challenge
-func (s *dnsChallenge) CleanUp(chlng challenge, domain string) error {
-	keyAuth, err := getKeyAuthorization(chlng.Token, s.jws.privKey)
-	if err != nil {
-		return err
-	}
-	return s.provider.CleanUp(domain, chlng.Token, keyAuth)
-}
-
-// Update FQDN with CNAME if any
-func updateDomainWithCName(r *dns.Msg, fqdn string) string {
-	for _, rr := range r.Answer {
-		if cn, ok := rr.(*dns.CNAME); ok {
-			if cn.Hdr.Name == fqdn {
-				fqdn = cn.Target
-				break
-			}
-		}
-	}
 	return fqdn
 }
 

--- a/providers/dns/acmedns/acmedns_test.go
+++ b/providers/dns/acmedns/acmedns_test.go
@@ -18,7 +18,7 @@ var (
 
 	// Fixed test data for unit tests.
 	egDomain  = "threeletter.agency"
-	egFQDN    = "_acme-challenge." + egDomain + "."
+	egFQDN    = "30feb5f3-7cfa-43e2-95aa-d42ca56db9b0.pki." + egDomain + "."
 	egKeyAuth = "⚷"
 	egAccount = goacmedns.Account{
 		FullDomain: "acme-dns." + egDomain,


### PR DESCRIPTION
Domain for which certificate is asked for can be a CNAME, so we should check it.
If domain has a CNAME, create the challange TXT record in the alias domain.