### PR TITLE
Don't trust identifiers order.

### DIFF
--- a/acme/client.go
+++ b/acme/client.go
@@ -662,9 +662,18 @@ func (c *Client) requestCertificateForOrder(order orderResource, bundle bool, pr
 
 	// determine certificate name(s) based on the authorization resources
 	commonName := order.Domains[0]
-	var san []string
+
+	// ACME draft Section 7.4 "Applying for Certificate Issuance"
+	// https://tools.ietf.org/html/draft-ietf-acme-acme-12#section-7.4
+	// says:
+	//   Clients SHOULD NOT make any assumptions about the sort order of
+	//   "identifiers" or "authorizations" elements in the returned order
+	//   object.
+	san := []string{commonName}
 	for _, auth := range order.Identifiers {
-		san = append(san, auth.Value)
+		if auth.Value != commonName {
+			san = append(san, auth.Value)
+		}
 	}
 
 	// TODO: should the CSR be customizable?

--- a/acme/client.go
+++ b/acme/client.go
@@ -690,13 +690,13 @@ func (c *Client) requestCertificateForCsr(order orderResource, bundle bool, csr 
 
 	csrString := base64.RawURLEncoding.EncodeToString(csr)
 	var retOrder orderMessage
-	_, error := postJSON(c.jws, order.Finalize, csrMessage{Csr: csrString}, &retOrder)
-	if error != nil {
-		return nil, error
+	_, err := postJSON(c.jws, order.Finalize, csrMessage{Csr: csrString}, &retOrder)
+	if err != nil {
+		return nil, err
 	}
 
 	if retOrder.Status == "invalid" {
-		return nil, error
+		return nil, err
 	}
 
 	certRes := CertificateResource{

--- a/acme/crypto.go
+++ b/acme/crypto.go
@@ -215,9 +215,7 @@ func generatePrivateKey(keyType KeyType) (crypto.PrivateKey, error) {
 
 func generateCsr(privateKey crypto.PrivateKey, domain string, san []string, mustStaple bool) ([]byte, error) {
 	template := x509.CertificateRequest{
-		Subject: pkix.Name{
-			CommonName: domain,
-		},
+		Subject: pkix.Name{CommonName: domain},
 	}
 
 	if len(san) > 0 {


### PR DESCRIPTION
[ACME draft Section 7.4 "Applying for Certificate Issuance"](https://tools.ietf.org/html/draft-ietf-acme-acme-12#section-7.4)
> Clients SHOULD NOT make any assumptions about the sort order of
> "identifiers" or "authorizations" elements in the returned order
> object.

Pebble respect this assumption and this produce some weird certificate where the CN is the not the CN but a random SAN.
