### PR TITLE
DNS Providers: Add ACME-DNS provider.

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -198,6 +198,7 @@ Here is an example bash command using the CloudFlare DNS provider:
 	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
 	fmt.Fprintln(w, "Valid providers and their associated credential environment variables:")
 	fmt.Fprintln(w)
+	fmt.Fprintln(w, "\tacme-dns:\tACME_DNS_API_BASE, ACME_DNS_STORAGE_PATH")
 	fmt.Fprintln(w, "\tazure:\tAZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID, AZURE_TENANT_ID, AZURE_RESOURCE_GROUP")
 	fmt.Fprintln(w, "\tauroradns:\tAURORA_USER_ID, AURORA_KEY, AURORA_ENDPOINT")
 	fmt.Fprintln(w, "\tbluecat:\tBLUECAT_SERVER_URL, BLUECAT_USER_NAME, BLUECAT_PASSWORD, BLUECAT_CONFIG_NAME, BLUECAT_DNS_VIEW")

--- a/providers/dns/acmedns/acmedns.go
+++ b/providers/dns/acmedns/acmedns.go
@@ -1,0 +1,161 @@
+// Package acmedns implements a DNS provider for solving DNS-01 challenges using
+// Joohoi's acme-dns project. For more information see the ACME-DNS homepage:
+//    https://github.com/joohoi/acme-dns
+package acmedns
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/cpu/goacmedns"
+	"github.com/xenolf/lego/acme"
+)
+
+const (
+	// envNamespace is the prefix for ACME-DNS environment variables.
+	envNamespace = "ACME_DNS_"
+	// apiBaseEnvVar is the environment variable name for the ACME-DNS API address
+	// (e.g. https://acmedns.your-domain.com).
+	apiBaseEnvVar = envNamespace + "API_BASE"
+	// storagePathEnvVar is the environment variable name for the ACME-DNS JSON
+	// account data file. A per-domain account will be registered/persisted to
+	// this file and used for TXT updates.
+	storagePathEnvVar = envNamespace + "STORAGE_PATH"
+)
+
+// acmeDNSClient is an interface describing the goacmedns.Client functions
+// the DNSProvider uses. It makes it easier for tests to shim a mock Client into
+// the DNSProvider.
+type acmeDNSClient interface {
+	// UpdateTXTRecord updates the provided account's TXT record to the given
+	// value or returns an error.
+	UpdateTXTRecord(goacmedns.Account, string) error
+	// RegisterAccount registers and returns a new account with the given
+	// allowFrom restriction or returns an error.
+	RegisterAccount([]string) (goacmedns.Account, error)
+}
+
+// DNSProvider is an implementation of the acme.ChallengeProvider interface for
+// an ACME-DNS server.
+type DNSProvider struct {
+	apiBase string
+	client  acmeDNSClient
+	storage goacmedns.Storage
+}
+
+// NewDNSProvider creates an ACME-DNS provider. Its configuration is loaded from
+// the environment by reading apiBaseEnvVar and storagePathEnvVar.
+func NewDNSProvider() (*DNSProvider, error) {
+	endpoint := os.Getenv(apiBaseEnvVar)
+	storagePath := os.Getenv(storagePathEnvVar)
+	return NewDNSProviderClient(endpoint, storagePath)
+}
+
+// NewDNSProviderClient creates an ACME-DNS DNSProvider configured to
+// communicate with the provided ACME-DNS API endpoint, and to save/load account
+// credentials in a file found at the provided storage path.
+func NewDNSProviderClient(apiBase string, storagePath string) (*DNSProvider, error) {
+	if apiBase == "" {
+		return nil, errors.New("ACME-DNS API base must not be empty")
+	}
+	if storagePath == "" {
+		return nil, errors.New("ACME-DNS Storage path must not be empty")
+	}
+
+	return &DNSProvider{
+		apiBase: apiBase,
+		client:  goacmedns.NewClient(apiBase),
+		storage: goacmedns.NewFileStorage(storagePath, 0600),
+	}, nil
+}
+
+// ErrCNAMERequired is returned by Present when the Domain indicated had no
+// existing ACME-DNS account in the Storage and additional setup is required.
+// The user must create a CNAME in the DNS zone for Domain that aliases FQDN
+// to Target in order to complete setup for the ACME-DNS account that was
+// created.
+type ErrCNAMERequired struct {
+	// The Domain that is being issued for.
+	Domain string
+	// The alias of the CNAME (left hand DNS label).
+	FQDN string
+	// The RDATA of the CNAME (right hand side, canonical name).
+	Target string
+}
+
+// Error returns a descriptive message for the ErrCNAMERequired instance telling
+// the user that a CNAME needs to be added to the DNS zone of c.Domain before
+// the ACME-DNS hook will work. The CNAME to be created should be of the form:
+//   {{ c.FQDN }} 	CNAME	{{ c.Target }}
+func (e ErrCNAMERequired) Error() string {
+	return fmt.Sprintf("acme-dns: new account created for %q. "+
+		"To complete setup for %q you must provision the following "+
+		"CNAME in your DNS zone and re-run this provider when it is "+
+		"in place:\n"+
+		"%s CNAME %s.",
+		e.Domain, e.Domain, e.FQDN, e.Target)
+}
+
+// Present creates a TXT record to fulfil the DNS-01 challenge. If there is an
+// existing account for the domain in the provider's storage then it will be
+// used to set the challenge response TXT record with the ACME-DNS server and
+// issuance will continue. If there is not an account for the given domain
+// present in the DNSProvider storage one will be created and registered with
+// the ACME DNS server and an ErrCNAMERequired error is returned. This will halt
+// issuance and indicate to the user that a one-time manual setup is required
+// for the domain.
+func (d *DNSProvider) Present(domain, _, keyAuth string) error {
+	// Compute the challenge response FQDN and TXT value for the domain based
+	// on the keyAuth.
+	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
+	// Check if credentials were previously saved for this domain.
+	account, err := d.storage.Fetch(domain)
+	// Errors other than goacmeDNS.ErrDomainNotFound are unexpected.
+	if err != nil && err != goacmedns.ErrDomainNotFound {
+		return err
+	} else if err == goacmedns.ErrDomainNotFound {
+		// The account did not exist. Create a new one and return an error
+		// indicating the required one-time manual CNAME setup.
+		return d.register(domain, fqdn)
+	}
+	// Update the acme-dns TXT record.
+	return d.client.UpdateTXTRecord(account, value)
+}
+
+// CleanUp removes the record matching the specified parameters. It is not
+// implemented for the ACME-DNS provider.
+func (d *DNSProvider) CleanUp(_, _, _ string) error {
+	// ACME-DNS doesn't support the notion of removing a record. For users of
+	// ACME-DNS it is expected the stale records remain in-place.
+	return nil
+}
+
+// register creates a new ACME-DNS account for the given domain. If account
+// creation works as expected a ErrCNAMERequired error is returned describing
+// the one-time manual CNAME setup required to complete setup of the ACME-DNS
+// hook for the domain. If any other error occurs it is returned as-is.
+func (d *DNSProvider) register(domain, fqdn string) error {
+	// TODO(@cpu): Read CIDR whitelists from the environment
+	newAcct, err := d.client.RegisterAccount(nil)
+	if err != nil {
+		return err
+	}
+	// Store the new account in the storage and call save to persist the data.
+	err = d.storage.Put(domain, newAcct)
+	if err != nil {
+		return err
+	}
+	err = d.storage.Save()
+	if err != nil {
+		return err
+	}
+	// Stop issuance by returning an error. The user needs to perform a manual
+	// one-time CNAME setup in their DNS zone to complete the setup of the new
+	// account we created.
+	return ErrCNAMERequired{
+		Domain: domain,
+		FQDN:   fqdn,
+		Target: newAcct.FullDomain,
+	}
+}

