### PR TITLE
Submit all dns records up front, then validate serially

### DIFF
--- a/acme/client.go
+++ b/acme/client.go
@@ -41,6 +41,12 @@ type solver interface {
 	Solve(challenge challenge, domain string) error
 }
 
+// Interface for challenges like dns, where we can set a record in advance for ALL challenges.
+// This saves quite a bit of time vs creating the records and solving them serially.
+type presolver interface {
+	PreSolve(challenge challenge, domain string) error
+}
+
 type validateFunc func(j *jws, domain, uri string, chlng challenge) error
 
 // Client is the user-friendy way to ACME
@@ -548,29 +554,59 @@ func (c *Client) createOrderForIdentifiers(domains []string) (orderResource, err
 	return orderRes, nil
 }
 
+// an authz with the solver we have chosen and the index of the challenge associated with it
+type selectedAuthSolver struct {
+	authz          authorization
+	challengeIndex int
+	solver         solver
+}
+
 // Looks through the challenge combinations to find a solvable match.
 // Then solves the challenges in series and returns.
 func (c *Client) solveChallengeForAuthz(authorizations []authorization) error {
 	failures := make(ObtainError)
 
-	// loop through the resources, basically through the domains.
+	authSolvers := []*selectedAuthSolver{}
+
+	// loop through the resources, basically through the domains. First pass just selects a solver for each authz.
 	for _, authz := range authorizations {
 		if authz.Status == "valid" {
 			// Boulder might recycle recent validated authz (see issue #267)
 			log.Infof("[%s] acme: Authorization already valid; skipping challenge", authz.Identifier.Value)
 			continue
 		}
-
-		// no solvers - no solving
 		if i, solver := c.chooseSolver(authz, authz.Identifier.Value); solver != nil {
-			err := solver.Solve(authz.Challenges[i], authz.Identifier.Value)
-			if err != nil {
-				//c.disableAuthz(authz.Identifier)
+			authSolvers = append(authSolvers, &selectedAuthSolver{
+				authz:          authz,
+				challengeIndex: i,
+				solver:         solver,
+			})
+		} else {
+			failures[authz.Identifier.Value] = fmt.Errorf("[%s] acme: Could not determine solvers", authz.Identifier.Value)
+		}
+	}
+
+	// for all valid presolvers, first submit the challenges so they have max time to propigate
+	for _, item := range authSolvers {
+		authz := item.authz
+		i := item.challengeIndex
+		if presolver, ok := item.solver.(presolver); ok {
+			if err := presolver.PreSolve(authz.Challenges[i], authz.Identifier.Value); err != nil {
 				failures[authz.Identifier.Value] = err
 			}
-		} else {
-			//c.disableAuthz(authz)
-			failures[authz.Identifier.Value] = fmt.Errorf("[%s] acme: Could not determine solvers", authz.Identifier.Value)
+		}
+	}
+
+	// finally solve all challenges for real
+	for _, item := range authSolvers {
+		authz := item.authz
+		i := item.challengeIndex
+		if failures[authz.Identifier.Value] != nil {
+			// already failed in previous loop
+			continue
+		}
+		if err := item.solver.Solve(authz.Challenges[i], authz.Identifier.Value); err != nil {
+			failures[authz.Identifier.Value] = err
 		}
 	}
 

--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -103,13 +103,6 @@ func (s *dnsChallenge) Solve(chlng challenge, domain string) error {
 		return err
 	}
 
-	defer func() {
-		err := s.provider.CleanUp(domain, chlng.Token, keyAuth)
-		if err != nil {
-			log.Warnf("Error cleaning up %s: %v ", domain, err)
-		}
-	}()
-
 	fqdn, value, _ := DNS01Record(domain, keyAuth)
 
 	log.Infof("[%s] Checking DNS record propagation using %+v", domain, RecursiveNameservers)
@@ -130,6 +123,15 @@ func (s *dnsChallenge) Solve(chlng challenge, domain string) error {
 	}
 
 	return s.validate(s.jws, domain, chlng.URL, challenge{Type: chlng.Type, Token: chlng.Token, KeyAuthorization: keyAuth})
+}
+
+// CleanUp cleans the challenge
+func (s *dnsChallenge) CleanUp(chlng challenge, domain string) error {
+	keyAuth, err := getKeyAuthorization(chlng.Token, s.jws.privKey)
+	if err != nil {
+		return err
+	}
+	return s.provider.CleanUp(domain, chlng.Token, keyAuth)
 }
 
 // checkDNSPropagation checks if the expected TXT record has been propagated to all authoritative nameservers.


### PR DESCRIPTION
This implements a simple way to increase the speed and reliability of dns challenges in cases where there are multiple challenges needed. It does not parallelize anything, it just creates all of the txt records in a preliminary pass so that things can propagate while we perform validations on other records. By the time the first record is resolving and validated, hopefully the others will be as well, and the overall time to issue a certificate can be greatly reduced.

The implementation simply involves an additional `presolver` interface implemented only by the dns solver so far. The intent of the `PreSolve` method is to allow preliminary work to happen in the first phase, and then validation can happen in the second `Solve` phase. If a `solver` does not implement `presolver`, the preliminary phase will just not be run.