### PR TITLE
Use path/filepath instead of path

### DIFF
--- a/account.go
+++ b/account.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/xenolf/lego/acme"
 	"github.com/xenolf/lego/log"
@@ -24,7 +24,7 @@ type Account struct {
 func NewAccount(email string, conf *Configuration) *Account {
 	accKeysPath := conf.AccountKeysPath(email)
 	// TODO: move to function in configuration?
-	accKeyPath := accKeysPath + string(os.PathSeparator) + email + ".key"
+	accKeyPath := filepath.Join(accKeysPath, email+".key")
 	if err := checkFolder(accKeysPath); err != nil {
 		log.Fatalf("Could not check/create directory for account %s: %v", email, err)
 	}
@@ -46,7 +46,7 @@ func NewAccount(email string, conf *Configuration) *Account {
 		}
 	}
 
-	accountFile := path.Join(conf.AccountPath(email), "account.json")
+	accountFile := filepath.Join(conf.AccountPath(email), "account.json")
 	if _, err := os.Stat(accountFile); os.IsNotExist(err) {
 		return &Account{Email: email, key: privKey, conf: conf}
 	}
@@ -127,7 +127,7 @@ func (a *Account) Save() error {
 	}
 
 	return ioutil.WriteFile(
-		path.Join(a.conf.AccountPath(a.Email), "account.json"),
+		filepath.Join(a.conf.AccountPath(a.Email), "account.json"),
 		jsonBytes,
 		0600,
 	)

--- a/cli.go
+++ b/cli.go
@@ -5,7 +5,7 @@ package main
 import (
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"text/tabwriter"
 
 	"github.com/urfave/cli"
@@ -29,7 +29,7 @@ func main() {
 	defaultPath := ""
 	cwd, err := os.Getwd()
 	if err == nil {
-		defaultPath = path.Join(cwd, ".lego")
+		defaultPath = filepath.Join(cwd, ".lego")
 	}
 
 	app.Before = func(c *cli.Context) error {

--- a/cli_handlers.go
+++ b/cli_handlers.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -164,11 +163,11 @@ func saveCertRes(certRes *acme.CertificateResource, conf *Configuration) {
 
 	// We store the certificate, private key and metadata in different files
 	// as web servers would not be able to work with a combined file.
-	certOut := path.Join(conf.CertPath(), domainName+".crt")
-	privOut := path.Join(conf.CertPath(), domainName+".key")
-	pemOut := path.Join(conf.CertPath(), domainName+".pem")
-	metaOut := path.Join(conf.CertPath(), domainName+".json")
-	issuerOut := path.Join(conf.CertPath(), domainName+".issuer.crt")
+	certOut := filepath.Join(conf.CertPath(), domainName+".crt")
+	privOut := filepath.Join(conf.CertPath(), domainName+".key")
+	pemOut := filepath.Join(conf.CertPath(), domainName+".pem")
+	metaOut := filepath.Join(conf.CertPath(), domainName+".json")
+	issuerOut := filepath.Join(conf.CertPath(), domainName+".issuer.crt")
 
 	err := checkFolder(filepath.Dir(certOut))
 	if err != nil {
@@ -379,7 +378,7 @@ func revoke(c *cli.Context) error {
 	for _, domain := range c.GlobalStringSlice("domains") {
 		log.Printf("Trying to revoke certificate for domain %s", domain)
 
-		certPath := path.Join(conf.CertPath(), domain+".crt")
+		certPath := filepath.Join(conf.CertPath(), domain+".crt")
 		certBytes, err := ioutil.ReadFile(certPath)
 		if err != nil {
 			log.Println(err)
@@ -412,9 +411,9 @@ func renew(c *cli.Context) error {
 	// load the cert resource from files.
 	// We store the certificate, private key and metadata in different files
 	// as web servers would not be able to work with a combined file.
-	certPath := path.Join(conf.CertPath(), domain+".crt")
-	privPath := path.Join(conf.CertPath(), domain+".key")
-	metaPath := path.Join(conf.CertPath(), domain+".json")
+	certPath := filepath.Join(conf.CertPath(), domain+".crt")
+	privPath := filepath.Join(conf.CertPath(), domain+".key")
+	metaPath := filepath.Join(conf.CertPath(), domain+".json")
 
 	certBytes, err := ioutil.ReadFile(certPath)
 	if err != nil {

--- a/configuration.go
+++ b/configuration.go
@@ -11,11 +11,6 @@ import (
 	"github.com/xenolf/lego/acme"
 )
 
-var pathReplacer = strings.NewReplacer(
-	":", "_",
-	"/", string(os.PathSeparator),
-)
-
 // Configuration type from CLI and config files.
 type Configuration struct {
 	context *cli.Context
@@ -55,7 +50,7 @@ func (c *Configuration) ExcludedSolvers() (cc []acme.Challenge) {
 // ServerPath returns the OS dependent path to the data for a specific CA
 func (c *Configuration) ServerPath() string {
 	srv, _ := url.Parse(c.context.GlobalString("server"))
-	return pathReplacer.Replace(srv.Host)
+	return strings.NewReplacer(":", "_", "/", string(os.PathSeparator)).Replace(srv.Host)
 }
 
 // CertPath gets the path for certificates.

--- a/configuration.go
+++ b/configuration.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/urfave/cli"
@@ -56,21 +56,21 @@ func (c *Configuration) ServerPath() string {
 
 // CertPath gets the path for certificates.
 func (c *Configuration) CertPath() string {
-	return path.Join(c.context.GlobalString("path"), "certificates")
+	return filepath.Join(c.context.GlobalString("path"), "certificates")
 }
 
 // AccountsPath returns the OS dependent path to the
 // local accounts for a specific CA
 func (c *Configuration) AccountsPath() string {
-	return path.Join(c.context.GlobalString("path"), "accounts", c.ServerPath())
+	return filepath.Join(c.context.GlobalString("path"), "accounts", c.ServerPath())
 }
 
 // AccountPath returns the OS dependent path to a particular account
 func (c *Configuration) AccountPath(acc string) string {
-	return path.Join(c.AccountsPath(), acc)
+	return filepath.Join(c.AccountsPath(), acc)
 }
 
 // AccountKeysPath returns the OS dependent path to the keys of a particular account
 func (c *Configuration) AccountKeysPath(acc string) string {
-	return path.Join(c.AccountPath(acc), "keys")
+	return filepath.Join(c.AccountPath(acc), "keys")
 }

--- a/configuration.go
+++ b/configuration.go
@@ -11,6 +11,11 @@ import (
 	"github.com/xenolf/lego/acme"
 )
 
+var pathReplacer = strings.NewReplacer(
+	":", "_",
+	"/", string(os.PathSeparator),
+)
+
 // Configuration type from CLI and config files.
 type Configuration struct {
 	context *cli.Context
@@ -50,8 +55,7 @@ func (c *Configuration) ExcludedSolvers() (cc []acme.Challenge) {
 // ServerPath returns the OS dependent path to the data for a specific CA
 func (c *Configuration) ServerPath() string {
 	srv, _ := url.Parse(c.context.GlobalString("server"))
-	srvStr := strings.Replace(srv.Host, ":", "_", -1)
-	return strings.Replace(srvStr, "/", string(os.PathSeparator), -1)
+	return pathReplacer.Replace(srv.Host)
 }
 
 // CertPath gets the path for certificates.

--- a/providers/http/webroot/webroot.go
+++ b/providers/http/webroot/webroot.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/xenolf/lego/acme"
 )
@@ -32,8 +32,8 @@ func NewHTTPProvider(path string) (*HTTPProvider, error) {
 func (w *HTTPProvider) Present(domain, token, keyAuth string) error {
 	var err error
 
-	challengeFilePath := path.Join(w.path, acme.HTTP01ChallengePath(token))
-	err = os.MkdirAll(path.Dir(challengeFilePath), 0755)
+	challengeFilePath := filepath.Join(w.path, acme.HTTP01ChallengePath(token))
+	err = os.MkdirAll(filepath.Dir(challengeFilePath), 0755)
 	if err != nil {
 		return fmt.Errorf("could not create required directories in webroot for HTTP challenge -> %v", err)
 	}
@@ -48,7 +48,7 @@ func (w *HTTPProvider) Present(domain, token, keyAuth string) error {
 
 // CleanUp removes the file created for the challenge
 func (w *HTTPProvider) CleanUp(domain, token, keyAuth string) error {
-	err := os.Remove(path.Join(w.path, acme.HTTP01ChallengePath(token)))
+	err := os.Remove(filepath.Join(w.path, acme.HTTP01ChallengePath(token)))
 	if err != nil {
 		return fmt.Errorf("could not remove file in webroot after HTTP challenge -> %v", err)
 	}


### PR DESCRIPTION
The path is a package to manipulate pseudo paths. use path/filepath for physical paths. For example, backslash and slash is contained both in `--path` usage.