--- a/providers/dns/acmedns/acmedns_test.go
+++ b/providers/dns/acmedns/acmedns_test.go
@@ -1,0 +1,301 @@
+package acmedns
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/cpu/goacmedns"
+)
+
+var (
+	// errorClientErr is used by the Client mocks that return an error.
+	errorClientErr = errors.New("errorClient always errors")
+	// errorStorageErr is used by the Storage mocks that return an error.
+	errorStorageErr = errors.New("errorStorage always errors")
+
+	// Fixed test data for unit tests.
+	egDomain  = "threeletter.agency"
+	egFQDN    = "_acme-challenge." + egDomain + "."
+	egKeyAuth = "⚷"
+	egAccount = goacmedns.Account{
+		FullDomain: "acme-dns." + egDomain,
+		SubDomain:  "random-looking-junk." + egDomain,
+		Username:   "spooky.mulder",
+		Password:   "trustno1",
+	}
+)
+
+// mockClient is a mock implementing the acmeDNSClient interface that always
+// returns a fixed goacmedns.Account from calls to Register.
+type mockClient struct {
+	mockAccount goacmedns.Account
+}
+
+// UpdateTXTRecord does nothing.
+func (c mockClient) UpdateTXTRecord(_ goacmedns.Account, _ string) error {
+	return nil
+}
+
+// RegisterAccount returns c.mockAccount and no errors.
+func (c mockClient) RegisterAccount(_ []string) (goacmedns.Account, error) {
+	return c.mockAccount, nil
+}
+
+// mockUpdateClient is a mock implementing the acmeDNSClient interface that
+// tracks the calls to UpdateTXTRecord in the records map.
+type mockUpdateClient struct {
+	mockClient
+	records map[goacmedns.Account]string
+}
+
+// UpdateTXTRecord saves a record value to c.records for the given acct.
+func (c mockUpdateClient) UpdateTXTRecord(acct goacmedns.Account, value string) error {
+	c.records[acct] = value
+	return nil
+}
+
+// errorRegisterClient is a mock implementing the acmeDNSClient interface that always
+// returns errors from errorUpdateClient.
+type errorUpdateClient struct {
+	mockClient
+}
+
+// UpdateTXTRecord always returns an error.
+func (c errorUpdateClient) UpdateTXTRecord(_ goacmedns.Account, _ string) error {
+	return errorClientErr
+}
+
+// errorRegisterClient is a mock implementing the acmeDNSClient interface that always
+// returns errors from RegisterAccount.
+type errorRegisterClient struct {
+	mockClient
+}
+
+// RegisterAccount always returns an error.
+func (c errorRegisterClient) RegisterAccount(_ []string) (goacmedns.Account, error) {
+	return goacmedns.Account{}, errorClientErr
+}
+
+// mockStorage is a mock implementing the goacmedns.Storage interface that
+// returns static account data and ignores Save.
+type mockStorage struct {
+	accounts map[string]goacmedns.Account
+}
+
+// Save does nothing.
+func (m mockStorage) Save() error {
+	return nil
+}
+
+// Put stores an account for the given domain in m.accounts.
+func (m mockStorage) Put(domain string, acct goacmedns.Account) error {
+	m.accounts[domain] = acct
+	return nil
+}
+
+// Fetch retrieves an account for the given domain from m.accounts or returns
+// goacmedns.ErrDomainNotFound.
+func (m mockStorage) Fetch(domain string) (goacmedns.Account, error) {
+	if acct, ok := m.accounts[domain]; ok {
+		return acct, nil
+	}
+	return goacmedns.Account{}, goacmedns.ErrDomainNotFound
+}
+
+// errorPutStorage is a mock implementing the goacmedns.Storage interface that
+// always returns errors from Put.
+type errorPutStorage struct {
+	mockStorage
+}
+
+// Put always errors.
+func (e errorPutStorage) Put(_ string, _ goacmedns.Account) error {
+	return errorStorageErr
+}
+
+// errorSaveStoragr is a mock implementing the goacmedns.Storage interface that
+// always returns errors from Save.
+type errorSaveStorage struct {
+	mockStorage
+}
+
+// Save always errors.
+func (e errorSaveStorage) Save() error {
+	return errorStorageErr
+}
+
+// errorFetchStorage is a mock implementing the goacmedns.Storage interface that
+// always returns errors from Fetch.
+type errorFetchStorage struct {
+	mockStorage
+}
+
+// Fetch always errors.
+func (e errorFetchStorage) Fetch(_ string) (goacmedns.Account, error) {
+	return goacmedns.Account{}, errorStorageErr
+}
+
+// TestPresent tests that the ACME-DNS Present function for updating a DNS-01
+// challenge response TXT record works as expected.
+func TestPresent(t *testing.T) {
+	// validAccountStorage is a mockStorage configured to return the egAccount.
+	validAccountStorage := mockStorage{
+		map[string]goacmedns.Account{
+			egDomain: egAccount,
+		},
+	}
+	// validUpdateClient is a mockClient configured with the egAccount that will
+	// track TXT updates in a map.
+	validUpdateClient := mockUpdateClient{
+		mockClient{egAccount},
+		make(map[goacmedns.Account]string),
+	}
+
+	testCases := []struct {
+		Name          string
+		Client        acmeDNSClient
+		Storage       goacmedns.Storage
+		ExpectedError error
+	}{
+		{
+			Name:          "present when client storage returns unexpected error",
+			Client:        mockClient{egAccount},
+			Storage:       errorFetchStorage{},
+			ExpectedError: errorStorageErr,
+		},
+		{
+			Name:   "present when client storage returns ErrDomainNotFound",
+			Client: mockClient{egAccount},
+			ExpectedError: ErrCNAMERequired{
+				Domain: egDomain,
+				FQDN:   egFQDN,
+				Target: egAccount.FullDomain,
+			},
+		},
+		{
+			Name:          "present when client UpdateTXTRecord returns unexpected error",
+			Client:        errorUpdateClient{},
+			Storage:       validAccountStorage,
+			ExpectedError: errorClientErr,
+		},
+		{
+			Name:    "present when everything works",
+			Storage: validAccountStorage,
+			Client:  validUpdateClient,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			// create the DNS provider using. The API base address and the storage
+			// path can be made up because we mock the client and storage instead of
+			// making real API calls and writing JSON to disk.
+			dp, err := NewDNSProviderClient("foo", "bar")
+			if err != nil {
+				t.Fatalf("unexpected error creating NewDNSProviderClient: %v", err)
+			}
+			// mock the client.
+			dp.client = tc.Client
+			// mock the storage.
+			dp.storage = mockStorage{make(map[string]goacmedns.Account)}
+			// override the storage mock if required by the testcase.
+			if tc.Storage != nil {
+				dp.storage = tc.Storage
+			}
+			// call Present. The token argument can be garbage because the ACME-DNS
+			// provider does not use it.
+			err = dp.Present(egDomain, "foo", egKeyAuth)
+			if tc.ExpectedError != nil && err == nil {
+				t.Errorf("expected present to return error %v, got nil", tc.ExpectedError)
+			} else if tc.ExpectedError == nil && err != nil {
+				t.Errorf("expected present to return no error, got %v", err)
+			} else if tc.ExpectedError != nil && err != nil && tc.ExpectedError != err {
+				t.Errorf("expected present to return error %v, got %v", tc.ExpectedError, err)
+			}
+		})
+	}
+
+	// Check that the success testcase set a record.
+	if len(validUpdateClient.records) != 1 {
+		t.Fatalf("expected present to successfully set a record on the mock, got none")
+	}
+
+	// Check that the success testcase set the right record for the right account.
+	if value, ok := validUpdateClient.records[egAccount]; !ok {
+		t.Errorf("expected present to successfully set a record for the egAccount, got none")
+	} else if len(value) != 43 {
+		t.Errorf("expected present to successfully set a record with 43 characters "+
+			"for the egAccount. Got value %q, len %d",
+			value, len(value))
+	}
+}
+
+// TestRegister tests that the ACME-DNS register function works correctly.
+func TestRegister(t *testing.T) {
+	testCases := []struct {
+		Name          string
+		Client        acmeDNSClient
+		Storage       goacmedns.Storage
+		Domain        string
+		FQDN          string
+		ExpectedError error
+	}{
+		{
+			Name:          "register when acme-dns client returns an error",
+			Client:        errorRegisterClient{},
+			ExpectedError: errorClientErr,
+		},
+		{
+			Name:          "register when acme-dns storage put returns an error",
+			Client:        mockClient{egAccount},
+			Storage:       errorPutStorage{mockStorage{make(map[string]goacmedns.Account)}},
+			ExpectedError: errorStorageErr,
+		},
+		{
+			Name:          "register when acme-dns storage save returns an error",
+			Client:        mockClient{egAccount},
+			Storage:       errorSaveStorage{mockStorage{make(map[string]goacmedns.Account)}},
+			ExpectedError: errorStorageErr,
+		},
+		{
+			Name:   "register when everything works",
+			Client: mockClient{egAccount},
+			ExpectedError: ErrCNAMERequired{
+				Domain: egDomain,
+				FQDN:   egFQDN,
+				Target: egAccount.FullDomain,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			// create the DNS provider using. The API base address and the storage
+			// path can be made up because we mock the client and storage instead of
+			// making real API calls and writing JSON to disk.
+			dp, err := NewDNSProviderClient("foo", "bar")
+			if err != nil {
+				t.Fatalf("unexpected error creating NewDNSProviderClient: %v", err)
+			}
+			// mock the client.
+			dp.client = tc.Client
+			// mock the storage.
+			dp.storage = mockStorage{
+				make(map[string]goacmedns.Account),
+			}
+			// override the storage mock if required by the testcase.
+			if tc.Storage != nil {
+				dp.storage = tc.Storage
+			}
+			// Call register for the example domain/fqdn.
+			err = dp.register(egDomain, egFQDN)
+			if tc.ExpectedError != nil && err == nil {
+				t.Errorf("expected register to return error %v, got nil", tc.ExpectedError)
+			} else if tc.ExpectedError == nil && err != nil {
+				t.Errorf("expected register to return no error, got %v", err)
+			} else if tc.ExpectedError != nil && err != nil && tc.ExpectedError != err {
+				t.Errorf("expected register to return error %v, got %v", tc.ExpectedError, err)
+			}
+		})
+	}
+}

