### PR TITLE
Check error to avoid panic due to nil client

### DIFF
--- a/providers/dns/ovh/ovh.go
+++ b/providers/dns/ovh/ovh.go
@@ -50,12 +50,16 @@ func NewDNSProviderCredentials(apiEndpoint, applicationKey, applicationSecret, c
 		return nil, fmt.Errorf("OVH credentials missing")
 	}
 
-	ovhClient, _ := ovh.NewClient(
+	ovhClient, err := ovh.NewClient(
 		apiEndpoint,
 		applicationKey,
 		applicationSecret,
 		consumerKey,
 	)
+
+	if err != nil {
+		return nil, err
+	}
 
 	return &DNSProvider{
 		client:    ovhClient,

--- a/providers/dns/ovh/ovh.go
+++ b/providers/dns/ovh/ovh.go
@@ -69,31 +69,12 @@ func NewDNSProviderCredentials(apiEndpoint, applicationKey, applicationSecret, c
 
 // Present creates a TXT record to fulfil the dns-01 challenge.
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
-
-	// txtRecordRequest represents the request body to DO's API to make a TXT record
-	type txtRecordRequest struct {
-		FieldType string `json:"fieldType"`
-		SubDomain string `json:"subDomain"`
-		Target    string `json:"target"`
-		TTL       int    `json:"ttl"`
-	}
-
-	// txtRecordResponse represents a response from DO's API after making a TXT record
-	type txtRecordResponse struct {
-		ID        int    `json:"id"`
-		FieldType string `json:"fieldType"`
-		SubDomain string `json:"subDomain"`
-		Target    string `json:"target"`
-		TTL       int    `json:"ttl"`
-		Zone      string `json:"zone"`
-	}
-
 	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
 
 	// Parse domain name
 	authZone, err := acme.FindZoneByFqdn(acme.ToFqdn(domain), acme.RecursiveNameservers)
 	if err != nil {
-		return fmt.Errorf("Could not determine zone for domain: '%s'. %s", domain, err)
+		return fmt.Errorf("could not determine zone for domain: '%s'. %s", domain, err)
 	}
 
 	authZone = acme.UnFqdn(authZone)
@@ -137,7 +118,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	authZone, err := acme.FindZoneByFqdn(acme.ToFqdn(domain), acme.RecursiveNameservers)
 	if err != nil {
-		return fmt.Errorf("Could not determine zone for domain: '%s'. %s", domain, err)
+		return fmt.Errorf("could not determine zone for domain: '%s'. %s", domain, err)
 	}
 
 	authZone = acme.UnFqdn(authZone)
@@ -163,4 +144,22 @@ func (d *DNSProvider) extractRecordName(fqdn, domain string) string {
 		return name[:idx]
 	}
 	return name
+}
+
+// txtRecordRequest represents the request body to DO's API to make a TXT record
+type txtRecordRequest struct {
+	FieldType string `json:"fieldType"`
+	SubDomain string `json:"subDomain"`
+	Target    string `json:"target"`
+	TTL       int    `json:"ttl"`
+}
+
+// txtRecordResponse represents a response from DO's API after making a TXT record
+type txtRecordResponse struct {
+	ID        int    `json:"id"`
+	FieldType string `json:"fieldType"`
+	SubDomain string `json:"subDomain"`
+	Target    string `json:"target"`
+	TTL       int    `json:"ttl"`
+	Zone      string `json:"zone"`
 }

--- a/providers/dns/route53/route53.go
+++ b/providers/dns/route53/route53.go
@@ -35,7 +35,7 @@ func NewDefaultConfig() *Config {
 	return &Config{
 		MaxRetries:         env.GetOrDefaultInt("AWS_MAX_RETRIES", 5),
 		TTL:                env.GetOrDefaultInt("AWS_TTL", 10),
-		PropagationTimeout: time.Minute * time.Duration(propagationMins),
+		PropagationTimeout: time.Second * time.Duration(propagationMins),
 		PollingInterval:    time.Second * time.Duration(intervalSecs),
 		HostedZoneID:       os.Getenv("AWS_HOSTED_ZONE_ID"),
 	}

--- a/providers/dns/route53/route53_test.go
+++ b/providers/dns/route53/route53_test.go
@@ -117,7 +117,7 @@ func TestConfigFromEnv(t *testing.T) {
 	config = NewDefaultConfig()
 	assert.Equal(t, config.MaxRetries, 10, "Expected PropagationTimeout to be configured from the environment")
 	assert.Equal(t, config.TTL, 99, "Expected TTL to be configured from the environment")
-	assert.Equal(t, config.PropagationTimeout, time.Minute*60, "Expected PropagationTimeout to be configured from the environment")
+	assert.Equal(t, config.PropagationTimeout, time.Second*60, "Expected PropagationTimeout to be configured from the environment")
 	assert.Equal(t, config.PollingInterval, time.Second*60, "Expected PollingInterval to be configured from the environment")
 	assert.Equal(t, config.HostedZoneID, zoneID, "Expected HostedZoneID to be configured from the environment")
 }


### PR DESCRIPTION
## Kind

Bugfix

## Description

This PR aadds a error checking during the OVH client creation to avoid panic.

Related https://github.com/containous/traefik/issues/2736