--- a/providers/dns/dns_providers.go
+++ b/providers/dns/dns_providers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/xenolf/lego/acme"
+	"github.com/xenolf/lego/providers/dns/acmedns"
 	"github.com/xenolf/lego/providers/dns/auroradns"
 	"github.com/xenolf/lego/providers/dns/azure"
 	"github.com/xenolf/lego/providers/dns/bluecat"
@@ -41,6 +42,8 @@ import (
 // NewDNSChallengeProviderByName Factory for DNS providers
 func NewDNSChallengeProviderByName(name string) (acme.ChallengeProvider, error) {
 	switch name {
+	case "acme-dns":
+		return acmedns.NewDNSProvider()
 	case "azure":
 		return azure.NewDNSProvider()
 	case "auroradns":


### PR DESCRIPTION
This commit adds a new "acme-dns" DNS provider for [acme-dns](https://github.com/joohoi/acme-dns) to allow Lego to set DNS-01 challenge response TXT records with an ACME-DNS server automatically. ACME-DNS allows ceding minimal zone editing permissions to the ACME client and can be useful when the primary DNS provider for the zone does not allow scripting/API access but can set a CNAME to an ACME-DNS server.

The acme-dns provider accepts an ACME-DNS API server address in the `ACME_DNS_API_BASE` environment variable. The provider's lower level ACME-DNS API calls & account loading/storing is handled by the [`github.com/cpu/goacmedns`](https://github.com/cpu/goacmedns) library. This is roughly modelled after the [acme-dns-certbot-joohoi](https://github.com/joohoi/acme-dns-certbot-joohoi) hook for Certbot and the [https://github.com/joohoi/pyacmedns](https://github.com/joohoi/pyacmedns) Python library.

The acme-dns provider accepts a JSON storage file for ACME-DNS account information in the `ACME_DNS_STORAGE_PATH` environment variable. The provider loads existing ACME-DNS accounts/domains from this file at runtime. When required, the provider handles registering new accounts with the ACME-DNS server and saves the details to the storage path. This will halt issuance with an error prompting the user to set the one-time manual CNAME required to delegate the DNS-01 challenge record to the ACME-DNS server. Subsequent runs will use the previously registered account from disk and assume the CNAME is in-place.

You can avoid having Lego fail on the first run by [pre-registering the domains with ACME-DNS](https://github.com/cpu/goacmedns#pre-registration) using the `goacmedns-register` command line utility and providing the `-storage` path you will later use as the `ACME_DNS_STORAGE_PATH` value. This will let you perform the initial one-time CNAME delegation ahead of using `lego`.

### Usage example:

ACME-DNS is running at `http://10.0.0.8:4443` with a configuration for `pki.threeletter.agency`. We're going to issue a certificate for `*.legotest.xkeyscore.club` using Lego and ACME-DNS, saving the account data in `/root/.lego-acme-dns-accounts.json`.

Since for this first run `ACME_DNS_STORAGE_PATH` is empty and the ACME-DNS CNAME delegation hasn't been done yet it will fail with an error about setting up the CNAME:

```
root@example:~# ACME_DNS_API_BASE=http://10.0.0.8:4443 ACME_DNS_STORAGE_PATH=/root/.lego-acme-dns-accounts.json lego --server https://acme-staging-v02.api.letsencrypt.org/directory --email daniel@binaryparadox.net -a --dns acme-dns --domains "*.legotest.xkeyscore.club" run
2018/07/01 14:31:05 No key found for account daniel@binaryparadox.net. Generating a curve P384 EC key.
2018/07/01 14:31:05 Saved key to /root/.lego/accounts/acme-staging-v02.api.letsencrypt.org/daniel@binaryparadox.net/keys/daniel@binaryparadox.net.key
2018/07/01 14:31:05 [INFO] acme: Registering account for daniel@binaryparadox.net
2018/07/01 14:31:05 !!!! HEADS UP !!!!
2018/07/01 14:31:05 
		Your account credentials have been saved in your Let's Encrypt
		configuration directory at "/root/.lego/accounts/acme-staging-v02.api.letsencrypt.org/daniel@binaryparadox.net".
		You should make a secure backup	of this folder now. This
		configuration directory will also contain certificates and
		private keys obtained from Let's Encrypt so making regular
		backups of this folder is ideal.
2018/07/01 14:31:05 [INFO] [*.legotest.xkeyscore.club] acme: Obtaining bundled SAN certificate
2018/07/01 14:31:06 [INFO] [*.legotest.xkeyscore.club] AuthURL: https://acme-staging-v02.api.letsencrypt.org/acme/authz/qRUiCZ99r1ZGkeJXnQuZwnsSyunr8HDp_LNwfyXdmpk
2018/07/01 14:31:06 [INFO] [legotest.xkeyscore.club] acme: Trying to solve DNS-01
2018/07/01 14:31:06 Could not obtain certificates
	acme: Error -> One or more domains had a problem:
[legotest.xkeyscore.club] error presenting token: acme-dns: new account created for "legotest.xkeyscore.club". To complete setup for "legotest.xkeyscore.club" you must provision the following CNAME in your DNS zone and re-run this provider when it is in place:
_acme-challenge.legotest.xkeyscore.club. CNAME a9b4649d-113f-4449-886b-28dd534cc599.pki.threeletter.agency.
```

After adding the `_acme-challenge.legotest.xkeyscore.club. CNAME a9b4649d-113f-4449-886b-28dd534cc599.pki.threeletter.agency.` record to the `xkeyscore.club` DNS zone and **making sure all of the secondary DNS servers have the record too** we can run Lego again:

```
root@example:~# ACME_DNS_API_BASE=http://10.0.0.8:4443 ACME_DNS_STORAGE_PATH=/root/.lego-acme-dns-accounts.json lego --server https://acme-staging-v02.api.letsencrypt.org/directory --email daniel@binaryparadox.net -a --dns acme-dns --dns-resolvers 8.8.8.8 --domains "*.legotest.xkeyscore.club" run
2018/07/01 14:35:56 [INFO] [*.legotest.xkeyscore.club] acme: Obtaining bundled SAN certificate
2018/07/01 14:35:56 [INFO] [*.legotest.xkeyscore.club] AuthURL: https://acme-staging-v02.api.letsencrypt.org/acme/authz/qRUiCZ99r1ZGkeJXnQuZwnsSyunr8HDp_LNwfyXdmpk
2018/07/01 14:35:56 [INFO] [legotest.xkeyscore.club] acme: Trying to solve DNS-01
2018/07/01 14:35:57 [INFO] [legotest.xkeyscore.club] Checking DNS record propagation using [8.8.8.8:53]
2018/07/01 14:36:02 [INFO] [legotest.xkeyscore.club] The server validated our request
2018/07/01 14:36:02 [INFO] [*.legotest.xkeyscore.club] acme: Validations succeeded; requesting certificates
2018/07/01 14:36:03 [INFO] [*.legotest.xkeyscore.club] Server responded with a certificate.
```

Woohoo! :tada:


