### PR TITLE
Allow to configure TTL, interval and timeout

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -522,6 +522,8 @@
     "github.com/OpenDNS/vegadns2client",
     "github.com/akamai/AkamaiOPEN-edgegrid-golang/configdns-v1",
     "github.com/akamai/AkamaiOPEN-edgegrid-golang/edgegrid",
+    "github.com/aliyun/alibaba-cloud-sdk-go/sdk",
+    "github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials",
     "github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests",
     "github.com/aliyun/alibaba-cloud-sdk-go/services/alidns",
     "github.com/aws/aws-sdk-go/aws",

--- a/acme/dns_challenge.go
+++ b/acme/dns_challenge.go
@@ -24,6 +24,14 @@ var (
 
 const defaultResolvConf = "/etc/resolv.conf"
 
+const (
+	// DefaultPropagationTimeout default propagation timeout
+	DefaultPropagationTimeout = 60 * time.Second
+
+	// DefaultPollingInterval default polling interval
+	DefaultPollingInterval = 2 * time.Second
+)
+
 var defaultNameservers = []string{
 	"google-public-dns-a.google.com:53",
 	"google-public-dns-b.google.com:53",
@@ -112,7 +120,7 @@ func (s *dnsChallenge) Solve(chlng challenge, domain string) error {
 	case ChallengeProviderTimeout:
 		timeout, interval = provider.Timeout()
 	default:
-		timeout, interval = 60*time.Second, 2*time.Second
+		timeout, interval = DefaultPropagationTimeout, DefaultPollingInterval
 	}
 
 	err = WaitFor(timeout, interval, func() (bool, error) {

--- a/platform/config/env/env.go
+++ b/platform/config/env/env.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Get environment variables
@@ -31,6 +32,39 @@ func Get(names ...string) (map[string]string, error) {
 // Returns the default if the envvar cannot be coopered to an int, or is not found.
 func GetOrDefaultInt(envVar string, defaultValue int) int {
 	v, err := strconv.Atoi(os.Getenv(envVar))
+	if err != nil {
+		return defaultValue
+	}
+
+	return v
+}
+
+// GetOrDefaultSecond returns the given environment variable value as an time.Duration (second).
+// Returns the default if the envvar cannot be coopered to an int, or is not found.
+func GetOrDefaultSecond(envVar string, defaultValue time.Duration) time.Duration {
+	v := GetOrDefaultInt(envVar, -1)
+	if v < 0 {
+		return defaultValue
+	}
+
+	return time.Duration(v) * time.Second
+}
+
+// GetOrDefaultString returns the given environment variable value as a string.
+// Returns the default if the envvar cannot be find.
+func GetOrDefaultString(envVar string, defaultValue string) string {
+	v := os.Getenv(envVar)
+	if len(v) == 0 {
+		return defaultValue
+	}
+
+	return v
+}
+
+// GetOrDefaultBool returns the given environment variable value as a boolean.
+// Returns the default if the envvar cannot be coopered to a boolean, or is not found.
+func GetOrDefaultBool(envVar string, defaultValue bool) bool {
+	v, err := strconv.ParseBool(os.Getenv(envVar))
 	if err != nil {
 		return defaultValue
 	}

--- a/platform/config/env/env_test.go
+++ b/platform/config/env/env_test.go
@@ -3,12 +3,13 @@ package env
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func Test_GetOrDefaultInt(t *testing.T) {
+func TestGetOrDefaultInt(t *testing.T) {
 	testCases := []struct {
 		desc         string
 		envValue     string
@@ -51,6 +52,127 @@ func Test_GetOrDefaultInt(t *testing.T) {
 
 			result := GetOrDefaultInt(key, test.defaultValue)
 			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestGetOrDefaultSecond(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		envValue     string
+		defaultValue time.Duration
+		expected     time.Duration
+	}{
+		{
+			desc:         "valid value",
+			envValue:     "100",
+			defaultValue: 2 * time.Second,
+			expected:     100 * time.Second,
+		},
+		{
+			desc:         "invalid content, use default value",
+			envValue:     "abc123",
+			defaultValue: 2 * time.Second,
+			expected:     2 * time.Second,
+		},
+		{
+			desc:         "invalid content, negative value",
+			envValue:     "-111",
+			defaultValue: 2 * time.Second,
+			expected:     2 * time.Second,
+		},
+		{
+			desc:         "float: invalid type, use default value",
+			envValue:     "1.11",
+			defaultValue: 2 * time.Second,
+			expected:     2 * time.Second,
+		},
+	}
+
+	var key = "LEGO_ENV_TC"
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			defer os.Unsetenv(key)
+			err := os.Setenv(key, test.envValue)
+			require.NoError(t, err)
+
+			result := GetOrDefaultSecond(key, test.defaultValue)
+			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+func TestGetOrDefaultString(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		envValue     string
+		defaultValue string
+		expected     string
+	}{
+		{
+			desc:         "missing env var",
+			defaultValue: "foo",
+			expected:     "foo",
+		},
+		{
+			desc:         "with env var",
+			envValue:     "bar",
+			defaultValue: "foo",
+			expected:     "bar",
+		},
+	}
+
+	var key = "LEGO_ENV_TC"
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			defer os.Unsetenv(key)
+			err := os.Setenv(key, test.envValue)
+			require.NoError(t, err)
+
+			actual := GetOrDefaultString(key, test.defaultValue)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestGetOrDefaultBool(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		envValue     string
+		defaultValue bool
+		expected     bool
+	}{
+		{
+			desc:         "missing env var",
+			defaultValue: true,
+			expected:     true,
+		},
+		{
+			desc:         "with env var",
+			envValue:     "true",
+			defaultValue: false,
+			expected:     true,
+		},
+		{
+			desc:         "invalid value",
+			envValue:     "foo",
+			defaultValue: false,
+			expected:     false,
+		},
+	}
+
+	var key = "LEGO_ENV_TC"
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			defer os.Unsetenv(key)
+			err := os.Setenv(key, test.envValue)
+			require.NoError(t, err)
+
+			actual := GetOrDefaultBool(key, test.defaultValue)
+			assert.Equal(t, test.expected, actual)
 		})
 	}
 }

--- a/providers/dns/alidns/alidns_test.go
+++ b/providers/dns/alidns/alidns_test.go
@@ -35,7 +35,11 @@ func TestNewDNSProviderValid(t *testing.T) {
 	os.Setenv("ALICLOUD_ACCESS_KEY", "")
 	os.Setenv("ALICLOUD_SECRET_KEY", "")
 
-	_, err := NewDNSProviderCredentials("123", "123", "")
+	config := NewDefaultConfig()
+	config.APIKey = "123"
+	config.SecretKey = "123"
+
+	_, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 }
 
@@ -54,7 +58,7 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	os.Setenv("ALICLOUD_SECRET_KEY", "")
 
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "AliDNS: some credentials information are missing: ALICLOUD_ACCESS_KEY,ALICLOUD_SECRET_KEY")
+	assert.EqualError(t, err, "alicloud: some credentials information are missing: ALICLOUD_ACCESS_KEY,ALICLOUD_SECRET_KEY")
 }
 
 func TestCloudXNSPresent(t *testing.T) {
@@ -62,7 +66,11 @@ func TestCloudXNSPresent(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	provider, err := NewDNSProviderCredentials(alidnsAPIKey, alidnsSecretKey, "")
+	config := NewDefaultConfig()
+	config.APIKey = alidnsAPIKey
+	config.SecretKey = alidnsSecretKey
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	err = provider.Present(alidnsDomain, "", "123d==")
@@ -75,7 +83,12 @@ func TestLivednspodCleanUp(t *testing.T) {
 	}
 
 	time.Sleep(time.Second * 1)
-	provider, err := NewDNSProviderCredentials(alidnsAPIKey, alidnsSecretKey, "")
+
+	config := NewDefaultConfig()
+	config.APIKey = alidnsAPIKey
+	config.SecretKey = alidnsSecretKey
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 	err = provider.CleanUp(alidnsDomain, "", "123d==")
 	assert.NoError(t, err)

--- a/providers/dns/auroradns/auroradns_test.go
+++ b/providers/dns/auroradns/auroradns_test.go
@@ -48,11 +48,16 @@ func TestAuroraDNSPresent(t *testing.T) {
 
 	defer mock.Close()
 
-	auroraProvider, err := NewDNSProviderCredentials(mock.URL, fakeAuroraDNSUserID, fakeAuroraDNSKey)
-	require.NoError(t, err)
-	require.NotNil(t, auroraProvider)
+	config := NewDefaultConfig()
+	config.UserID = fakeAuroraDNSUserID
+	config.Key = fakeAuroraDNSKey
+	config.BaseURL = mock.URL
 
-	err = auroraProvider.Present("example.com", "", "foobar")
+	provider, err := NewDNSProviderConfig(config)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	err = provider.Present("example.com", "", "foobar")
 	require.NoError(t, err, "fail to create TXT record")
 
 	assert.True(t, requestReceived, "Expected request to be received by mock backend, but it wasn't")
@@ -93,14 +98,19 @@ func TestAuroraDNSCleanUp(t *testing.T) {
 	}))
 	defer mock.Close()
 
-	auroraProvider, err := NewDNSProviderCredentials(mock.URL, fakeAuroraDNSUserID, fakeAuroraDNSKey)
-	require.NoError(t, err)
-	require.NotNil(t, auroraProvider)
+	config := NewDefaultConfig()
+	config.UserID = fakeAuroraDNSUserID
+	config.Key = fakeAuroraDNSKey
+	config.BaseURL = mock.URL
 
-	err = auroraProvider.Present("example.com", "", "foobar")
+	provider, err := NewDNSProviderConfig(config)
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	err = provider.Present("example.com", "", "foobar")
 	require.NoError(t, err, "fail to create TXT record")
 
-	err = auroraProvider.CleanUp("example.com", "", "foobar")
+	err = provider.CleanUp("example.com", "", "foobar")
 	require.NoError(t, err, "fail to remove TXT record")
 
 	assert.True(t, requestReceived, "Expected request to be received by mock backend, but it wasn't")

--- a/providers/dns/azure/azure.go
+++ b/providers/dns/azure/azure.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -19,14 +20,31 @@ import (
 	"github.com/xenolf/lego/platform/config/env"
 )
 
+// Config is used to configure the creation of the DNSProvider
+type Config struct {
+	ClientID           string
+	ClientSecret       string
+	SubscriptionID     string
+	TenantID           string
+	ResourceGroup      string
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+	TTL                int
+	HTTPClient         *http.Client
+}
+
+// NewDefaultConfig returns a default configuration for the DNSProvider
+func NewDefaultConfig() *Config {
+	return &Config{
+		TTL:                env.GetOrDefaultInt("AZURE_TTL", 60),
+		PropagationTimeout: env.GetOrDefaultSecond("AZURE_PROPAGATION_TIMEOUT", 2*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond("AZURE_POLLING_INTERVAL", 2*time.Second),
+	}
+}
+
 // DNSProvider is an implementation of the acme.ChallengeProvider interface
 type DNSProvider struct {
-	clientID       string
-	clientSecret   string
-	subscriptionID string
-	tenantID       string
-	resourceGroup  string
-	context        context.Context
+	config *Config
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for azure.
@@ -35,54 +53,66 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("AZURE_CLIENT_ID", "AZURE_CLIENT_SECRET", "AZURE_SUBSCRIPTION_ID", "AZURE_TENANT_ID", "AZURE_RESOURCE_GROUP")
 	if err != nil {
-		return nil, fmt.Errorf("Azure: %v", err)
+		return nil, fmt.Errorf("azure: %v", err)
 	}
 
-	return NewDNSProviderCredentials(
-		values["AZURE_CLIENT_ID"],
-		values["AZURE_CLIENT_SECRET"],
-		values["AZURE_SUBSCRIPTION_ID"],
-		values["AZURE_TENANT_ID"],
-		values["AZURE_RESOURCE_GROUP"],
-	)
+	config := NewDefaultConfig()
+	config.ClientID = values["AZURE_CLIENT_ID"]
+	config.ClientSecret = values["AZURE_CLIENT_SECRET"]
+	config.SubscriptionID = values["AZURE_SUBSCRIPTION_ID"]
+	config.TenantID = values["AZURE_TENANT_ID"]
+	config.ResourceGroup = values["AZURE_RESOURCE_GROUP"]
+
+	return NewDNSProviderConfig(config)
 }
 
-// NewDNSProviderCredentials uses the supplied credentials to return a
-// DNSProvider instance configured for azure.
+// NewDNSProviderCredentials uses the supplied credentials
+// to return a DNSProvider instance configured for azure.
+// Deprecated
 func NewDNSProviderCredentials(clientID, clientSecret, subscriptionID, tenantID, resourceGroup string) (*DNSProvider, error) {
-	if clientID == "" || clientSecret == "" || subscriptionID == "" || tenantID == "" || resourceGroup == "" {
-		return nil, errors.New("Azure: some credentials information are missing")
+	config := NewDefaultConfig()
+	config.ClientID = clientID
+	config.ClientSecret = clientSecret
+	config.SubscriptionID = subscriptionID
+	config.TenantID = tenantID
+	config.ResourceGroup = resourceGroup
+
+	return NewDNSProviderConfig(config)
+}
+
+// NewDNSProviderConfig return a DNSProvider instance configured for Azure.
+func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
+	if config == nil {
+		return nil, errors.New("azure: the configuration of the DNS provider is nil")
 	}
 
-	return &DNSProvider{
-		clientID:       clientID,
-		clientSecret:   clientSecret,
-		subscriptionID: subscriptionID,
-		tenantID:       tenantID,
-		resourceGroup:  resourceGroup,
-		// TODO: A timeout can be added here for cancellation purposes.
-		context: context.Background(),
-	}, nil
+	if config.ClientID == "" || config.ClientSecret == "" || config.SubscriptionID == "" || config.TenantID == "" || config.ResourceGroup == "" {
+		return nil, errors.New("azure: some credentials information are missing")
+	}
+
+	return &DNSProvider{config: config}, nil
 }
 
 // Timeout returns the timeout and interval to use when checking for DNS
 // propagation. Adjusting here to cope with spikes in propagation times.
 func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
-	return 120 * time.Second, 2 * time.Second
+	return d.config.PropagationTimeout, d.config.PollingInterval
 }
 
 // Present creates a TXT record to fulfil the dns-01 challenge
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
+	ctx := context.Background()
 	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
-	zone, err := d.getHostedZoneID(fqdn)
+
+	zone, err := d.getHostedZoneID(ctx, fqdn)
 	if err != nil {
-		return err
+		return fmt.Errorf("azure: %v", err)
 	}
 
-	rsc := dns.NewRecordSetsClient(d.subscriptionID)
-	spt, err := d.newServicePrincipalTokenFromCredentials(azure.PublicCloud.ResourceManagerEndpoint)
+	rsc := dns.NewRecordSetsClient(d.config.SubscriptionID)
+	spt, err := d.newServicePrincipalToken(azure.PublicCloud.ResourceManagerEndpoint)
 	if err != nil {
-		return err
+		return fmt.Errorf("azure: %v", err)
 	}
 
 	rsc.Authorizer = autorest.NewBearerAuthorizer(spt)
@@ -91,59 +121,55 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	rec := dns.RecordSet{
 		Name: &relative,
 		RecordSetProperties: &dns.RecordSetProperties{
-			TTL:        to.Int64Ptr(60),
+			TTL:        to.Int64Ptr(int64(d.config.TTL)),
 			TxtRecords: &[]dns.TxtRecord{{Value: &[]string{value}}},
 		},
 	}
 
-	_, err = rsc.CreateOrUpdate(d.context, d.resourceGroup, zone, relative, dns.TXT, rec, "", "")
-	return err
-}
-
-// Returns the relative record to the domain
-func toRelativeRecord(domain, zone string) string {
-	return acme.UnFqdn(strings.TrimSuffix(domain, zone))
+	_, err = rsc.CreateOrUpdate(ctx, d.config.ResourceGroup, zone, relative, dns.TXT, rec, "", "")
+	return fmt.Errorf("azure: %v", err)
 }
 
 // CleanUp removes the TXT record matching the specified parameters
 func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
+	ctx := context.Background()
 	fqdn, _, _ := acme.DNS01Record(domain, keyAuth)
 
-	zone, err := d.getHostedZoneID(fqdn)
+	zone, err := d.getHostedZoneID(ctx, fqdn)
 	if err != nil {
-		return err
+		return fmt.Errorf("azure: %v", err)
 	}
 
 	relative := toRelativeRecord(fqdn, acme.ToFqdn(zone))
-	rsc := dns.NewRecordSetsClient(d.subscriptionID)
-	spt, err := d.newServicePrincipalTokenFromCredentials(azure.PublicCloud.ResourceManagerEndpoint)
+	rsc := dns.NewRecordSetsClient(d.config.SubscriptionID)
+	spt, err := d.newServicePrincipalToken(azure.PublicCloud.ResourceManagerEndpoint)
 	if err != nil {
-		return err
+		return fmt.Errorf("azure: %v", err)
 	}
 
 	rsc.Authorizer = autorest.NewBearerAuthorizer(spt)
 
-	_, err = rsc.Delete(d.context, d.resourceGroup, zone, relative, dns.TXT, "")
-	return err
+	_, err = rsc.Delete(ctx, d.config.ResourceGroup, zone, relative, dns.TXT, "")
+	return fmt.Errorf("azure: %v", err)
 }
 
 // Checks that azure has a zone for this domain name.
-func (d *DNSProvider) getHostedZoneID(fqdn string) (string, error) {
+func (d *DNSProvider) getHostedZoneID(ctx context.Context, fqdn string) (string, error) {
 	authZone, err := acme.FindZoneByFqdn(fqdn, acme.RecursiveNameservers)
 	if err != nil {
 		return "", err
 	}
 
 	// Now we want to to Azure and get the zone.
-	spt, err := d.newServicePrincipalTokenFromCredentials(azure.PublicCloud.ResourceManagerEndpoint)
+	spt, err := d.newServicePrincipalToken(azure.PublicCloud.ResourceManagerEndpoint)
 	if err != nil {
 		return "", err
 	}
 
-	dc := dns.NewZonesClient(d.subscriptionID)
+	dc := dns.NewZonesClient(d.config.SubscriptionID)
 	dc.Authorizer = autorest.NewBearerAuthorizer(spt)
 
-	zone, err := dc.Get(d.context, d.resourceGroup, acme.UnFqdn(authZone))
+	zone, err := dc.Get(ctx, d.config.ResourceGroup, acme.UnFqdn(authZone))
 	if err != nil {
 		return "", err
 	}
@@ -154,10 +180,15 @@ func (d *DNSProvider) getHostedZoneID(fqdn string) (string, error) {
 
 // NewServicePrincipalTokenFromCredentials creates a new ServicePrincipalToken using values of the
 // passed credentials map.
-func (d *DNSProvider) newServicePrincipalTokenFromCredentials(scope string) (*adal.ServicePrincipalToken, error) {
-	oauthConfig, err := adal.NewOAuthConfig(azure.PublicCloud.ActiveDirectoryEndpoint, d.tenantID)
+func (d *DNSProvider) newServicePrincipalToken(scope string) (*adal.ServicePrincipalToken, error) {
+	oauthConfig, err := adal.NewOAuthConfig(azure.PublicCloud.ActiveDirectoryEndpoint, d.config.TenantID)
 	if err != nil {
 		return nil, err
 	}
-	return adal.NewServicePrincipalToken(*oauthConfig, d.clientID, d.clientSecret, scope)
+	return adal.NewServicePrincipalToken(*oauthConfig, d.config.ClientID, d.config.ClientSecret, scope)
+}
+
+// Returns the relative record to the domain
+func toRelativeRecord(domain, zone string) string {
+	return acme.UnFqdn(strings.TrimSuffix(domain, zone))
 }

--- a/providers/dns/azure/azure_test.go
+++ b/providers/dns/azure/azure_test.go
@@ -43,7 +43,14 @@ func TestNewDNSProviderValid(t *testing.T) {
 	defer restoreEnv()
 	os.Setenv("AZURE_CLIENT_ID", "")
 
-	_, err := NewDNSProviderCredentials(azureClientID, azureClientSecret, azureSubscriptionID, azureTenantID, azureResourceGroup)
+	config := NewDefaultConfig()
+	config.ClientID = azureClientID
+	config.ClientSecret = azureClientSecret
+	config.SubscriptionID = azureSubscriptionID
+	config.TenantID = azureTenantID
+	config.ResourceGroup = azureResourceGroup
+
+	_, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 }
 
@@ -64,7 +71,7 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	os.Setenv("AZURE_SUBSCRIPTION_ID", "")
 
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "Azure: some credentials information are missing: AZURE_CLIENT_ID,AZURE_CLIENT_SECRET,AZURE_SUBSCRIPTION_ID,AZURE_TENANT_ID,AZURE_RESOURCE_GROUP")
+	assert.EqualError(t, err, "azure: some credentials information are missing: AZURE_CLIENT_ID,AZURE_CLIENT_SECRET,AZURE_SUBSCRIPTION_ID,AZURE_TENANT_ID,AZURE_RESOURCE_GROUP")
 }
 
 func TestLiveAzurePresent(t *testing.T) {
@@ -72,7 +79,14 @@ func TestLiveAzurePresent(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	provider, err := NewDNSProviderCredentials(azureClientID, azureClientSecret, azureSubscriptionID, azureTenantID, azureResourceGroup)
+	config := NewDefaultConfig()
+	config.ClientID = azureClientID
+	config.ClientSecret = azureClientSecret
+	config.SubscriptionID = azureSubscriptionID
+	config.TenantID = azureTenantID
+	config.ResourceGroup = azureResourceGroup
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	err = provider.Present(azureDomain, "", "123d==")
@@ -84,7 +98,15 @@ func TestLiveAzureCleanUp(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	provider, err := NewDNSProviderCredentials(azureClientID, azureClientSecret, azureSubscriptionID, azureTenantID, azureResourceGroup)
+	config := NewDefaultConfig()
+	config.ClientID = azureClientID
+	config.ClientSecret = azureClientSecret
+	config.SubscriptionID = azureSubscriptionID
+	config.TenantID = azureTenantID
+	config.ResourceGroup = azureResourceGroup
+
+	provider, err := NewDNSProviderConfig(config)
+
 	time.Sleep(time.Second * 1)
 
 	assert.NoError(t, err)

--- a/providers/dns/bluecat/bluecat.go
+++ b/providers/dns/bluecat/bluecat.go
@@ -5,6 +5,7 @@ package bluecat
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -17,91 +18,221 @@ import (
 	"github.com/xenolf/lego/platform/config/env"
 )
 
-const bluecatURLTemplate = "%s/Services/REST/v1"
 const configType = "Configuration"
 const viewType = "View"
 const txtType = "TXTRecord"
 const zoneType = "Zone"
 
-type entityResponse struct {
-	ID         uint   `json:"id"`
-	Name       string `json:"name"`
-	Type       string `json:"type"`
-	Properties string `json:"properties"`
+// Config is used to configure the creation of the DNSProvider
+type Config struct {
+	BaseURL            string
+	UserName           string
+	Password           string
+	ConfigName         string
+	DNSView            string
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+	TTL                int
+	HTTPClient         *http.Client
+}
+
+// NewDefaultConfig returns a default configuration for the DNSProvider
+func NewDefaultConfig() *Config {
+	return &Config{
+		TTL:                env.GetOrDefaultInt("BLUECAT_TTL", 120),
+		PropagationTimeout: env.GetOrDefaultSecond("BLUECAT_PROPAGATION_TIMEOUT", acme.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond("BLUECAT_POLLING_INTERVAL", acme.DefaultPollingInterval),
+		HTTPClient: &http.Client{
+			Timeout: env.GetOrDefaultSecond("BLUECAT_HTTP_TIMEOUT", 30*time.Second),
+		},
+	}
 }
 
 // DNSProvider is an implementation of the acme.ChallengeProvider interface that uses
 // Bluecat's Address Manager REST API to manage TXT records for a domain.
 type DNSProvider struct {
-	baseURL    string
-	userName   string
-	password   string
-	configName string
-	dnsView    string
-	token      string
-	client     *http.Client
+	config *Config
+	token  string
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for Bluecat DNS.
-// Credentials must be passed in the environment variables: BLUECAT_SERVER_URL,
-// BLUECAT_USER_NAME and BLUECAT_PASSWORD. BLUECAT_SERVER_URL should have the
-// scheme, hostname, and port (if required) of the authoritative Bluecat BAM
-// server. The REST endpoint will be appended. In addition, the Configuration name
-// and external DNS View Name must be passed in BLUECAT_CONFIG_NAME and
-// BLUECAT_DNS_VIEW
+// Credentials must be passed in the environment variables: BLUECAT_SERVER_URL, BLUECAT_USER_NAME and BLUECAT_PASSWORD.
+// BLUECAT_SERVER_URL should have the scheme, hostname, and port (if required) of the authoritative Bluecat BAM server.
+// The REST endpoint will be appended. In addition, the Configuration name
+// and external DNS View Name must be passed in BLUECAT_CONFIG_NAME and BLUECAT_DNS_VIEW
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("BLUECAT_SERVER_URL", "BLUECAT_USER_NAME", "BLUECAT_CONFIG_NAME", "BLUECAT_CONFIG_NAME", "BLUECAT_DNS_VIEW")
 	if err != nil {
-		return nil, fmt.Errorf("BlueCat: %v", err)
+		return nil, fmt.Errorf("bluecat: %v", err)
 	}
 
-	httpClient := &http.Client{Timeout: 30 * time.Second}
+	config := NewDefaultConfig()
+	config.BaseURL = values["BLUECAT_SERVER_URL"]
+	config.UserName = values["BLUECAT_USER_NAME"]
+	config.Password = values["BLUECAT_PASSWORD"]
+	config.ConfigName = values["BLUECAT_CONFIG_NAME"]
+	config.DNSView = values["BLUECAT_DNS_VIEW"]
 
-	return NewDNSProviderCredentials(
-		values["BLUECAT_SERVER_URL"],
-		values["BLUECAT_USER_NAME"],
-		values["BLUECAT_PASSWORD"],
-		values["BLUECAT_CONFIG_NAME"],
-		values["BLUECAT_DNS_VIEW"],
-		httpClient,
-	)
+	return NewDNSProviderConfig(config)
 }
 
-// NewDNSProviderCredentials uses the supplied credentials to return a
-// DNSProvider instance configured for Bluecat DNS.
-func NewDNSProviderCredentials(server, userName, password, configName, dnsView string, httpClient *http.Client) (*DNSProvider, error) {
-	if server == "" || userName == "" || password == "" || configName == "" || dnsView == "" {
-		return nil, fmt.Errorf("Bluecat credentials missing")
-	}
+// NewDNSProviderCredentials uses the supplied credentials
+// to return a DNSProvider instance configured for Bluecat DNS.
+// Deprecated
+func NewDNSProviderCredentials(baseURL, userName, password, configName, dnsView string, httpClient *http.Client) (*DNSProvider, error) {
+	config := NewDefaultConfig()
+	config.BaseURL = baseURL
+	config.UserName = userName
+	config.Password = password
+	config.ConfigName = configName
+	config.DNSView = dnsView
 
-	client := http.DefaultClient
 	if httpClient != nil {
-		client = httpClient
+		config.HTTPClient = httpClient
 	}
 
-	return &DNSProvider{
-		baseURL:    fmt.Sprintf(bluecatURLTemplate, server),
-		userName:   userName,
-		password:   password,
-		configName: configName,
-		dnsView:    dnsView,
-		client:     client,
-	}, nil
+	return NewDNSProviderConfig(config)
+}
+
+// NewDNSProviderConfig return a DNSProvider instance configured for Bluecat DNS.
+func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
+	if config == nil {
+		return nil, errors.New("bluecat: the configuration of the DNS provider is nil")
+	}
+
+	if config.BaseURL == "" || config.UserName == "" || config.Password == "" || config.ConfigName == "" || config.DNSView == "" {
+		return nil, fmt.Errorf("bluecat: credentials missing")
+	}
+
+	return &DNSProvider{config: config}, nil
+}
+
+// Present creates a TXT record using the specified parameters
+// This will *not* create a subzone to contain the TXT record,
+// so make sure the FQDN specified is within an extant zone.
+func (d *DNSProvider) Present(domain, token, keyAuth string) error {
+	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
+
+	err := d.login()
+	if err != nil {
+		return err
+	}
+
+	viewID, err := d.lookupViewID(d.config.DNSView)
+	if err != nil {
+		return err
+	}
+
+	parentZoneID, name, err := d.lookupParentZoneID(viewID, fqdn)
+	if err != nil {
+		return err
+	}
+
+	queryArgs := map[string]string{
+		"parentId": strconv.FormatUint(uint64(parentZoneID), 10),
+	}
+
+	body := bluecatEntity{
+		Name:       name,
+		Type:       "TXTRecord",
+		Properties: fmt.Sprintf("ttl=%d|absoluteName=%s|txt=%s|", d.config.TTL, fqdn, value),
+	}
+
+	resp, err := d.sendRequest(http.MethodPost, "addEntity", body, queryArgs)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	addTxtBytes, _ := ioutil.ReadAll(resp.Body)
+	addTxtResp := string(addTxtBytes)
+	// addEntity responds only with body text containing the ID of the created record
+	_, err = strconv.ParseUint(addTxtResp, 10, 64)
+	if err != nil {
+		return fmt.Errorf("bluecat: addEntity request failed: %s", addTxtResp)
+	}
+
+	err = d.deploy(parentZoneID)
+	if err != nil {
+		return err
+	}
+
+	return d.logout()
+}
+
+// CleanUp removes the TXT record matching the specified parameters
+func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
+	fqdn, _, _ := acme.DNS01Record(domain, keyAuth)
+
+	err := d.login()
+	if err != nil {
+		return err
+	}
+
+	viewID, err := d.lookupViewID(d.config.DNSView)
+	if err != nil {
+		return err
+	}
+
+	parentID, name, err := d.lookupParentZoneID(viewID, fqdn)
+	if err != nil {
+		return err
+	}
+
+	queryArgs := map[string]string{
+		"parentId": strconv.FormatUint(uint64(parentID), 10),
+		"name":     name,
+		"type":     txtType,
+	}
+
+	resp, err := d.sendRequest(http.MethodGet, "getEntityByName", nil, queryArgs)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var txtRec entityResponse
+	err = json.NewDecoder(resp.Body).Decode(&txtRec)
+	if err != nil {
+		return fmt.Errorf("bluecat: %v", err)
+	}
+	queryArgs = map[string]string{
+		"objectId": strconv.FormatUint(uint64(txtRec.ID), 10),
+	}
+
+	resp, err = d.sendRequest(http.MethodDelete, http.MethodDelete, nil, queryArgs)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	err = d.deploy(parentID)
+	if err != nil {
+		return err
+	}
+
+	return d.logout()
+}
+
+// Timeout returns the timeout and interval to use when checking for DNS propagation.
+// Adjusting here to cope with spikes in propagation times.
+func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
+	return d.config.PropagationTimeout, d.config.PollingInterval
 }
 
 // Send a REST request, using query parameters specified. The Authorization
 // header will be set if we have an active auth token
 func (d *DNSProvider) sendRequest(method, resource string, payload interface{}, queryArgs map[string]string) (*http.Response, error) {
-	url := fmt.Sprintf("%s/%s", d.baseURL, resource)
+	url := fmt.Sprintf("%s/Services/REST/v1/%s", d.config.BaseURL, resource)
 
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("bluecat: %v", err)
 	}
 
 	req, err := http.NewRequest(method, url, bytes.NewReader(body))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("bluecat: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	if len(d.token) > 0 {
@@ -114,15 +245,15 @@ func (d *DNSProvider) sendRequest(method, resource string, payload interface{}, 
 		q.Add(argName, argVal)
 	}
 	req.URL.RawQuery = q.Encode()
-	resp, err := d.client.Do(req)
+	resp, err := d.config.HTTPClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("bluecat: %v", err)
 	}
 
 	if resp.StatusCode >= 400 {
 		errBytes, _ := ioutil.ReadAll(resp.Body)
 		errResp := string(errBytes)
-		return nil, fmt.Errorf("Bluecat API request failed with HTTP status code %d\n Full message: %s",
+		return nil, fmt.Errorf("bluecat: request failed with HTTP status code %d\n Full message: %s",
 			resp.StatusCode, errResp)
 	}
 
@@ -133,8 +264,8 @@ func (d *DNSProvider) sendRequest(method, resource string, payload interface{}, 
 // password and receives a token to be used in for subsequent requests.
 func (d *DNSProvider) login() error {
 	queryArgs := map[string]string{
-		"username": d.userName,
-		"password": d.password,
+		"username": d.config.UserName,
+		"password": d.config.Password,
 	}
 
 	resp, err := d.sendRequest(http.MethodGet, "login", nil, queryArgs)
@@ -145,18 +276,16 @@ func (d *DNSProvider) login() error {
 
 	authBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return err
+		return fmt.Errorf("bluecat: %v", err)
 	}
 	authResp := string(authBytes)
 
 	if strings.Contains(authResp, "Authentication Error") {
 		msg := strings.Trim(authResp, "\"")
-		return fmt.Errorf("Bluecat API request failed: %s", msg)
+		return fmt.Errorf("bluecat: request failed: %s", msg)
 	}
 	// Upon success, API responds with "Session Token-> BAMAuthToken: dQfuRMTUxNjc3MjcyNDg1ODppcGFybXM= <- for User : username"
-	re := regexp.MustCompile("BAMAuthToken: [^ ]+")
-	token := re.FindString(authResp)
-	d.token = token
+	d.token = regexp.MustCompile("BAMAuthToken: [^ ]+").FindString(authResp)
 	return nil
 }
 
@@ -174,7 +303,7 @@ func (d *DNSProvider) logout() error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("Bluecat API request failed to delete session with HTTP status code %d", resp.StatusCode)
+		return fmt.Errorf("bluecat: request failed to delete session with HTTP status code %d", resp.StatusCode)
 	}
 
 	authBytes, err := ioutil.ReadAll(resp.Body)
@@ -185,7 +314,7 @@ func (d *DNSProvider) logout() error {
 
 	if !strings.Contains(authResp, "successfully") {
 		msg := strings.Trim(authResp, "\"")
-		return fmt.Errorf("Bluecat API request failed to delete session: %s", msg)
+		return fmt.Errorf("bluecat: request failed to delete session: %s", msg)
 	}
 
 	d.token = ""
@@ -197,7 +326,7 @@ func (d *DNSProvider) logout() error {
 func (d *DNSProvider) lookupConfID() (uint, error) {
 	queryArgs := map[string]string{
 		"parentId": strconv.Itoa(0),
-		"name":     d.configName,
+		"name":     d.config.ConfigName,
 		"type":     configType,
 	}
 
@@ -210,7 +339,7 @@ func (d *DNSProvider) lookupConfID() (uint, error) {
 	var conf entityResponse
 	err = json.NewDecoder(resp.Body).Decode(&conf)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("bluecat: %v", err)
 	}
 	return conf.ID, nil
 }
@@ -224,7 +353,7 @@ func (d *DNSProvider) lookupViewID(viewName string) (uint, error) {
 
 	queryArgs := map[string]string{
 		"parentId": strconv.FormatUint(uint64(confID), 10),
-		"name":     d.dnsView,
+		"name":     d.config.DNSView,
 		"type":     viewType,
 	}
 
@@ -237,7 +366,7 @@ func (d *DNSProvider) lookupViewID(viewName string) (uint, error) {
 	var view entityResponse
 	err = json.NewDecoder(resp.Body).Decode(&view)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("bluecat: %v", err)
 	}
 
 	return view.ID, nil
@@ -280,7 +409,7 @@ func (d *DNSProvider) getZone(parentID uint, name string) (uint, error) {
 	resp, err := d.sendRequest(http.MethodGet, "getEntityByName", nil, queryArgs)
 	// Return an empty zone if the named zone doesn't exist
 	if resp != nil && resp.StatusCode == 404 {
-		return 0, fmt.Errorf("Bluecat API could not find zone named %s", name)
+		return 0, fmt.Errorf("bluecat: could not find zone named %s", name)
 	}
 	if err != nil {
 		return 0, err
@@ -290,63 +419,10 @@ func (d *DNSProvider) getZone(parentID uint, name string) (uint, error) {
 	var zone entityResponse
 	err = json.NewDecoder(resp.Body).Decode(&zone)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("bluecat: %v", err)
 	}
 
 	return zone.ID, nil
-}
-
-// Present creates a TXT record using the specified parameters
-// This will *not* create a subzone to contain the TXT record,
-// so make sure the FQDN specified is within an extant zone.
-func (d *DNSProvider) Present(domain, token, keyAuth string) error {
-	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
-
-	err := d.login()
-	if err != nil {
-		return err
-	}
-
-	viewID, err := d.lookupViewID(d.dnsView)
-	if err != nil {
-		return err
-	}
-
-	parentZoneID, name, err := d.lookupParentZoneID(viewID, fqdn)
-	if err != nil {
-		return err
-	}
-
-	queryArgs := map[string]string{
-		"parentId": strconv.FormatUint(uint64(parentZoneID), 10),
-	}
-
-	body := bluecatEntity{
-		Name:       name,
-		Type:       "TXTRecord",
-		Properties: fmt.Sprintf("ttl=%d|absoluteName=%s|txt=%s|", ttl, fqdn, value),
-	}
-
-	resp, err := d.sendRequest(http.MethodPost, "addEntity", body, queryArgs)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	addTxtBytes, _ := ioutil.ReadAll(resp.Body)
-	addTxtResp := string(addTxtBytes)
-	// addEntity responds only with body text containing the ID of the created record
-	_, err = strconv.ParseUint(addTxtResp, 10, 64)
-	if err != nil {
-		return fmt.Errorf("Bluecat API addEntity request failed: %s", addTxtResp)
-	}
-
-	err = d.deploy(parentZoneID)
-	if err != nil {
-		return err
-	}
-
-	return d.logout()
 }
 
 // Deploy the DNS config for the specified entity to the authoritative servers
@@ -362,66 +438,4 @@ func (d *DNSProvider) deploy(entityID uint) error {
 	defer resp.Body.Close()
 
 	return nil
-}
-
-// CleanUp removes the TXT record matching the specified parameters
-func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
-	fqdn, _, _ := acme.DNS01Record(domain, keyAuth)
-
-	err := d.login()
-	if err != nil {
-		return err
-	}
-
-	viewID, err := d.lookupViewID(d.dnsView)
-	if err != nil {
-		return err
-	}
-
-	parentID, name, err := d.lookupParentZoneID(viewID, fqdn)
-	if err != nil {
-		return err
-	}
-
-	queryArgs := map[string]string{
-		"parentId": strconv.FormatUint(uint64(parentID), 10),
-		"name":     name,
-		"type":     txtType,
-	}
-
-	resp, err := d.sendRequest(http.MethodGet, "getEntityByName", nil, queryArgs)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	var txtRec entityResponse
-	err = json.NewDecoder(resp.Body).Decode(&txtRec)
-	if err != nil {
-		return err
-	}
-	queryArgs = map[string]string{
-		"objectId": strconv.FormatUint(uint64(txtRec.ID), 10),
-	}
-
-	resp, err = d.sendRequest(http.MethodDelete, http.MethodDelete, nil, queryArgs)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	err = d.deploy(parentID)
-	if err != nil {
-		return err
-	}
-
-	return d.logout()
-}
-
-// JSON body for Bluecat entity requests and responses
-type bluecatEntity struct {
-	ID         string `json:"id,omitempty"`
-	Name       string `json:"name"`
-	Type       string `json:"type"`
-	Properties string `json:"properties"`
 }

--- a/providers/dns/bluecat/client.go
+++ b/providers/dns/bluecat/client.go
@@ -1,0 +1,16 @@
+package bluecat
+
+// JSON body for Bluecat entity requests and responses
+type bluecatEntity struct {
+	ID         string `json:"id,omitempty"`
+	Name       string `json:"name"`
+	Type       string `json:"type"`
+	Properties string `json:"properties"`
+}
+
+type entityResponse struct {
+	ID         uint   `json:"id"`
+	Name       string `json:"name"`
+	Type       string `json:"type"`
+	Properties string `json:"properties"`
+}

--- a/providers/dns/cloudflare/client.go
+++ b/providers/dns/cloudflare/client.go
@@ -1,0 +1,212 @@
+package cloudflare
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/xenolf/lego/acme"
+)
+
+// defaultBaseURL represents the API endpoint to call.
+const defaultBaseURL = "https://api.cloudflare.com/client/v4"
+
+// APIError contains error details for failed requests
+type APIError struct {
+	Code       int        `json:"code,omitempty"`
+	Message    string     `json:"message,omitempty"`
+	ErrorChain []APIError `json:"error_chain,omitempty"`
+}
+
+// APIResponse represents a response from Cloudflare API
+type APIResponse struct {
+	Success bool            `json:"success"`
+	Errors  []*APIError     `json:"errors"`
+	Result  json.RawMessage `json:"result"`
+}
+
+// TxtRecord represents a Cloudflare DNS record
+type TxtRecord struct {
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Content string `json:"content"`
+	ID      string `json:"id,omitempty"`
+	TTL     int    `json:"ttl,omitempty"`
+	ZoneID  string `json:"zone_id,omitempty"`
+}
+
+// HostedZone represents a Cloudflare DNS zone
+type HostedZone struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// Client Cloudflare API client
+type Client struct {
+	authEmail  string
+	authKey    string
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+// NewClient create a Cloudflare API client
+func NewClient(authEmail string, authKey string) (*Client, error) {
+	if authEmail == "" {
+		return nil, errors.New("cloudflare: some credentials information are missing: email")
+	}
+
+	if authKey == "" {
+		return nil, errors.New("cloudflare: some credentials information are missing: key")
+	}
+
+	return &Client{
+		authEmail:  authEmail,
+		authKey:    authKey,
+		BaseURL:    defaultBaseURL,
+		HTTPClient: http.DefaultClient,
+	}, nil
+}
+
+// GetHostedZoneID get hosted zone
+func (c *Client) GetHostedZoneID(fqdn string) (string, error) {
+	authZone, err := acme.FindZoneByFqdn(fqdn, acme.RecursiveNameservers)
+	if err != nil {
+		return "", err
+	}
+
+	result, err := c.doRequest(http.MethodGet, "/zones?name="+acme.UnFqdn(authZone), nil)
+	if err != nil {
+		return "", err
+	}
+
+	var hostedZone []HostedZone
+	err = json.Unmarshal(result, &hostedZone)
+	if err != nil {
+		return "", fmt.Errorf("cloudflare: HostedZone unmarshaling error: %v", err)
+	}
+
+	count := len(hostedZone)
+	if count == 0 {
+		return "", fmt.Errorf("cloudflare: zone %s not found for domain %s", authZone, fqdn)
+	} else if count > 1 {
+		return "", fmt.Errorf("cloudflare: zone %s cannot be find for domain %s: too many hostedZone: %v", authZone, fqdn, hostedZone)
+	}
+
+	return hostedZone[0].ID, nil
+}
+
+// FindTxtRecord Find a TXT record
+func (c *Client) FindTxtRecord(zoneID, fqdn string) (*TxtRecord, error) {
+	result, err := c.doRequest(
+		http.MethodGet,
+		fmt.Sprintf("/zones/%s/dns_records?per_page=1000&type=TXT&name=%s", zoneID, acme.UnFqdn(fqdn)),
+		nil,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var records []TxtRecord
+	err = json.Unmarshal(result, &records)
+	if err != nil {
+		return nil, fmt.Errorf("cloudflare: record unmarshaling error: %v", err)
+	}
+
+	for _, rec := range records {
+		fmt.Println(rec.Name, acme.UnFqdn(fqdn))
+		if rec.Name == acme.UnFqdn(fqdn) {
+			return &rec, nil
+		}
+	}
+
+	return nil, fmt.Errorf("cloudflare: no existing record found for %s", fqdn)
+}
+
+// AddTxtRecord add a TXT record
+func (c *Client) AddTxtRecord(fqdn string, record TxtRecord) error {
+	zoneID, err := c.GetHostedZoneID(fqdn)
+	if err != nil {
+		return err
+	}
+
+	body, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("cloudflare: record marshaling error: %v", err)
+	}
+
+	_, err = c.doRequest(http.MethodPost, fmt.Sprintf("/zones/%s/dns_records", zoneID), bytes.NewReader(body))
+	return err
+}
+
+// RemoveTxtRecord Remove a TXT record
+func (c *Client) RemoveTxtRecord(fqdn string) error {
+	zoneID, err := c.GetHostedZoneID(fqdn)
+	if err != nil {
+		return err
+	}
+
+	record, err := c.FindTxtRecord(zoneID, fqdn)
+	if err != nil {
+		return err
+	}
+
+	_, err = c.doRequest(http.MethodDelete, fmt.Sprintf("/zones/%s/dns_records/%s", record.ZoneID, record.ID), nil)
+	return err
+}
+
+func (c *Client) doRequest(method, uri string, body io.Reader) (json.RawMessage, error) {
+	req, err := http.NewRequest(method, fmt.Sprintf("%s%s", c.BaseURL, uri), body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("X-Auth-Email", c.authEmail)
+	req.Header.Set("X-Auth-Key", c.authKey)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cloudflare: error querying API: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	content, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("cloudflare: %s", toUnreadableBodyMessage(req, content))
+	}
+
+	var r APIResponse
+	err = json.Unmarshal(content, &r)
+	if err != nil {
+		return nil, fmt.Errorf("cloudflare: APIResponse unmarshaling error: %v: %s", err, toUnreadableBodyMessage(req, content))
+	}
+
+	if !r.Success {
+		if len(r.Errors) > 0 {
+			return nil, fmt.Errorf("cloudflare: error \n%s", toError(r))
+		}
+
+		return nil, fmt.Errorf("cloudflare: %s", toUnreadableBodyMessage(req, content))
+	}
+
+	return r.Result, nil
+}
+
+func toUnreadableBodyMessage(req *http.Request, rawBody []byte) string {
+	return fmt.Sprintf("the request %s sent a response with a body which is an invalid format: %q", req.URL, string(rawBody))
+}
+
+func toError(r APIResponse) error {
+	errStr := ""
+	for _, apiErr := range r.Errors {
+		errStr += fmt.Sprintf("\t Error: %d: %s", apiErr.Code, apiErr.Message)
+		for _, chainErr := range apiErr.ErrorChain {
+			errStr += fmt.Sprintf("<- %d: %s", chainErr.Code, chainErr.Message)
+		}
+	}
+	return fmt.Errorf("cloudflare: error \n%s", errStr)
+}

--- a/providers/dns/cloudflare/client_test.go
+++ b/providers/dns/cloudflare/client_test.go
@@ -1,0 +1,188 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func handlerMock(method string, response *APIResponse, data interface{}) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		if req.Method != method {
+			content, err := json.Marshal(APIResponse{
+				Success: false,
+				Errors: []*APIError{
+					{
+						Code:       666,
+						Message:    fmt.Sprintf("invalid method: got %s want %s", req.Method, method),
+						ErrorChain: nil,
+					},
+				},
+			})
+			if err != nil {
+				http.Error(rw, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			http.Error(rw, string(content), http.StatusBadRequest)
+			return
+		}
+
+		jsonData, err := json.Marshal(data)
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		response.Result = jsonData
+
+		content, err := json.Marshal(response)
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		rw.Write(content)
+	})
+}
+
+func TestClient_GetHostedZoneID(t *testing.T) {
+	type result struct {
+		zoneID string
+		error  bool
+	}
+
+	testCases := []struct {
+		desc     string
+		fqdn     string
+		response *APIResponse
+		data     []HostedZone
+		expected result
+	}{
+		{
+			desc:     "zone found",
+			fqdn:     "_acme-challenge.foo.com.",
+			response: &APIResponse{Success: true},
+			data: []HostedZone{
+				{
+					ID:   "A",
+					Name: "ZONE_A",
+				},
+			},
+			expected: result{zoneID: "A"},
+		},
+		{
+			desc:     "no many zones",
+			fqdn:     "_acme-challenge.foo.com.",
+			response: &APIResponse{Success: true},
+			data: []HostedZone{
+				{
+					ID:   "A",
+					Name: "ZONE_A",
+				},
+				{
+					ID:   "B",
+					Name: "ZONE_B",
+				},
+			},
+			expected: result{error: true},
+		},
+		{
+			desc:     "no zone found",
+			fqdn:     "_acme-challenge.foo.com.",
+			response: &APIResponse{Success: true},
+			expected: result{error: true},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			server := httptest.NewServer(handlerMock(http.MethodGet, test.response, test.data))
+
+			client, _ := NewClient("authEmail", "authKey")
+			client.BaseURL = server.URL
+
+			zoneID, err := client.GetHostedZoneID(test.fqdn)
+
+			if test.expected.error {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expected.zoneID, zoneID)
+			}
+		})
+	}
+}
+
+func TestClient_FindTxtRecord(t *testing.T) {
+	type result struct {
+		txtRecord *TxtRecord
+		error     bool
+	}
+
+	testCases := []struct {
+		desc     string
+		fqdn     string
+		zoneID   string
+		response *APIResponse
+		data     []TxtRecord
+		expected result
+	}{
+		{
+			desc:     "TXT record found",
+			fqdn:     "_acme-challenge.foo.com.",
+			zoneID:   "ZONE_A",
+			response: &APIResponse{Success: true},
+			data: []TxtRecord{
+				{
+					Name:    "_acme-challenge.foo.com",
+					Type:    "TXT",
+					Content: "txtTXTtxtTXTtxtTXTtxtTXT",
+					ID:      "A",
+					TTL:     50,
+					ZoneID:  "ZONE_A",
+				},
+			},
+			expected: result{
+				txtRecord: &TxtRecord{
+					Name:    "_acme-challenge.foo.com",
+					Type:    "TXT",
+					Content: "txtTXTtxtTXTtxtTXTtxtTXT",
+					ID:      "A",
+					TTL:     50,
+					ZoneID:  "ZONE_A",
+				},
+			},
+		},
+		{
+			desc:     "TXT record not found",
+			fqdn:     "_acme-challenge.foo.com.",
+			zoneID:   "ZONE_A",
+			response: &APIResponse{Success: true},
+			expected: result{error: true},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			server := httptest.NewServer(handlerMock(http.MethodGet, test.response, test.data))
+
+			client, _ := NewClient("authEmail", "authKey")
+			client.BaseURL = server.URL
+
+			txtRecord, err := client.FindTxtRecord(test.zoneID, test.fqdn)
+
+			if test.expected.error {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, test.expected.txtRecord, txtRecord)
+			}
+		})
+	}
+}

--- a/providers/dns/cloudflare/cloudflare.go
+++ b/providers/dns/cloudflare/cloudflare.go
@@ -3,12 +3,8 @@
 package cloudflare
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -17,208 +13,108 @@ import (
 )
 
 // CloudFlareAPIURL represents the API endpoint to call.
-// TODO: Unexport?
-const CloudFlareAPIURL = "https://api.cloudflare.com/client/v4"
+const CloudFlareAPIURL = defaultBaseURL // Deprecated
+
+// Config is used to configure the creation of the DNSProvider
+type Config struct {
+	AuthEmail          string
+	AuthKey            string
+	TTL                int
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+	HTTPClient         *http.Client
+}
+
+// NewDefaultConfig returns a default configuration for the DNSProvider
+func NewDefaultConfig() *Config {
+	return &Config{
+		TTL:                env.GetOrDefaultInt("CLOUDFLARE_TTL", 120),
+		PropagationTimeout: env.GetOrDefaultSecond("CLOUDFLARE_PROPAGATION_TIMEOUT", 2*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond("CLOUDFLARE_POLLING_INTERVAL", 2*time.Second),
+		HTTPClient: &http.Client{
+			Timeout: env.GetOrDefaultSecond("CLOUDFLARE_HTTP_TIMEOUT", 30*time.Second),
+		},
+	}
+}
 
 // DNSProvider is an implementation of the acme.ChallengeProvider interface
 type DNSProvider struct {
-	authEmail string
-	authKey   string
-	client    *http.Client
+	client *Client
+	config *Config
 }
 
-// NewDNSProvider returns a DNSProvider instance configured for cloudflare.
-// Credentials must be passed in the environment variables: CLOUDFLARE_EMAIL
-// and CLOUDFLARE_API_KEY.
+// NewDNSProvider returns a DNSProvider instance configured for Cloudflare.
+// Credentials must be passed in the environment variables:
+// CLOUDFLARE_EMAIL and CLOUDFLARE_API_KEY.
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("CLOUDFLARE_EMAIL", "CLOUDFLARE_API_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("CloudFlare: %v", err)
+		return nil, fmt.Errorf("cloudflare: %v", err)
 	}
 
-	return NewDNSProviderCredentials(values["CLOUDFLARE_EMAIL"], values["CLOUDFLARE_API_KEY"])
+	config := NewDefaultConfig()
+	config.AuthEmail = values["CLOUDFLARE_EMAIL"]
+	config.AuthKey = values["CLOUDFLARE_API_KEY"]
+
+	return NewDNSProviderConfig(config)
 }
 
-// NewDNSProviderCredentials uses the supplied credentials to return a
-// DNSProvider instance configured for cloudflare.
+// NewDNSProviderCredentials uses the supplied credentials
+// to return a DNSProvider instance configured for Cloudflare.
+// Deprecated
 func NewDNSProviderCredentials(email, key string) (*DNSProvider, error) {
-	if email == "" || key == "" {
-		return nil, errors.New("CloudFlare: some credentials information are missing")
+	config := NewDefaultConfig()
+	config.AuthEmail = email
+	config.AuthKey = key
+
+	return NewDNSProviderConfig(config)
+}
+
+// NewDNSProviderConfig return a DNSProvider instance configured for Cloudflare.
+func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
+	if config == nil {
+		return nil, errors.New("cloudflare: the configuration of the DNS provider is nil")
 	}
 
+	client, err := NewClient(config.AuthEmail, config.AuthKey)
+	if err != nil {
+		return nil, err
+	}
+
+	client.HTTPClient = config.HTTPClient
+
+	// TODO: must be remove. keep only for compatibility reason.
+	client.BaseURL = CloudFlareAPIURL
+
 	return &DNSProvider{
-		authEmail: email,
-		authKey:   key,
-		client:    &http.Client{Timeout: 30 * time.Second},
+		client: client,
+		config: config,
 	}, nil
 }
 
 // Timeout returns the timeout and interval to use when checking for DNS
 // propagation. Adjusting here to cope with spikes in propagation times.
 func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
-	return 120 * time.Second, 2 * time.Second
+	return d.config.PropagationTimeout, d.config.PollingInterval
 }
 
 // Present creates a TXT record to fulfil the dns-01 challenge
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
-	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
-	zoneID, err := d.getHostedZoneID(fqdn)
-	if err != nil {
-		return err
-	}
+	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
 
-	rec := cloudFlareRecord{
+	rec := TxtRecord{
 		Type:    "TXT",
 		Name:    acme.UnFqdn(fqdn),
 		Content: value,
-		TTL:     ttl,
+		TTL:     d.config.TTL,
 	}
 
-	body, err := json.Marshal(rec)
-	if err != nil {
-		return err
-	}
-
-	_, err = d.doRequest(http.MethodPost, fmt.Sprintf("/zones/%s/dns_records", zoneID), bytes.NewReader(body))
-	return err
+	return d.client.AddTxtRecord(fqdn, rec)
 }
 
 // CleanUp removes the TXT record matching the specified parameters
 func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	fqdn, _, _ := acme.DNS01Record(domain, keyAuth)
 
-	record, err := d.findTxtRecord(fqdn)
-	if err != nil {
-		return err
-	}
-
-	_, err = d.doRequest(http.MethodDelete, fmt.Sprintf("/zones/%s/dns_records/%s", record.ZoneID, record.ID), nil)
-	return err
-}
-
-func (d *DNSProvider) getHostedZoneID(fqdn string) (string, error) {
-	// HostedZone represents a CloudFlare DNS zone
-	type HostedZone struct {
-		ID   string `json:"id"`
-		Name string `json:"name"`
-	}
-
-	authZone, err := acme.FindZoneByFqdn(fqdn, acme.RecursiveNameservers)
-	if err != nil {
-		return "", err
-	}
-
-	result, err := d.doRequest(http.MethodGet, "/zones?name="+acme.UnFqdn(authZone), nil)
-	if err != nil {
-		return "", err
-	}
-
-	var hostedZone []HostedZone
-	err = json.Unmarshal(result, &hostedZone)
-	if err != nil {
-		return "", err
-	}
-
-	if len(hostedZone) != 1 {
-		return "", fmt.Errorf("zone %s not found in CloudFlare for domain %s", authZone, fqdn)
-	}
-
-	return hostedZone[0].ID, nil
-}
-
-func (d *DNSProvider) findTxtRecord(fqdn string) (*cloudFlareRecord, error) {
-	zoneID, err := d.getHostedZoneID(fqdn)
-	if err != nil {
-		return nil, err
-	}
-
-	result, err := d.doRequest(
-		http.MethodGet,
-		fmt.Sprintf("/zones/%s/dns_records?per_page=1000&type=TXT&name=%s", zoneID, acme.UnFqdn(fqdn)),
-		nil,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	var records []cloudFlareRecord
-	err = json.Unmarshal(result, &records)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, rec := range records {
-		if rec.Name == acme.UnFqdn(fqdn) {
-			return &rec, nil
-		}
-	}
-
-	return nil, fmt.Errorf("no existing record found for %s", fqdn)
-}
-
-func (d *DNSProvider) doRequest(method, uri string, body io.Reader) (json.RawMessage, error) {
-	req, err := http.NewRequest(method, fmt.Sprintf("%s%s", CloudFlareAPIURL, uri), body)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("X-Auth-Email", d.authEmail)
-	req.Header.Set("X-Auth-Key", d.authKey)
-
-	resp, err := d.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("error querying Cloudflare API -> %v", err)
-	}
-
-	defer resp.Body.Close()
-
-	var r APIResponse
-	err = json.NewDecoder(resp.Body).Decode(&r)
-	if err != nil {
-		return nil, err
-	}
-
-	if !r.Success {
-		if len(r.Errors) > 0 {
-			errStr := ""
-			for _, apiErr := range r.Errors {
-				errStr += fmt.Sprintf("\t Error: %d: %s", apiErr.Code, apiErr.Message)
-				for _, chainErr := range apiErr.ErrorChain {
-					errStr += fmt.Sprintf("<- %d: %s", chainErr.Code, chainErr.Message)
-				}
-			}
-			return nil, fmt.Errorf("Cloudflare API Error \n%s", errStr)
-		}
-		strBody := "Unreadable body"
-		if body, err := ioutil.ReadAll(resp.Body); err == nil {
-			strBody = string(body)
-		}
-		return nil, fmt.Errorf("Cloudflare API error: the request %s sent a response with a body which is not in JSON format: %s", req.URL.String(), strBody)
-	}
-
-	return r.Result, nil
-}
-
-// APIError contains error details for failed requests
-type APIError struct {
-	Code       int        `json:"code,omitempty"`
-	Message    string     `json:"message,omitempty"`
-	ErrorChain []APIError `json:"error_chain,omitempty"`
-}
-
-// APIResponse represents a response from CloudFlare API
-type APIResponse struct {
-	Success bool            `json:"success"`
-	Errors  []*APIError     `json:"errors"`
-	Result  json.RawMessage `json:"result"`
-}
-
-// cloudFlareRecord represents a CloudFlare DNS record
-type cloudFlareRecord struct {
-	Name    string `json:"name"`
-	Type    string `json:"type"`
-	Content string `json:"content"`
-	ID      string `json:"id,omitempty"`
-	TTL     int    `json:"ttl,omitempty"`
-	ZoneID  string `json:"zone_id,omitempty"`
+	return d.client.RemoveTxtRecord(fqdn)
 }

--- a/providers/dns/cloudflare/cloudflare_test.go
+++ b/providers/dns/cloudflare/cloudflare_test.go
@@ -34,7 +34,11 @@ func TestNewDNSProviderValid(t *testing.T) {
 	os.Setenv("CLOUDFLARE_API_KEY", "")
 	defer restoreEnv()
 
-	_, err := NewDNSProviderCredentials("123", "123")
+	config := NewDefaultConfig()
+	config.AuthEmail = "123"
+	config.AuthKey = "123"
+
+	_, err := NewDNSProviderConfig(config)
 
 	assert.NoError(t, err)
 }
@@ -54,7 +58,7 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	os.Setenv("CLOUDFLARE_API_KEY", "")
 
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "CloudFlare: some credentials information are missing: CLOUDFLARE_EMAIL,CLOUDFLARE_API_KEY")
+	assert.EqualError(t, err, "cloudflare: some credentials information are missing: CLOUDFLARE_EMAIL,CLOUDFLARE_API_KEY")
 }
 
 func TestNewDNSProviderMissingCredErrSingle(t *testing.T) {
@@ -62,7 +66,7 @@ func TestNewDNSProviderMissingCredErrSingle(t *testing.T) {
 	os.Setenv("CLOUDFLARE_EMAIL", "awesome@possum.com")
 
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "CloudFlare: some credentials information are missing: CLOUDFLARE_API_KEY")
+	assert.EqualError(t, err, "cloudflare: some credentials information are missing: CLOUDFLARE_API_KEY")
 }
 
 func TestCloudFlarePresent(t *testing.T) {
@@ -70,7 +74,11 @@ func TestCloudFlarePresent(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	provider, err := NewDNSProviderCredentials(cflareEmail, cflareAPIKey)
+	config := NewDefaultConfig()
+	config.AuthEmail = cflareEmail
+	config.AuthKey = cflareAPIKey
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	err = provider.Present(cflareDomain, "", "123d==")
@@ -84,7 +92,11 @@ func TestCloudFlareCleanUp(t *testing.T) {
 
 	time.Sleep(time.Second * 2)
 
-	provider, err := NewDNSProviderCredentials(cflareEmail, cflareAPIKey)
+	config := NewDefaultConfig()
+	config.AuthEmail = cflareEmail
+	config.AuthKey = cflareAPIKey
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	err = provider.CleanUp(cflareDomain, "", "123d==")

--- a/providers/dns/digitalocean/client.go
+++ b/providers/dns/digitalocean/client.go
@@ -1,0 +1,26 @@
+package digitalocean
+
+const defaultBaseURL = "https://api.digitalocean.com"
+
+// txtRecordRequest represents the request body to DO's API to make a TXT record
+type txtRecordRequest struct {
+	RecordType string `json:"type"`
+	Name       string `json:"name"`
+	Data       string `json:"data"`
+	TTL        int    `json:"ttl"`
+}
+
+// txtRecordResponse represents a response from DO's API after making a TXT record
+type txtRecordResponse struct {
+	DomainRecord struct {
+		ID   int    `json:"id"`
+		Type string `json:"type"`
+		Name string `json:"name"`
+		Data string `json:"data"`
+	} `json:"domain_record"`
+}
+
+type digitalOceanAPIError struct {
+	ID      string `json:"id"`
+	Message string `json:"message"`
+}

--- a/providers/dns/digitalocean/digitalocean.go
+++ b/providers/dns/digitalocean/digitalocean.go
@@ -5,7 +5,10 @@ package digitalocean
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net/http"
 	"sync"
 	"time"
@@ -14,13 +17,35 @@ import (
 	"github.com/xenolf/lego/platform/config/env"
 )
 
+// Config is used to configure the creation of the DNSProvider
+type Config struct {
+	BaseURL            string
+	AuthToken          string
+	TTL                int
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+	HTTPClient         *http.Client
+}
+
+// NewDefaultConfig returns a default configuration for the DNSProvider
+func NewDefaultConfig() *Config {
+	return &Config{
+		BaseURL:            defaultBaseURL,
+		TTL:                env.GetOrDefaultInt("DO_TTL", 30),
+		PropagationTimeout: env.GetOrDefaultSecond("DO_PROPAGATION_TIMEOUT", 60*time.Second),
+		PollingInterval:    env.GetOrDefaultSecond("DO_POLLING_INTERVAL", 5*time.Second),
+		HTTPClient: &http.Client{
+			Timeout: env.GetOrDefaultSecond("DO_HTTP_TIMEOUT", 30*time.Second),
+		},
+	}
+}
+
 // DNSProvider is an implementation of the acme.ChallengeProvider interface
 // that uses DigitalOcean's REST API to manage TXT records for a domain.
 type DNSProvider struct {
-	apiAuthToken string
-	recordIDs    map[string]int
-	recordIDsMu  sync.Mutex
-	client       *http.Client
+	config      *Config
+	recordIDs   map[string]int
+	recordIDsMu sync.Mutex
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for Digital
@@ -29,74 +54,60 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("DO_AUTH_TOKEN")
 	if err != nil {
-		return nil, fmt.Errorf("DigitalOcean: %v", err)
+		return nil, fmt.Errorf("digitalocean: %v", err)
 	}
 
-	return NewDNSProviderCredentials(values["DO_AUTH_TOKEN"])
+	config := NewDefaultConfig()
+	config.AuthToken = values["DO_AUTH_TOKEN"]
+
+	return NewDNSProviderConfig(config)
 }
 
-// NewDNSProviderCredentials uses the supplied credentials to return a
-// DNSProvider instance configured for Digital Ocean.
+// NewDNSProviderCredentials uses the supplied credentials
+// to return a DNSProvider instance configured for Digital Ocean.
+// Deprecated
 func NewDNSProviderCredentials(apiAuthToken string) (*DNSProvider, error) {
-	if apiAuthToken == "" {
-		return nil, fmt.Errorf("DigitalOcean credentials missing")
+	config := NewDefaultConfig()
+	config.AuthToken = apiAuthToken
+
+	return NewDNSProviderConfig(config)
+}
+
+// NewDNSProviderConfig return a DNSProvider instance configured for Digital Ocean.
+func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
+	if config == nil {
+		return nil, errors.New("digitalocean: the configuration of the DNS provider is nil")
 	}
+
+	if config.AuthToken == "" {
+		return nil, fmt.Errorf("digitalocean: credentials missing")
+	}
+
+	if config.BaseURL == "" {
+		config.BaseURL = defaultBaseURL
+	}
+
 	return &DNSProvider{
-		apiAuthToken: apiAuthToken,
-		recordIDs:    make(map[string]int),
-		client:       &http.Client{Timeout: 30 * time.Second},
+		config:    config,
+		recordIDs: make(map[string]int),
 	}, nil
 }
 
-// Timeout returns the timeout and interval to use when checking for DNS
-// propagation. Adjusting here to cope with spikes in propagation times.
+// Timeout returns the timeout and interval to use when checking for DNS propagation.
+// Adjusting here to cope with spikes in propagation times.
 func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
-	return 60 * time.Second, 5 * time.Second
+	return d.config.PropagationTimeout, d.config.PollingInterval
 }
 
 // Present creates a TXT record using the specified parameters
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
 
-	authZone, err := acme.FindZoneByFqdn(acme.ToFqdn(domain), acme.RecursiveNameservers)
+	respData, err := d.addTxtRecord(domain, fqdn, value)
 	if err != nil {
-		return fmt.Errorf("could not determine zone for domain: '%s'. %s", domain, err)
+		return fmt.Errorf("digitalocean: %v", err)
 	}
 
-	authZone = acme.UnFqdn(authZone)
-
-	reqURL := fmt.Sprintf("%s/v2/domains/%s/records", digitalOceanBaseURL, authZone)
-	reqData := txtRecordRequest{RecordType: "TXT", Name: fqdn, Data: value, TTL: 30}
-	body, err := json.Marshal(reqData)
-	if err != nil {
-		return err
-	}
-
-	req, err := http.NewRequest(http.MethodPost, reqURL, bytes.NewReader(body))
-	if err != nil {
-		return err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", d.apiAuthToken))
-
-	resp, err := d.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 400 {
-		var errInfo digitalOceanAPIError
-		json.NewDecoder(resp.Body).Decode(&errInfo)
-		return fmt.Errorf("HTTP %d: %s: %s", resp.StatusCode, errInfo.ID, errInfo.Message)
-	}
-
-	// Everything looks good; but we'll need the ID later to delete the record
-	var respData txtRecordResponse
-	err = json.NewDecoder(resp.Body).Decode(&respData)
-	if err != nil {
-		return err
-	}
 	d.recordIDsMu.Lock()
 	d.recordIDs[fqdn] = respData.DomainRecord.ID
 	d.recordIDsMu.Unlock()
@@ -113,35 +124,12 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	recordID, ok := d.recordIDs[fqdn]
 	d.recordIDsMu.Unlock()
 	if !ok {
-		return fmt.Errorf("unknown record ID for '%s'", fqdn)
+		return fmt.Errorf("digitalocean: unknown record ID for '%s'", fqdn)
 	}
 
-	authZone, err := acme.FindZoneByFqdn(acme.ToFqdn(domain), acme.RecursiveNameservers)
+	err := d.removeTxtRecord(domain, recordID)
 	if err != nil {
-		return fmt.Errorf("could not determine zone for domain: '%s'. %s", domain, err)
-	}
-
-	authZone = acme.UnFqdn(authZone)
-
-	reqURL := fmt.Sprintf("%s/v2/domains/%s/records/%d", digitalOceanBaseURL, authZone, recordID)
-	req, err := http.NewRequest(http.MethodDelete, reqURL, nil)
-	if err != nil {
-		return err
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", d.apiAuthToken))
-
-	resp, err := d.client.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 400 {
-		var errInfo digitalOceanAPIError
-		json.NewDecoder(resp.Body).Decode(&errInfo)
-		return fmt.Errorf("HTTP %d: %s: %s", resp.StatusCode, errInfo.ID, errInfo.Message)
+		return fmt.Errorf("digitalocean: %v", err)
 	}
 
 	// Delete record ID from map
@@ -152,27 +140,101 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	return nil
 }
 
-type digitalOceanAPIError struct {
-	ID      string `json:"id"`
-	Message string `json:"message"`
+func (d *DNSProvider) removeTxtRecord(domain string, recordID int) error {
+	authZone, err := acme.FindZoneByFqdn(acme.ToFqdn(domain), acme.RecursiveNameservers)
+	if err != nil {
+		return fmt.Errorf("could not determine zone for domain: '%s'. %s", domain, err)
+	}
+
+	reqURL := fmt.Sprintf("%s/v2/domains/%s/records/%d", d.config.BaseURL, acme.UnFqdn(authZone), recordID)
+	req, err := d.newRequest(http.MethodDelete, reqURL, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := d.config.HTTPClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return readError(req, resp)
+	}
+
+	return nil
 }
 
-var digitalOceanBaseURL = "https://api.digitalocean.com"
+func (d *DNSProvider) addTxtRecord(domain, fqdn, value string) (*txtRecordResponse, error) {
+	authZone, err := acme.FindZoneByFqdn(acme.ToFqdn(domain), acme.RecursiveNameservers)
+	if err != nil {
+		return nil, fmt.Errorf("could not determine zone for domain: '%s'. %s", domain, err)
+	}
 
-// txtRecordRequest represents the request body to DO's API to make a TXT record
-type txtRecordRequest struct {
-	RecordType string `json:"type"`
-	Name       string `json:"name"`
-	Data       string `json:"data"`
-	TTL        int    `json:"ttl"`
+	reqData := txtRecordRequest{RecordType: "TXT", Name: fqdn, Data: value, TTL: d.config.TTL}
+	body, err := json.Marshal(reqData)
+	if err != nil {
+		return nil, err
+	}
+
+	reqURL := fmt.Sprintf("%s/v2/domains/%s/records", d.config.BaseURL, acme.UnFqdn(authZone))
+	req, err := d.newRequest(http.MethodPost, reqURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := d.config.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, readError(req, resp)
+	}
+
+	content, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.New(toUnreadableBodyMessage(req, content))
+	}
+
+	// Everything looks good; but we'll need the ID later to delete the record
+	respData := &txtRecordResponse{}
+	err = json.Unmarshal(content, respData)
+	if err != nil {
+		return nil, fmt.Errorf("%v: %s", err, toUnreadableBodyMessage(req, content))
+	}
+
+	return respData, nil
 }
 
-// txtRecordResponse represents a response from DO's API after making a TXT record
-type txtRecordResponse struct {
-	DomainRecord struct {
-		ID   int    `json:"id"`
-		Type string `json:"type"`
-		Name string `json:"name"`
-		Data string `json:"data"`
-	} `json:"domain_record"`
+func (d *DNSProvider) newRequest(method, reqURL string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequest(method, reqURL, body)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", d.config.AuthToken))
+
+	return req, nil
+}
+
+func readError(req *http.Request, resp *http.Response) error {
+	content, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return errors.New(toUnreadableBodyMessage(req, content))
+	}
+
+	var errInfo digitalOceanAPIError
+	err = json.Unmarshal(content, &errInfo)
+	if err != nil {
+		return fmt.Errorf("digitalOceanAPIError unmarshaling error: %v: %s", err, toUnreadableBodyMessage(req, content))
+	}
+
+	return fmt.Errorf("HTTP %d: %s: %s", resp.StatusCode, errInfo.ID, errInfo.Message)
+}
+
+func toUnreadableBodyMessage(req *http.Request, rawBody []byte) string {
+	return fmt.Sprintf("the request %s sent a response with a body which is an invalid format: %q", req.URL, string(rawBody))
 }

--- a/providers/dns/digitalocean/digitalocean_test.go
+++ b/providers/dns/digitalocean/digitalocean_test.go
@@ -42,13 +42,16 @@ func TestDigitalOceanPresent(t *testing.T) {
 		}`)
 	}))
 	defer mock.Close()
-	digitalOceanBaseURL = mock.URL
 
-	doprov, err := NewDNSProviderCredentials(fakeDigitalOceanAuth)
+	config := NewDefaultConfig()
+	config.AuthToken = fakeDigitalOceanAuth
+	config.BaseURL = mock.URL
+
+	provider, err := NewDNSProviderConfig(config)
 	require.NoError(t, err)
-	require.NotNil(t, doprov)
+	require.NotNil(t, provider)
 
-	err = doprov.Present("example.com", "", "foobar")
+	err = provider.Present("example.com", "", "foobar")
 	require.NoError(t, err, "fail to create TXT record")
 
 	assert.True(t, requestReceived, "Expected request to be received by mock backend, but it wasn't")
@@ -69,17 +72,20 @@ func TestDigitalOceanCleanUp(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer mock.Close()
-	digitalOceanBaseURL = mock.URL
 
-	doprov, err := NewDNSProviderCredentials(fakeDigitalOceanAuth)
+	config := NewDefaultConfig()
+	config.AuthToken = fakeDigitalOceanAuth
+	config.BaseURL = mock.URL
+
+	provider, err := NewDNSProviderConfig(config)
 	require.NoError(t, err)
-	require.NotNil(t, doprov)
+	require.NotNil(t, provider)
 
-	doprov.recordIDsMu.Lock()
-	doprov.recordIDs["_acme-challenge.example.com."] = 1234567
-	doprov.recordIDsMu.Unlock()
+	provider.recordIDsMu.Lock()
+	provider.recordIDs["_acme-challenge.example.com."] = 1234567
+	provider.recordIDsMu.Unlock()
 
-	err = doprov.CleanUp("example.com", "", "")
+	err = provider.CleanUp("example.com", "", "")
 	require.NoError(t, err, "fail to remove TXT record")
 
 	assert.True(t, requestReceived, "Expected request to be received by mock backend, but it wasn't")

--- a/providers/dns/dnsmadeeasy/client.go
+++ b/providers/dns/dnsmadeeasy/client.go
@@ -1,0 +1,168 @@
+package dnsmadeeasy
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// Domain holds the DNSMadeEasy API representation of a Domain
+type Domain struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// Record holds the DNSMadeEasy API representation of a Domain Record
+type Record struct {
+	ID       int    `json:"id"`
+	Type     string `json:"type"`
+	Name     string `json:"name"`
+	Value    string `json:"value"`
+	TTL      int    `json:"ttl"`
+	SourceID int    `json:"sourceId"`
+}
+
+// Client DNSMadeEasy client
+type Client struct {
+	apiKey     string
+	apiSecret  string
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+// NewClient creates a DNSMadeEasy client
+func NewClient(apiKey string, apiSecret string) (*Client, error) {
+	if apiKey == "" {
+		return nil, fmt.Errorf("DNSMadeEasy: credentials missing: API key")
+	}
+
+	if apiSecret == "" {
+		return nil, fmt.Errorf("DNSMadeEasy: credentials missing: API secret")
+	}
+
+	return &Client{
+		apiKey:     apiKey,
+		apiSecret:  apiSecret,
+		HTTPClient: &http.Client{},
+	}, nil
+}
+
+// GetDomain gets a domain
+func (c *Client) GetDomain(authZone string) (*Domain, error) {
+	domainName := authZone[0 : len(authZone)-1]
+	resource := fmt.Sprintf("%s%s", "/dns/managed/name?domainname=", domainName)
+
+	resp, err := c.sendRequest(http.MethodGet, resource, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	domain := &Domain{}
+	err = json.NewDecoder(resp.Body).Decode(&domain)
+	if err != nil {
+		return nil, err
+	}
+
+	return domain, nil
+}
+
+// GetRecords gets all TXT records
+func (c *Client) GetRecords(domain *Domain, recordName, recordType string) (*[]Record, error) {
+	resource := fmt.Sprintf("%s/%d/%s%s%s%s", "/dns/managed", domain.ID, "records?recordName=", recordName, "&type=", recordType)
+
+	resp, err := c.sendRequest(http.MethodGet, resource, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	type recordsResponse struct {
+		Records *[]Record `json:"data"`
+	}
+
+	records := &recordsResponse{}
+	err = json.NewDecoder(resp.Body).Decode(&records)
+	if err != nil {
+		return nil, err
+	}
+
+	return records.Records, nil
+}
+
+// CreateRecord creates a TXT records
+func (c *Client) CreateRecord(domain *Domain, record *Record) error {
+	url := fmt.Sprintf("%s/%d/%s", "/dns/managed", domain.ID, "records")
+
+	resp, err := c.sendRequest(http.MethodPost, url, record)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+// DeleteRecord deletes a TXT records
+func (c *Client) DeleteRecord(record Record) error {
+	resource := fmt.Sprintf("%s/%d/%s/%d", "/dns/managed", record.SourceID, "records", record.ID)
+
+	resp, err := c.sendRequest(http.MethodDelete, resource, nil)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func (c *Client) sendRequest(method, resource string, payload interface{}) (*http.Response, error) {
+	url := fmt.Sprintf("%s%s", c.BaseURL, resource)
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	timestamp := time.Now().UTC().Format(time.RFC1123)
+	signature, err := computeHMAC(timestamp, c.apiSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(method, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("x-dnsme-apiKey", c.apiKey)
+	req.Header.Set("x-dnsme-requestDate", timestamp)
+	req.Header.Set("x-dnsme-hmac", signature)
+	req.Header.Set("accept", "application/json")
+	req.Header.Set("content-type", "application/json")
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode > 299 {
+		return nil, fmt.Errorf("DNSMadeEasy API request failed with HTTP status code %d", resp.StatusCode)
+	}
+
+	return resp, nil
+}
+
+func computeHMAC(message string, secret string) (string, error) {
+	key := []byte(secret)
+	h := hmac.New(sha1.New, key)
+	_, err := h.Write([]byte(message))
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/providers/dns/dnspod/dnspod_test.go
+++ b/providers/dns/dnspod/dnspod_test.go
@@ -30,7 +30,10 @@ func TestNewDNSProviderValid(t *testing.T) {
 	defer restoreEnv()
 	os.Setenv("DNSPOD_API_KEY", "")
 
-	_, err := NewDNSProviderCredentials("123")
+	config := NewDefaultConfig()
+	config.LoginToken = "123"
+
+	_, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 }
 func TestNewDNSProviderValidEnv(t *testing.T) {
@@ -46,7 +49,7 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	os.Setenv("DNSPOD_API_KEY", "")
 
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "DNSPod: some credentials information are missing: DNSPOD_API_KEY")
+	assert.EqualError(t, err, "dnspod: some credentials information are missing: DNSPOD_API_KEY")
 }
 
 func TestLivednspodPresent(t *testing.T) {
@@ -54,7 +57,10 @@ func TestLivednspodPresent(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	provider, err := NewDNSProviderCredentials(dnspodAPIKey)
+	config := NewDefaultConfig()
+	config.LoginToken = dnspodAPIKey
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	err = provider.Present(dnspodDomain, "", "123d==")
@@ -68,7 +74,10 @@ func TestLivednspodCleanUp(t *testing.T) {
 
 	time.Sleep(time.Second * 1)
 
-	provider, err := NewDNSProviderCredentials(dnspodAPIKey)
+	config := NewDefaultConfig()
+	config.LoginToken = dnspodAPIKey
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	err = provider.CleanUp(dnspodDomain, "", "123d==")

--- a/providers/dns/duckdns/duckdns_test.go
+++ b/providers/dns/duckdns/duckdns_test.go
@@ -39,7 +39,7 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	os.Setenv("DUCKDNS_TOKEN", "")
 
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "DuckDNS: some credentials information are missing: DUCKDNS_TOKEN")
+	assert.EqualError(t, err, "duckdns: some credentials information are missing: DUCKDNS_TOKEN")
 }
 
 func TestLiveDuckdnsPresent(t *testing.T) {

--- a/providers/dns/dyn/client.go
+++ b/providers/dns/dyn/client.go
@@ -1,0 +1,35 @@
+package dyn
+
+import "encoding/json"
+
+const defaultBaseURL = "https://api.dynect.net/REST"
+
+type dynResponse struct {
+	// One of 'success', 'failure', or 'incomplete'
+	Status string `json:"status"`
+
+	// The structure containing the actual results of the request
+	Data json.RawMessage `json:"data"`
+
+	// The ID of the job that was created in response to a request.
+	JobID int `json:"job_id"`
+
+	// A list of zero or more messages
+	Messages json.RawMessage `json:"msgs"`
+}
+
+type creds struct {
+	Customer string `json:"customer_name"`
+	User     string `json:"user_name"`
+	Pass     string `json:"password"`
+}
+
+type session struct {
+	Token   string `json:"token"`
+	Version string `json:"version"`
+}
+
+type publish struct {
+	Publish bool   `json:"publish"`
+	Notes   string `json:"notes"`
+}

--- a/providers/dns/exoscale/exoscale.go
+++ b/providers/dns/exoscale/exoscale.go
@@ -5,15 +5,43 @@ package exoscale
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"os"
+	"time"
 
 	"github.com/exoscale/egoscale"
 	"github.com/xenolf/lego/acme"
 	"github.com/xenolf/lego/platform/config/env"
 )
 
+const defaultBaseURL = "https://api.exoscale.ch/dns"
+
+// Config is used to configure the creation of the DNSProvider
+type Config struct {
+	APIKey             string
+	APISecret          string
+	Endpoint           string
+	HTTPClient         *http.Client
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+	TTL                int
+}
+
+// NewDefaultConfig returns a default configuration for the DNSProvider
+func NewDefaultConfig() *Config {
+	return &Config{
+		TTL:                env.GetOrDefaultInt("EXOSCALE_TTL", 120),
+		PropagationTimeout: env.GetOrDefaultSecond("EXOSCALE_PROPAGATION_TIMEOUT", acme.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond("EXOSCALE_POLLING_INTERVAL", acme.DefaultPollingInterval),
+		HTTPClient: &http.Client{
+			Timeout: env.GetOrDefaultSecond("EXOSCALE_HTTP_TIMEOUT", 0),
+		},
+	}
+}
+
 // DNSProvider is an implementation of the acme.ChallengeProvider interface.
 type DNSProvider struct {
+	config *Config
 	client *egoscale.Client
 }
 
@@ -22,32 +50,52 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("EXOSCALE_API_KEY", "EXOSCALE_API_SECRET")
 	if err != nil {
-		return nil, fmt.Errorf("Exoscale: %v", err)
+		return nil, fmt.Errorf("exoscale: %v", err)
 	}
 
-	endpoint := os.Getenv("EXOSCALE_ENDPOINT")
-	return NewDNSProviderClient(values["EXOSCALE_API_KEY"], values["EXOSCALE_API_SECRET"], endpoint)
+	config := NewDefaultConfig()
+	config.APIKey = values["EXOSCALE_API_KEY"]
+	config.APISecret = values["EXOSCALE_API_SECRET"]
+	config.Endpoint = os.Getenv("EXOSCALE_ENDPOINT")
+
+	return NewDNSProviderConfig(config)
 }
 
-// NewDNSProviderClient Uses the supplied parameters to return a DNSProvider instance
-// configured for Exoscale.
+// NewDNSProviderClient Uses the supplied parameters
+// to return a DNSProvider instance configured for Exoscale.
+// Deprecated
 func NewDNSProviderClient(key, secret, endpoint string) (*DNSProvider, error) {
-	if key == "" || secret == "" {
-		return nil, fmt.Errorf("Exoscale credentials missing")
+	config := NewDefaultConfig()
+	config.APIKey = key
+	config.APISecret = secret
+	config.Endpoint = endpoint
+
+	return NewDNSProviderConfig(config)
+}
+
+// NewDNSProviderConfig return a DNSProvider instance configured for Exoscale.
+func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
+	if config == nil {
+		return nil, errors.New("the configuration of the DNS provider is nil")
 	}
 
-	if endpoint == "" {
-		endpoint = "https://api.exoscale.ch/dns"
+	if config.APIKey == "" || config.APISecret == "" {
+		return nil, fmt.Errorf("exoscale: credentials missing")
 	}
 
-	return &DNSProvider{
-		client: egoscale.NewClient(endpoint, key, secret),
-	}, nil
+	if config.Endpoint == "" {
+		config.Endpoint = defaultBaseURL
+	}
+
+	client := egoscale.NewClient(config.Endpoint, config.APIKey, config.APISecret)
+	client.HTTPClient = config.HTTPClient
+
+	return &DNSProvider{client: client, config: config}, nil
 }
 
 // Present creates a TXT record to fulfil the dns-01 challenge.
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
-	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
+	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
 	zone, recordName, err := d.FindZoneAndRecordName(fqdn, domain)
 	if err != nil {
 		return err
@@ -61,7 +109,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	if recordID == 0 {
 		record := egoscale.DNSRecord{
 			Name:       recordName,
-			TTL:        ttl,
+			TTL:        d.config.TTL,
 			Content:    value,
 			RecordType: "TXT",
 		}
@@ -74,7 +122,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		record := egoscale.UpdateDNSRecord{
 			ID:         recordID,
 			Name:       recordName,
-			TTL:        ttl,
+			TTL:        d.config.TTL,
 			Content:    value,
 			RecordType: "TXT",
 		}
@@ -109,6 +157,12 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	}
 
 	return nil
+}
+
+// Timeout returns the timeout and interval to use when checking for DNS propagation.
+// Adjusting here to cope with spikes in propagation times.
+func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
+	return d.config.PropagationTimeout, d.config.PollingInterval
 }
 
 // FindExistingRecordID Query Exoscale to find an existing record for this name.

--- a/providers/dns/exoscale/exoscale_test.go
+++ b/providers/dns/exoscale/exoscale_test.go
@@ -34,7 +34,11 @@ func TestNewDNSProviderValid(t *testing.T) {
 	os.Setenv("EXOSCALE_API_KEY", "")
 	os.Setenv("EXOSCALE_API_SECRET", "")
 
-	_, err := NewDNSProviderClient("example@example.com", "123", "")
+	config := NewDefaultConfig()
+	config.APIKey = "example@example.com"
+	config.APISecret = "123"
+
+	_, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 }
 
@@ -53,11 +57,15 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	defer restoreEnv()
 
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "Exoscale: some credentials information are missing: EXOSCALE_API_KEY,EXOSCALE_API_SECRET")
+	assert.EqualError(t, err, "exoscale: some credentials information are missing: EXOSCALE_API_KEY,EXOSCALE_API_SECRET")
 }
 
 func TestExtractRootRecordName(t *testing.T) {
-	provider, err := NewDNSProviderClient("example@example.com", "123", "")
+	config := NewDefaultConfig()
+	config.APIKey = "example@example.com"
+	config.APISecret = "123"
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	zone, recordName, err := provider.FindZoneAndRecordName("_acme-challenge.bar.com.", "bar.com")
@@ -67,7 +75,11 @@ func TestExtractRootRecordName(t *testing.T) {
 }
 
 func TestExtractSubRecordName(t *testing.T) {
-	provider, err := NewDNSProviderClient("example@example.com", "123", "")
+	config := NewDefaultConfig()
+	config.APIKey = "example@example.com"
+	config.APISecret = "123"
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	zone, recordName, err := provider.FindZoneAndRecordName("_acme-challenge.foo.bar.com.", "foo.bar.com")
@@ -81,7 +93,11 @@ func TestLiveExoscalePresent(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	provider, err := NewDNSProviderClient(exoscaleAPIKey, exoscaleAPISecret, "")
+	config := NewDefaultConfig()
+	config.APIKey = exoscaleAPIKey
+	config.APISecret = exoscaleAPISecret
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	err = provider.Present(exoscaleDomain, "", "123d==")
@@ -99,7 +115,11 @@ func TestLiveExoscaleCleanUp(t *testing.T) {
 
 	time.Sleep(time.Second * 1)
 
-	provider, err := NewDNSProviderClient(exoscaleAPIKey, exoscaleAPISecret, "")
+	config := NewDefaultConfig()
+	config.APIKey = exoscaleAPIKey
+	config.APISecret = exoscaleAPISecret
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	err = provider.CleanUp(exoscaleDomain, "", "123d==")

--- a/providers/dns/fastdns/fastdns_test.go
+++ b/providers/dns/fastdns/fastdns_test.go
@@ -43,7 +43,13 @@ func TestNewDNSProviderValid(t *testing.T) {
 	os.Setenv("AKAMAI_CLIENT_SECRET", "")
 	os.Setenv("AKAMAI_ACCESS_TOKEN", "")
 
-	_, err := NewDNSProviderClient("somehost", "someclienttoken", "someclientsecret", "someaccesstoken")
+	config := NewDefaultConfig()
+	config.Host = "somehost"
+	config.ClientToken = "someclienttoken"
+	config.ClientSecret = "someclientsecret"
+	config.AccessToken = "someaccesstoken"
+
+	_, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 }
 
@@ -66,7 +72,7 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	os.Setenv("AKAMAI_ACCESS_TOKEN", "")
 
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "FastDNS: some credentials information are missing: AKAMAI_HOST,AKAMAI_CLIENT_TOKEN,AKAMAI_CLIENT_SECRET,AKAMAI_ACCESS_TOKEN")
+	assert.EqualError(t, err, "fastdns: some credentials information are missing: AKAMAI_HOST,AKAMAI_CLIENT_TOKEN,AKAMAI_CLIENT_SECRET,AKAMAI_ACCESS_TOKEN")
 }
 
 func TestLiveFastdnsPresent(t *testing.T) {
@@ -74,7 +80,13 @@ func TestLiveFastdnsPresent(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	provider, err := NewDNSProviderClient(host, clientToken, clientSecret, accessToken)
+	config := NewDefaultConfig()
+	config.Host = host
+	config.ClientToken = clientToken
+	config.ClientSecret = clientSecret
+	config.AccessToken = accessToken
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	err = provider.Present(testDomain, "", "123d==")
@@ -86,7 +98,13 @@ func TestLiveFastdnsPresent(t *testing.T) {
 }
 
 func TestExtractRootRecordName(t *testing.T) {
-	provider, err := NewDNSProviderClient("somehost", "someclienttoken", "someclientsecret", "someaccesstoken")
+	config := NewDefaultConfig()
+	config.Host = "somehost"
+	config.ClientToken = "someclienttoken"
+	config.ClientSecret = "someclientsecret"
+	config.AccessToken = "someaccesstoken"
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	zone, recordName, err := provider.findZoneAndRecordName("_acme-challenge.bar.com.", "bar.com")
@@ -96,7 +114,13 @@ func TestExtractRootRecordName(t *testing.T) {
 }
 
 func TestExtractSubRecordName(t *testing.T) {
-	provider, err := NewDNSProviderClient("somehost", "someclienttoken", "someclientsecret", "someaccesstoken")
+	config := NewDefaultConfig()
+	config.Host = "somehost"
+	config.ClientToken = "someclienttoken"
+	config.ClientSecret = "someclientsecret"
+	config.AccessToken = "someaccesstoken"
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	zone, recordName, err := provider.findZoneAndRecordName("_acme-challenge.foo.bar.com.", "foo.bar.com")
@@ -112,7 +136,13 @@ func TestLiveFastdnsCleanUp(t *testing.T) {
 
 	time.Sleep(time.Second * 1)
 
-	provider, err := NewDNSProviderClient(host, clientToken, clientSecret, accessToken)
+	config := NewDefaultConfig()
+	config.Host = host
+	config.ClientToken = clientToken
+	config.ClientSecret = clientSecret
+	config.AccessToken = accessToken
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	err = provider.CleanUp(testDomain, "", "123d==")

--- a/providers/dns/gandi/client.go
+++ b/providers/dns/gandi/client.go
@@ -1,0 +1,94 @@
+package gandi
+
+import (
+	"encoding/xml"
+	"fmt"
+)
+
+// types for XML-RPC method calls and parameters
+
+type param interface {
+	param()
+}
+
+type paramString struct {
+	XMLName xml.Name `xml:"param"`
+	Value   string   `xml:"value>string"`
+}
+
+type paramInt struct {
+	XMLName xml.Name `xml:"param"`
+	Value   int      `xml:"value>int"`
+}
+
+type structMember interface {
+	structMember()
+}
+type structMemberString struct {
+	Name  string `xml:"name"`
+	Value string `xml:"value>string"`
+}
+type structMemberInt struct {
+	Name  string `xml:"name"`
+	Value int    `xml:"value>int"`
+}
+type paramStruct struct {
+	XMLName       xml.Name       `xml:"param"`
+	StructMembers []structMember `xml:"value>struct>member"`
+}
+
+func (p paramString) param()               {}
+func (p paramInt) param()                  {}
+func (m structMemberString) structMember() {}
+func (m structMemberInt) structMember()    {}
+func (p paramStruct) param()               {}
+
+type methodCall struct {
+	XMLName    xml.Name `xml:"methodCall"`
+	MethodName string   `xml:"methodName"`
+	Params     []param  `xml:"params"`
+}
+
+// types for XML-RPC responses
+
+type response interface {
+	faultCode() int
+	faultString() string
+}
+
+type responseFault struct {
+	FaultCode   int    `xml:"fault>value>struct>member>value>int"`
+	FaultString string `xml:"fault>value>struct>member>value>string"`
+}
+
+func (r responseFault) faultCode() int      { return r.FaultCode }
+func (r responseFault) faultString() string { return r.FaultString }
+
+type responseStruct struct {
+	responseFault
+	StructMembers []struct {
+		Name     string `xml:"name"`
+		ValueInt int    `xml:"value>int"`
+	} `xml:"params>param>value>struct>member"`
+}
+
+type responseInt struct {
+	responseFault
+	Value int `xml:"params>param>value>int"`
+}
+
+type responseBool struct {
+	responseFault
+	Value bool `xml:"params>param>value>boolean"`
+}
+
+// POSTing/Marshalling/Unmarshalling
+
+type rpcError struct {
+	faultCode   int
+	faultString string
+}
+
+func (e rpcError) Error() string {
+	return fmt.Sprintf("Gandi DNS: RPC Error: (%d) %s", e.faultCode, e.faultString)
+}

--- a/providers/dns/gandi/gandi.go
+++ b/providers/dns/gandi/gandi.go
@@ -5,6 +5,7 @@ package gandi
 import (
 	"bytes"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -20,14 +21,37 @@ import (
 // Gandi API reference:       http://doc.rpc.gandi.net/index.html
 // Gandi API domain examples: http://doc.rpc.gandi.net/domain/faq.html
 
-var (
-	// endpoint is the Gandi XML-RPC endpoint used by Present and
-	// CleanUp. It is overridden during tests.
-	endpoint = "https://rpc.gandi.net/xmlrpc/"
-	// findZoneByFqdn determines the DNS zone of an fqdn. It is overridden
-	// during tests.
-	findZoneByFqdn = acme.FindZoneByFqdn
+const (
+	// defaultBaseURL Gandi XML-RPC endpoint used by Present and CleanUp
+	defaultBaseURL = "https://rpc.gandi.net/xmlrpc/"
+	minTTL         = 300
 )
+
+// findZoneByFqdn determines the DNS zone of an fqdn.
+// It is overridden during tests.
+var findZoneByFqdn = acme.FindZoneByFqdn
+
+// Config is used to configure the creation of the DNSProvider
+type Config struct {
+	BaseURL            string
+	APIKey             string
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+	TTL                int
+	HTTPClient         *http.Client
+}
+
+// NewDefaultConfig returns a default configuration for the DNSProvider
+func NewDefaultConfig() *Config {
+	return &Config{
+		TTL:                env.GetOrDefaultInt("GANDI_TTL", minTTL),
+		PropagationTimeout: env.GetOrDefaultSecond("GANDI_PROPAGATION_TIMEOUT", 40*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond("GANDI_POLLING_INTERVAL", 60*time.Second),
+		HTTPClient: &http.Client{
+			Timeout: env.GetOrDefaultSecond("GANDI_HTTP_TIMEOUT", 60*time.Second),
+		},
+	}
+}
 
 // inProgressInfo contains information about an in-progress challenge
 type inProgressInfo struct {
@@ -40,11 +64,10 @@ type inProgressInfo struct {
 // acme.ChallengeProviderTimeout interface that uses Gandi's XML-RPC
 // API to manage TXT records for a domain.
 type DNSProvider struct {
-	apiKey              string
 	inProgressFQDNs     map[string]inProgressInfo
 	inProgressAuthZones map[string]struct{}
 	inProgressMu        sync.Mutex
-	client              *http.Client
+	config              *Config
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for Gandi.
@@ -52,23 +75,43 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("GANDI_API_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("GandiDNS: %v", err)
+		return nil, fmt.Errorf("gandi: %v", err)
 	}
 
-	return NewDNSProviderCredentials(values["GANDI_API_KEY"])
+	config := NewDefaultConfig()
+	config.APIKey = values["GANDI_API_KEY"]
+
+	return NewDNSProviderConfig(config)
 }
 
-// NewDNSProviderCredentials uses the supplied credentials to return a
-// DNSProvider instance configured for Gandi.
+// NewDNSProviderCredentials uses the supplied credentials
+// to return a DNSProvider instance configured for Gandi.
+// Deprecated
 func NewDNSProviderCredentials(apiKey string) (*DNSProvider, error) {
-	if apiKey == "" {
-		return nil, fmt.Errorf("no Gandi API Key given")
+	config := NewDefaultConfig()
+	config.APIKey = apiKey
+
+	return NewDNSProviderConfig(config)
+}
+
+// NewDNSProviderConfig return a DNSProvider instance configured for Gandi.
+func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
+	if config == nil {
+		return nil, errors.New("gandi: the configuration of the DNS provider is nil")
 	}
+
+	if config.APIKey == "" {
+		return nil, fmt.Errorf("gandi: no API Key given")
+	}
+
+	if config.BaseURL == "" {
+		config.BaseURL = defaultBaseURL
+	}
+
 	return &DNSProvider{
-		apiKey:              apiKey,
+		config:              config,
 		inProgressFQDNs:     make(map[string]inProgressInfo),
 		inProgressAuthZones: make(map[string]struct{}),
-		client:              &http.Client{Timeout: 60 * time.Second},
 	}, nil
 }
 
@@ -76,27 +119,27 @@ func NewDNSProviderCredentials(apiKey string) (*DNSProvider, error) {
 // does this by creating and activating a new temporary Gandi DNS
 // zone. This new zone contains the TXT record.
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
-	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
-	if ttl < 300 {
-		ttl = 300 // 300 is gandi minimum value for ttl
+	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
+
+	if d.config.TTL < minTTL {
+		d.config.TTL = minTTL // 300 is gandi minimum value for ttl
 	}
 
 	// find authZone and Gandi zone_id for fqdn
 	authZone, err := findZoneByFqdn(fqdn, acme.RecursiveNameservers)
 	if err != nil {
-		return fmt.Errorf("Gandi DNS: findZoneByFqdn failure: %v", err)
+		return fmt.Errorf("gandi: findZoneByFqdn failure: %v", err)
 	}
 
 	zoneID, err := d.getZoneID(authZone)
 	if err != nil {
-		return err
+		return fmt.Errorf("gandi: %v", err)
 	}
 
 	// determine name of TXT record
 	if !strings.HasSuffix(
 		strings.ToLower(fqdn), strings.ToLower("."+authZone)) {
-		return fmt.Errorf(
-			"Gandi DNS: unexpected authZone %s for fqdn %s", authZone, fqdn)
+		return fmt.Errorf("gandi: unexpected authZone %s for fqdn %s", authZone, fqdn)
 	}
 	name := fqdn[:len(fqdn)-len("."+authZone)]
 
@@ -106,16 +149,12 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	defer d.inProgressMu.Unlock()
 
 	if _, ok := d.inProgressAuthZones[authZone]; ok {
-		return fmt.Errorf(
-			"Gandi DNS: challenge already in progress for authZone %s",
-			authZone)
+		return fmt.Errorf("gandi: challenge already in progress for authZone %s", authZone)
 	}
 
 	// perform API actions to create and activate new gandi zone
 	// containing the required TXT record
-	newZoneName := fmt.Sprintf(
-		"%s [ACME Challenge %s]",
-		acme.UnFqdn(authZone), time.Now().Format(time.RFC822Z))
+	newZoneName := fmt.Sprintf("%s [ACME Challenge %s]", acme.UnFqdn(authZone), time.Now().Format(time.RFC822Z))
 
 	newZoneID, err := d.cloneZone(zoneID, newZoneName)
 	if err != nil {
@@ -124,22 +163,22 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 
 	newZoneVersion, err := d.newZoneVersion(newZoneID)
 	if err != nil {
-		return err
+		return fmt.Errorf("gandi: %v", err)
 	}
 
-	err = d.addTXTRecord(newZoneID, newZoneVersion, name, value, ttl)
+	err = d.addTXTRecord(newZoneID, newZoneVersion, name, value, d.config.TTL)
 	if err != nil {
-		return err
+		return fmt.Errorf("gandi: %v", err)
 	}
 
 	err = d.setZoneVersion(newZoneID, newZoneVersion)
 	if err != nil {
-		return err
+		return fmt.Errorf("gandi: %v", err)
 	}
 
 	err = d.setZone(authZone, newZoneID)
 	if err != nil {
-		return err
+		return fmt.Errorf("gandi: %v", err)
 	}
 
 	// save data necessary for CleanUp
@@ -149,6 +188,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		authZone:  authZone,
 	}
 	d.inProgressAuthZones[authZone] = struct{}{}
+
 	return nil
 }
 
@@ -157,6 +197,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 // removing the temporary one created by Present.
 func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	fqdn, _, _ := acme.DNS01Record(domain, keyAuth)
+
 	// acquire lock and retrieve zoneID, newZoneID and authZone
 	d.inProgressMu.Lock()
 	defer d.inProgressMu.Unlock()
@@ -175,7 +216,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	// perform API actions to restore old gandi zone for authZone
 	err := d.setZone(authZone, zoneID)
 	if err != nil {
-		return err
+		return fmt.Errorf("gandi: %v", err)
 	}
 
 	return d.deleteZone(newZoneID)
@@ -185,109 +226,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 // are used by the acme package as timeout and check interval values
 // when checking for DNS record propagation with Gandi.
 func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
-	return 40 * time.Minute, 60 * time.Second
-}
-
-// types for XML-RPC method calls and parameters
-
-type param interface {
-	param()
-}
-type paramString struct {
-	XMLName xml.Name `xml:"param"`
-	Value   string   `xml:"value>string"`
-}
-type paramInt struct {
-	XMLName xml.Name `xml:"param"`
-	Value   int      `xml:"value>int"`
-}
-
-type structMember interface {
-	structMember()
-}
-type structMemberString struct {
-	Name  string `xml:"name"`
-	Value string `xml:"value>string"`
-}
-type structMemberInt struct {
-	Name  string `xml:"name"`
-	Value int    `xml:"value>int"`
-}
-type paramStruct struct {
-	XMLName       xml.Name       `xml:"param"`
-	StructMembers []structMember `xml:"value>struct>member"`
-}
-
-func (p paramString) param()               {}
-func (p paramInt) param()                  {}
-func (m structMemberString) structMember() {}
-func (m structMemberInt) structMember()    {}
-func (p paramStruct) param()               {}
-
-type methodCall struct {
-	XMLName    xml.Name `xml:"methodCall"`
-	MethodName string   `xml:"methodName"`
-	Params     []param  `xml:"params"`
-}
-
-// types for XML-RPC responses
-
-type response interface {
-	faultCode() int
-	faultString() string
-}
-
-type responseFault struct {
-	FaultCode   int    `xml:"fault>value>struct>member>value>int"`
-	FaultString string `xml:"fault>value>struct>member>value>string"`
-}
-
-func (r responseFault) faultCode() int      { return r.FaultCode }
-func (r responseFault) faultString() string { return r.FaultString }
-
-type responseStruct struct {
-	responseFault
-	StructMembers []struct {
-		Name     string `xml:"name"`
-		ValueInt int    `xml:"value>int"`
-	} `xml:"params>param>value>struct>member"`
-}
-
-type responseInt struct {
-	responseFault
-	Value int `xml:"params>param>value>int"`
-}
-
-type responseBool struct {
-	responseFault
-	Value bool `xml:"params>param>value>boolean"`
-}
-
-// POSTing/Marshalling/Unmarshalling
-
-type rpcError struct {
-	faultCode   int
-	faultString string
-}
-
-func (e rpcError) Error() string {
-	return fmt.Sprintf(
-		"Gandi DNS: RPC Error: (%d) %s", e.faultCode, e.faultString)
-}
-
-func (d *DNSProvider) httpPost(url string, bodyType string, body io.Reader) ([]byte, error) {
-	resp, err := d.client.Post(url, bodyType, body)
-	if err != nil {
-		return nil, fmt.Errorf("Gandi DNS: HTTP Post Error: %v", err)
-	}
-	defer resp.Body.Close()
-
-	b, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("Gandi DNS: HTTP Post Error: %v", err)
-	}
-
-	return b, nil
+	return d.config.PropagationTimeout, d.config.PollingInterval
 }
 
 // rpcCall makes an XML-RPC call to Gandi's RPC endpoint by
@@ -298,12 +237,12 @@ func (d *DNSProvider) rpcCall(call *methodCall, resp response) error {
 	// marshal
 	b, err := xml.MarshalIndent(call, "", "  ")
 	if err != nil {
-		return fmt.Errorf("Gandi DNS: Marshal Error: %v", err)
+		return fmt.Errorf("marshal error: %v", err)
 	}
 
 	// post
 	b = append([]byte(`<?xml version="1.0"?>`+"\n"), b...)
-	respBody, err := d.httpPost(endpoint, "text/xml", bytes.NewReader(b))
+	respBody, err := d.httpPost(d.config.BaseURL, "text/xml", bytes.NewReader(b))
 	if err != nil {
 		return err
 	}
@@ -311,7 +250,7 @@ func (d *DNSProvider) rpcCall(call *methodCall, resp response) error {
 	// unmarshal
 	err = xml.Unmarshal(respBody, resp)
 	if err != nil {
-		return fmt.Errorf("Gandi DNS: Unmarshal Error: %v", err)
+		return fmt.Errorf("unmarshal error: %v", err)
 	}
 	if resp.faultCode() != 0 {
 		return rpcError{
@@ -327,7 +266,7 @@ func (d *DNSProvider) getZoneID(domain string) (int, error) {
 	err := d.rpcCall(&methodCall{
 		MethodName: "domain.info",
 		Params: []param{
-			paramString{Value: d.apiKey},
+			paramString{Value: d.config.APIKey},
 			paramString{Value: domain},
 		},
 	}, resp)
@@ -343,8 +282,7 @@ func (d *DNSProvider) getZoneID(domain string) (int, error) {
 	}
 
 	if zoneID == 0 {
-		return 0, fmt.Errorf(
-			"Gandi DNS: Could not determine zone_id for %s", domain)
+		return 0, fmt.Errorf("could not determine zone_id for %s", domain)
 	}
 	return zoneID, nil
 }
@@ -354,7 +292,7 @@ func (d *DNSProvider) cloneZone(zoneID int, name string) (int, error) {
 	err := d.rpcCall(&methodCall{
 		MethodName: "domain.zone.clone",
 		Params: []param{
-			paramString{Value: d.apiKey},
+			paramString{Value: d.config.APIKey},
 			paramInt{Value: zoneID},
 			paramInt{Value: 0},
 			paramStruct{
@@ -378,7 +316,7 @@ func (d *DNSProvider) cloneZone(zoneID int, name string) (int, error) {
 	}
 
 	if newZoneID == 0 {
-		return 0, fmt.Errorf("Gandi DNS: Could not determine cloned zone_id")
+		return 0, fmt.Errorf("could not determine cloned zone_id")
 	}
 	return newZoneID, nil
 }
@@ -388,7 +326,7 @@ func (d *DNSProvider) newZoneVersion(zoneID int) (int, error) {
 	err := d.rpcCall(&methodCall{
 		MethodName: "domain.zone.version.new",
 		Params: []param{
-			paramString{Value: d.apiKey},
+			paramString{Value: d.config.APIKey},
 			paramInt{Value: zoneID},
 		},
 	}, resp)
@@ -397,7 +335,7 @@ func (d *DNSProvider) newZoneVersion(zoneID int) (int, error) {
 	}
 
 	if resp.Value == 0 {
-		return 0, fmt.Errorf("Gandi DNS: Could not create new zone version")
+		return 0, fmt.Errorf("could not create new zone version")
 	}
 	return resp.Value, nil
 }
@@ -407,7 +345,7 @@ func (d *DNSProvider) addTXTRecord(zoneID int, version int, name string, value s
 	err := d.rpcCall(&methodCall{
 		MethodName: "domain.zone.record.add",
 		Params: []param{
-			paramString{Value: d.apiKey},
+			paramString{Value: d.config.APIKey},
 			paramInt{Value: zoneID},
 			paramInt{Value: version},
 			paramStruct{
@@ -436,7 +374,7 @@ func (d *DNSProvider) setZoneVersion(zoneID int, version int) error {
 	err := d.rpcCall(&methodCall{
 		MethodName: "domain.zone.version.set",
 		Params: []param{
-			paramString{Value: d.apiKey},
+			paramString{Value: d.config.APIKey},
 			paramInt{Value: zoneID},
 			paramInt{Value: version},
 		},
@@ -446,7 +384,7 @@ func (d *DNSProvider) setZoneVersion(zoneID int, version int) error {
 	}
 
 	if !resp.Value {
-		return fmt.Errorf("Gandi DNS: could not set zone version")
+		return fmt.Errorf("could not set zone version")
 	}
 	return nil
 }
@@ -456,7 +394,7 @@ func (d *DNSProvider) setZone(domain string, zoneID int) error {
 	err := d.rpcCall(&methodCall{
 		MethodName: "domain.zone.set",
 		Params: []param{
-			paramString{Value: d.apiKey},
+			paramString{Value: d.config.APIKey},
 			paramString{Value: domain},
 			paramInt{Value: zoneID},
 		},
@@ -473,8 +411,7 @@ func (d *DNSProvider) setZone(domain string, zoneID int) error {
 	}
 
 	if respZoneID != zoneID {
-		return fmt.Errorf(
-			"Gandi DNS: Could not set new zone_id for %s", domain)
+		return fmt.Errorf("could not set new zone_id for %s", domain)
 	}
 	return nil
 }
@@ -484,7 +421,7 @@ func (d *DNSProvider) deleteZone(zoneID int) error {
 	err := d.rpcCall(&methodCall{
 		MethodName: "domain.zone.delete",
 		Params: []param{
-			paramString{Value: d.apiKey},
+			paramString{Value: d.config.APIKey},
 			paramInt{Value: zoneID},
 		},
 	}, resp)
@@ -493,7 +430,22 @@ func (d *DNSProvider) deleteZone(zoneID int) error {
 	}
 
 	if !resp.Value {
-		return fmt.Errorf("Gandi DNS: could not delete zone_id")
+		return fmt.Errorf("could not delete zone_id")
 	}
 	return nil
+}
+
+func (d *DNSProvider) httpPost(url string, bodyType string, body io.Reader) ([]byte, error) {
+	resp, err := d.config.HTTPClient.Post(url, bodyType, body)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP Post Error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP Post Error: %v", err)
+	}
+
+	return b, nil
 }

--- a/providers/dns/gandiv5/client.go
+++ b/providers/dns/gandiv5/client.go
@@ -1,0 +1,18 @@
+package gandiv5
+
+// types for JSON method calls and parameters
+
+type addFieldRequest struct {
+	RRSetTTL    int      `json:"rrset_ttl"`
+	RRSetValues []string `json:"rrset_values"`
+}
+
+type deleteFieldRequest struct {
+	Delete bool `json:"delete"`
+}
+
+// types for JSON responses
+
+type responseStruct struct {
+	Message string `json:"message"`
+}

--- a/providers/dns/gandiv5/gandiv5.go
+++ b/providers/dns/gandiv5/gandiv5.go
@@ -5,6 +5,7 @@ package gandiv5
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -18,15 +19,15 @@ import (
 
 // Gandi API reference:       http://doc.livedns.gandi.net/
 
-var (
-	// endpoint is the Gandi API endpoint used by Present and
-	// CleanUp. It is overridden during tests.
-	endpoint = "https://dns.api.gandi.net/api/v5"
-
-	// findZoneByFqdn determines the DNS zone of an fqdn. It is overridden
-	// during tests.
-	findZoneByFqdn = acme.FindZoneByFqdn
+const (
+	// defaultBaseURL endpoint is the Gandi API endpoint used by Present and CleanUp.
+	defaultBaseURL = "https://dns.api.gandi.net/api/v5"
+	minTTL         = 300
 )
+
+// findZoneByFqdn determines the DNS zone of an fqdn.
+// It is overridden during tests.
+var findZoneByFqdn = acme.FindZoneByFqdn
 
 // inProgressInfo contains information about an in-progress challenge
 type inProgressInfo struct {
@@ -34,14 +35,35 @@ type inProgressInfo struct {
 	authZone  string
 }
 
+// Config is used to configure the creation of the DNSProvider
+type Config struct {
+	BaseURL            string
+	APIKey             string
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+	TTL                int
+	HTTPClient         *http.Client
+}
+
+// NewDefaultConfig returns a default configuration for the DNSProvider
+func NewDefaultConfig() *Config {
+	return &Config{
+		TTL:                env.GetOrDefaultInt("GANDIV5_TTL", minTTL),
+		PropagationTimeout: env.GetOrDefaultSecond("GANDIV5_PROPAGATION_TIMEOUT", 20*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond("GANDIV5_POLLING_INTERVAL", 20*time.Second),
+		HTTPClient: &http.Client{
+			Timeout: env.GetOrDefaultSecond("GANDIV5_HTTP_TIMEOUT", 10*time.Second),
+		},
+	}
+}
+
 // DNSProvider is an implementation of the
 // acme.ChallengeProviderTimeout interface that uses Gandi's LiveDNS
 // API to manage TXT records for a domain.
 type DNSProvider struct {
-	apiKey          string
+	config          *Config
 	inProgressFQDNs map[string]inProgressInfo
 	inProgressMu    sync.Mutex
-	client          *http.Client
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for Gandi.
@@ -49,43 +71,63 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("GANDIV5_API_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("GandiDNS: %v", err)
+		return nil, fmt.Errorf("gandi: %v", err)
 	}
 
-	return NewDNSProviderCredentials(values["GANDIV5_API_KEY"])
+	config := NewDefaultConfig()
+	config.APIKey = values["GANDIV5_API_KEY"]
+
+	return NewDNSProviderConfig(config)
 }
 
-// NewDNSProviderCredentials uses the supplied credentials to return a
-// DNSProvider instance configured for Gandi.
+// NewDNSProviderCredentials uses the supplied credentials
+// to return a DNSProvider instance configured for Gandi.
+// Deprecated
 func NewDNSProviderCredentials(apiKey string) (*DNSProvider, error) {
-	if apiKey == "" {
-		return nil, fmt.Errorf("Gandi DNS: No Gandi API Key given")
+	config := NewDefaultConfig()
+	config.APIKey = apiKey
+
+	return NewDNSProviderConfig(config)
+}
+
+// NewDNSProviderConfig return a DNSProvider instance configured for Gandi.
+func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
+	if config == nil {
+		return nil, errors.New("gandiv5: the configuration of the DNS provider is nil")
 	}
+
+	if config.APIKey == "" {
+		return nil, fmt.Errorf("gandiv5: no API Key given")
+	}
+
+	if config.BaseURL == "" {
+		config.BaseURL = defaultBaseURL
+	}
+
 	return &DNSProvider{
-		apiKey:          apiKey,
+		config:          config,
 		inProgressFQDNs: make(map[string]inProgressInfo),
-		client:          &http.Client{Timeout: 10 * time.Second},
 	}, nil
 }
 
 // Present creates a TXT record using the specified parameters.
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
-	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
-	if ttl < 300 {
-		ttl = 300 // 300 is gandi minimum value for ttl
+	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
+
+	if d.config.TTL < minTTL {
+		d.config.TTL = minTTL // 300 is gandi minimum value for ttl
 	}
 
 	// find authZone
 	authZone, err := findZoneByFqdn(fqdn, acme.RecursiveNameservers)
 	if err != nil {
-		return fmt.Errorf("Gandi DNS: findZoneByFqdn failure: %v", err)
+		return fmt.Errorf("gandiv5: findZoneByFqdn failure: %v", err)
 	}
 
 	// determine name of TXT record
 	if !strings.HasSuffix(
 		strings.ToLower(fqdn), strings.ToLower("."+authZone)) {
-		return fmt.Errorf(
-			"Gandi DNS: unexpected authZone %s for fqdn %s", authZone, fqdn)
+		return fmt.Errorf("gandiv5: unexpected authZone %s for fqdn %s", authZone, fqdn)
 	}
 	name := fqdn[:len(fqdn)-len("."+authZone)]
 
@@ -95,7 +137,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	defer d.inProgressMu.Unlock()
 
 	// add TXT record into authZone
-	err = d.addTXTRecord(acme.UnFqdn(authZone), name, value, ttl)
+	err = d.addTXTRecord(acme.UnFqdn(authZone), name, value, d.config.TTL)
 	if err != nil {
 		return err
 	}
@@ -125,37 +167,47 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	delete(d.inProgressFQDNs, fqdn)
 
 	// delete TXT record from authZone
-	return d.deleteTXTRecord(acme.UnFqdn(authZone), fieldName)
+	err := d.deleteTXTRecord(acme.UnFqdn(authZone), fieldName)
+	if err != nil {
+		return fmt.Errorf("gandiv5: %v", err)
+	}
+	return nil
 }
 
 // Timeout returns the values (20*time.Minute, 20*time.Second) which
 // are used by the acme package as timeout and check interval values
 // when checking for DNS record propagation with Gandi.
 func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
-	return 20 * time.Minute, 20 * time.Second
+	return d.config.PropagationTimeout, d.config.PollingInterval
 }
 
-// types for JSON method calls and parameters
+// functions to perform API actions
 
-type addFieldRequest struct {
-	RRSetTTL    int      `json:"rrset_ttl"`
-	RRSetValues []string `json:"rrset_values"`
+func (d *DNSProvider) addTXTRecord(domain string, name string, value string, ttl int) error {
+	target := fmt.Sprintf("domains/%s/records/%s/TXT", domain, name)
+	response, err := d.sendRequest(http.MethodPut, target, addFieldRequest{
+		RRSetTTL:    ttl,
+		RRSetValues: []string{value},
+	})
+	if response != nil {
+		log.Infof("gandiv5: %s", response.Message)
+	}
+	return err
 }
 
-type deleteFieldRequest struct {
-	Delete bool `json:"delete"`
+func (d *DNSProvider) deleteTXTRecord(domain string, name string) error {
+	target := fmt.Sprintf("domains/%s/records/%s/TXT", domain, name)
+	response, err := d.sendRequest(http.MethodDelete, target, deleteFieldRequest{
+		Delete: true,
+	})
+	if response != nil && response.Message == "" {
+		log.Infof("gandiv5: Zone record deleted")
+	}
+	return err
 }
-
-// types for JSON responses
-
-type responseStruct struct {
-	Message string `json:"message"`
-}
-
-// POSTing/Marshalling/Unmarshalling
 
 func (d *DNSProvider) sendRequest(method string, resource string, payload interface{}) (*responseStruct, error) {
-	url := fmt.Sprintf("%s/%s", endpoint, resource)
+	url := fmt.Sprintf("%s/%s", d.config.BaseURL, resource)
 
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -168,19 +220,20 @@ func (d *DNSProvider) sendRequest(method string, resource string, payload interf
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	if len(d.apiKey) > 0 {
-		req.Header.Set("X-Api-Key", d.apiKey)
+	if len(d.config.APIKey) > 0 {
+		req.Header.Set("X-Api-Key", d.config.APIKey)
 	}
 
-	resp, err := d.client.Do(req)
+	resp, err := d.config.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("Gandi DNS: request failed with HTTP status code %d", resp.StatusCode)
+		return nil, fmt.Errorf("request failed with HTTP status code %d", resp.StatusCode)
 	}
+
 	var response responseStruct
 	err = json.NewDecoder(resp.Body).Decode(&response)
 	if err != nil && method != http.MethodDelete {
@@ -188,29 +241,4 @@ func (d *DNSProvider) sendRequest(method string, resource string, payload interf
 	}
 
 	return &response, nil
-}
-
-// functions to perform API actions
-
-func (d *DNSProvider) addTXTRecord(domain string, name string, value string, ttl int) error {
-	target := fmt.Sprintf("domains/%s/records/%s/TXT", domain, name)
-	response, err := d.sendRequest(http.MethodPut, target, addFieldRequest{
-		RRSetTTL:    ttl,
-		RRSetValues: []string{value},
-	})
-	if response != nil {
-		log.Infof("Gandi DNS: %s", response.Message)
-	}
-	return err
-}
-
-func (d *DNSProvider) deleteTXTRecord(domain string, name string) error {
-	target := fmt.Sprintf("domains/%s/records/%s/TXT", domain, name)
-	response, err := d.sendRequest(http.MethodDelete, target, deleteFieldRequest{
-		Delete: true,
-	})
-	if response != nil && response.Message == "" {
-		log.Infof("Gandi DNS: Zone record deleted")
-	}
-	return err
 }

--- a/providers/dns/gandiv5/gandiv5_test.go
+++ b/providers/dns/gandiv5/gandiv5_test.go
@@ -15,11 +15,7 @@ import (
 // TestDNSProvider runs Present and CleanUp against a fake Gandi RPC
 // Server, whose responses are predetermined for particular requests.
 func TestDNSProvider(t *testing.T) {
-	fakeAPIKey := "123412341234123412341234"
 	fakeKeyAuth := "XXXX"
-
-	provider, err := NewDNSProviderCredentials(fakeAPIKey)
-	require.NoError(t, err)
 
 	regexpToken, err := regexp.Compile(`"rrset_values":\[".+"\]`)
 	require.NoError(t, err)
@@ -46,13 +42,19 @@ func TestDNSProvider(t *testing.T) {
 		return "example.com.", nil
 	}
 
-	// override gandi endpoint and findZoneByFqdn function
-	savedEndpoint, savedFindZoneByFqdn := endpoint, findZoneByFqdn
-	defer func() {
-		endpoint, findZoneByFqdn = savedEndpoint, savedFindZoneByFqdn
-	}()
+	config := NewDefaultConfig()
+	config.APIKey = "123412341234123412341234"
+	config.BaseURL = fakeServer.URL
 
-	endpoint, findZoneByFqdn = fakeServer.URL, fakeFindZoneByFqdn
+	provider, err := NewDNSProviderConfig(config)
+	require.NoError(t, err)
+
+	// override findZoneByFqdn function
+	savedFindZoneByFqdn := findZoneByFqdn
+	defer func() {
+		findZoneByFqdn = savedFindZoneByFqdn
+	}()
+	findZoneByFqdn = fakeFindZoneByFqdn
 
 	// run Present
 	err = provider.Present("abc.def.example.com", "", fakeKeyAuth)

--- a/providers/dns/gcloud/googlecloud.go
+++ b/providers/dns/gcloud/googlecloud.go
@@ -4,29 +4,47 @@ package gcloud
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"time"
 
 	"github.com/xenolf/lego/acme"
-
+	"github.com/xenolf/lego/platform/config/env"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2/google"
-
 	"google.golang.org/api/dns/v1"
 )
 
-// DNSProvider is an implementation of the DNSProvider interface.
-type DNSProvider struct {
-	project string
-	client  *dns.Service
+// Config is used to configure the creation of the DNSProvider
+type Config struct {
+	Project            string
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+	TTL                int
+	HTTPClient         *http.Client
 }
 
-// NewDNSProvider returns a DNSProvider instance configured for Google Cloud
-// DNS. Project name must be passed in the environment variable: GCE_PROJECT.
-// A Service Account file can be passed in the environment variable:
-// GCE_SERVICE_ACCOUNT_FILE
+// NewDefaultConfig returns a default configuration for the DNSProvider
+func NewDefaultConfig() *Config {
+	return &Config{
+		TTL:                env.GetOrDefaultInt("GCE_TTL", 120),
+		PropagationTimeout: env.GetOrDefaultSecond("GCE_PROPAGATION_TIMEOUT", 180*time.Second),
+		PollingInterval:    env.GetOrDefaultSecond("GCE_POLLING_INTERVAL", 5*time.Second),
+	}
+}
+
+// DNSProvider is an implementation of the DNSProvider interface.
+type DNSProvider struct {
+	config *Config
+	client *dns.Service
+}
+
+// NewDNSProvider returns a DNSProvider instance configured for Google Cloud DNS.
+// Project name must be passed in the environment variable: GCE_PROJECT.
+// A Service Account file can be passed in the environment variable: GCE_SERVICE_ACCOUNT_FILE
 func NewDNSProvider() (*DNSProvider, error) {
 	if saFile, ok := os.LookupEnv("GCE_SERVICE_ACCOUNT_FILE"); ok {
 		return NewDNSProviderServiceAccount(saFile)
@@ -36,37 +54,35 @@ func NewDNSProvider() (*DNSProvider, error) {
 	return NewDNSProviderCredentials(project)
 }
 
-// NewDNSProviderCredentials uses the supplied credentials to return a
-// DNSProvider instance configured for Google Cloud DNS.
+// NewDNSProviderCredentials uses the supplied credentials
+// to return a DNSProvider instance configured for Google Cloud DNS.
 func NewDNSProviderCredentials(project string) (*DNSProvider, error) {
 	if project == "" {
-		return nil, fmt.Errorf("Google Cloud project name missing")
+		return nil, fmt.Errorf("googlecloud: project name missing")
 	}
 
 	client, err := google.DefaultClient(context.Background(), dns.NdevClouddnsReadwriteScope)
 	if err != nil {
-		return nil, fmt.Errorf("unable to get Google Cloud client: %v", err)
+		return nil, fmt.Errorf("googlecloud: unable to get Google Cloud client: %v", err)
 	}
-	svc, err := dns.New(client)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create Google Cloud DNS service: %v", err)
-	}
-	return &DNSProvider{
-		project: project,
-		client:  svc,
-	}, nil
+
+	config := NewDefaultConfig()
+	config.Project = project
+	config.HTTPClient = client
+
+	return NewDNSProviderConfig(config)
 }
 
-// NewDNSProviderServiceAccount uses the supplied service account JSON file to
-// return a DNSProvider instance configured for Google Cloud DNS.
+// NewDNSProviderServiceAccount uses the supplied service account JSON file
+// to return a DNSProvider instance configured for Google Cloud DNS.
 func NewDNSProviderServiceAccount(saFile string) (*DNSProvider, error) {
 	if saFile == "" {
-		return nil, fmt.Errorf("Google Cloud Service Account file missing")
+		return nil, fmt.Errorf("googlecloud: Service Account file missing")
 	}
 
 	dat, err := ioutil.ReadFile(saFile)
 	if err != nil {
-		return nil, fmt.Errorf("unable to read Service Account file: %v", err)
+		return nil, fmt.Errorf("googlecloud: unable to read Service Account file: %v", err)
 	}
 
 	// read project id from service account file
@@ -75,39 +91,50 @@ func NewDNSProviderServiceAccount(saFile string) (*DNSProvider, error) {
 	}
 	err = json.Unmarshal(dat, &datJSON)
 	if err != nil || datJSON.ProjectID == "" {
-		return nil, fmt.Errorf("project ID not found in Google Cloud Service Account file")
+		return nil, fmt.Errorf("googlecloud: project ID not found in Google Cloud Service Account file")
 	}
 	project := datJSON.ProjectID
 
 	conf, err := google.JWTConfigFromJSON(dat, dns.NdevClouddnsReadwriteScope)
 	if err != nil {
-		return nil, fmt.Errorf("unable to acquire config: %v", err)
+		return nil, fmt.Errorf("googlecloud: unable to acquire config: %v", err)
 	}
 	client := conf.Client(context.Background())
 
-	svc, err := dns.New(client)
-	if err != nil {
-		return nil, fmt.Errorf("unable to create Google Cloud DNS service: %v", err)
+	config := NewDefaultConfig()
+	config.Project = project
+	config.HTTPClient = client
+
+	return NewDNSProviderConfig(config)
+}
+
+// NewDNSProviderConfig return a DNSProvider instance configured for Google Cloud DNS.
+func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
+	if config == nil {
+		return nil, errors.New("googlecloud: the configuration of the DNS provider is nil")
 	}
-	return &DNSProvider{
-		project: project,
-		client:  svc,
-	}, nil
+
+	svc, err := dns.New(config.HTTPClient)
+	if err != nil {
+		return nil, fmt.Errorf("googlecloud: unable to create Google Cloud DNS service: %v", err)
+	}
+
+	return &DNSProvider{config: config, client: svc}, nil
 }
 
 // Present creates a TXT record to fulfil the dns-01 challenge.
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
-	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
+	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
 
 	zone, err := d.getHostedZone(domain)
 	if err != nil {
-		return err
+		return fmt.Errorf("googlecloud: %v", err)
 	}
 
 	rec := &dns.ResourceRecordSet{
 		Name:    fqdn,
 		Rrdatas: []string{value},
-		Ttl:     int64(ttl),
+		Ttl:     int64(d.config.TTL),
 		Type:    "TXT",
 	}
 	change := &dns.Change{
@@ -117,25 +144,25 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	// Look for existing records.
 	existing, err := d.findTxtRecords(zone, fqdn)
 	if err != nil {
-		return err
+		return fmt.Errorf("googlecloud: %v", err)
 	}
 	if len(existing) > 0 {
 		// Attempt to delete the existing records when adding our new one.
 		change.Deletions = existing
 	}
 
-	chg, err := d.client.Changes.Create(d.project, zone, change).Do()
+	chg, err := d.client.Changes.Create(d.config.Project, zone, change).Do()
 	if err != nil {
-		return err
+		return fmt.Errorf("googlecloud: %v", err)
 	}
 
 	// wait for change to be acknowledged
 	for chg.Status == "pending" {
 		time.Sleep(time.Second)
 
-		chg, err = d.client.Changes.Get(d.project, zone, chg.Id).Do()
+		chg, err = d.client.Changes.Get(d.config.Project, zone, chg.Id).Do()
 		if err != nil {
-			return err
+			return fmt.Errorf("googlecloud: %v", err)
 		}
 	}
 
@@ -148,26 +175,26 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	zone, err := d.getHostedZone(domain)
 	if err != nil {
-		return err
+		return fmt.Errorf("googlecloud: %v", err)
 	}
 
 	records, err := d.findTxtRecords(zone, fqdn)
 	if err != nil {
-		return err
+		return fmt.Errorf("googlecloud: %v", err)
 	}
 
 	if len(records) == 0 {
 		return nil
 	}
 
-	_, err = d.client.Changes.Create(d.project, zone, &dns.Change{Deletions: records}).Do()
-	return err
+	_, err = d.client.Changes.Create(d.config.Project, zone, &dns.Change{Deletions: records}).Do()
+	return fmt.Errorf("googlecloud: %v", err)
 }
 
 // Timeout customizes the timeout values used by the ACME package for checking
 // DNS record validity.
 func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
-	return 180 * time.Second, 5 * time.Second
+	return d.config.PropagationTimeout, d.config.PollingInterval
 }
 
 // getHostedZone returns the managed-zone
@@ -178,23 +205,22 @@ func (d *DNSProvider) getHostedZone(domain string) (string, error) {
 	}
 
 	zones, err := d.client.ManagedZones.
-		List(d.project).
+		List(d.config.Project).
 		DnsName(authZone).
 		Do()
 	if err != nil {
-		return "", fmt.Errorf("GoogleCloud API call failed: %v", err)
+		return "", fmt.Errorf("API call failed: %v", err)
 	}
 
 	if len(zones.ManagedZones) == 0 {
-		return "", fmt.Errorf("no matching GoogleCloud domain found for domain %s", authZone)
+		return "", fmt.Errorf("no matching domain found for domain %s", authZone)
 	}
 
 	return zones.ManagedZones[0].Name, nil
 }
 
 func (d *DNSProvider) findTxtRecords(zone, fqdn string) ([]*dns.ResourceRecordSet, error) {
-
-	recs, err := d.client.ResourceRecordSets.List(d.project, zone).Name(fqdn).Type("TXT").Do()
+	recs, err := d.client.ResourceRecordSets.List(d.config.Project, zone).Name(fqdn).Type("TXT").Do()
 	if err != nil {
 		return nil, err
 	}

--- a/providers/dns/gcloud/googlecloud_test.go
+++ b/providers/dns/gcloud/googlecloud_test.go
@@ -60,7 +60,7 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	os.Setenv("GCE_PROJECT", "")
 
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "Google Cloud project name missing")
+	assert.EqualError(t, err, "googlecloud: project name missing")
 }
 
 func TestLiveGoogleCloudPresent(t *testing.T) {

--- a/providers/dns/glesys/client.go
+++ b/providers/dns/glesys/client.go
@@ -1,0 +1,24 @@
+package glesys
+
+// types for JSON method calls, parameters, and responses
+
+type addRecordRequest struct {
+	DomainName string `json:"domainname"`
+	Host       string `json:"host"`
+	Type       string `json:"type"`
+	Data       string `json:"data"`
+	TTL        int    `json:"ttl,omitempty"`
+}
+
+type deleteRecordRequest struct {
+	RecordID int `json:"recordid"`
+}
+
+type responseStruct struct {
+	Response struct {
+		Status struct {
+			Code int `json:"code"`
+		} `json:"status"`
+		Record deleteRecordRequest `json:"record"`
+	} `json:"response"`
+}

--- a/providers/dns/glesys/glesys.go
+++ b/providers/dns/glesys/glesys.go
@@ -5,6 +5,7 @@ package glesys
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -18,64 +19,102 @@ import (
 
 // GleSYS API reference: https://github.com/GleSYS/API/wiki/API-Documentation
 
-// domainAPI is the GleSYS API endpoint used by Present and CleanUp.
-const domainAPI = "https://api.glesys.com/domain"
+const (
+	// defaultBaseURL is the GleSYS API endpoint used by Present and CleanUp.
+	defaultBaseURL = "https://api.glesys.com/domain"
+	minTTL         = 60
+)
+
+// Config is used to configure the creation of the DNSProvider
+type Config struct {
+	APIUser            string
+	APIKey             string
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+	TTL                int
+	HTTPClient         *http.Client
+}
+
+// NewDefaultConfig returns a default configuration for the DNSProvider
+func NewDefaultConfig() *Config {
+	return &Config{
+		TTL:                env.GetOrDefaultInt("GLESYS_TTL", minTTL),
+		PropagationTimeout: env.GetOrDefaultSecond("GLESYS_PROPAGATION_TIMEOUT", 20*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond("GLESYS_POLLING_INTERVAL", 20*time.Second),
+		HTTPClient: &http.Client{
+			Timeout: env.GetOrDefaultSecond("GLESYS_HTTP_TIMEOUT", 10*time.Second),
+		},
+	}
+}
 
 // DNSProvider is an implementation of the
 // acme.ChallengeProviderTimeout interface that uses GleSYS
 // API to manage TXT records for a domain.
 type DNSProvider struct {
-	apiUser       string
-	apiKey        string
+	config        *Config
 	activeRecords map[string]int
 	inProgressMu  sync.Mutex
-	client        *http.Client
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for GleSYS.
-// Credentials must be passed in the environment variables: GLESYS_API_USER
-// and GLESYS_API_KEY.
+// Credentials must be passed in the environment variables:
+// GLESYS_API_USER and GLESYS_API_KEY.
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("GLESYS_API_USER", "GLESYS_API_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("GleSYS DNS: %v", err)
+		return nil, fmt.Errorf("glesys: %v", err)
 	}
 
-	return NewDNSProviderCredentials(values["GLESYS_API_USER"], values["GLESYS_API_KEY"])
+	config := NewDefaultConfig()
+	config.APIUser = values["GLESYS_API_USER"]
+	config.APIKey = values["GLESYS_API_KEY"]
+
+	return NewDNSProviderConfig(config)
 }
 
-// NewDNSProviderCredentials uses the supplied credentials to return a
-// DNSProvider instance configured for GleSYS.
+// NewDNSProviderCredentials uses the supplied credentials
+// to return a DNSProvider instance configured for GleSYS.
+// Deprecated
 func NewDNSProviderCredentials(apiUser string, apiKey string) (*DNSProvider, error) {
-	if apiUser == "" || apiKey == "" {
-		return nil, fmt.Errorf("GleSYS DNS: Incomplete credentials provided")
+	config := NewDefaultConfig()
+	config.APIUser = apiUser
+	config.APIKey = apiKey
+
+	return NewDNSProviderConfig(config)
+}
+
+// NewDNSProviderConfig return a DNSProvider instance configured for GleSYS.
+func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
+	if config == nil {
+		return nil, errors.New("glesys: the configuration of the DNS provider is nil")
+	}
+
+	if config.APIUser == "" || config.APIKey == "" {
+		return nil, fmt.Errorf("glesys: incomplete credentials provided")
 	}
 
 	return &DNSProvider{
-		apiUser:       apiUser,
-		apiKey:        apiKey,
 		activeRecords: make(map[string]int),
-		client:        &http.Client{Timeout: 10 * time.Second},
 	}, nil
 }
 
 // Present creates a TXT record using the specified parameters.
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
-	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
-	if ttl < 60 {
-		ttl = 60 // 60 is GleSYS minimum value for ttl
+	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
+
+	if d.config.TTL < minTTL {
+		d.config.TTL = minTTL // 60 is GleSYS minimum value for ttl
 	}
 	// find authZone
 	authZone, err := acme.FindZoneByFqdn(fqdn, acme.RecursiveNameservers)
 	if err != nil {
-		return fmt.Errorf("GleSYS DNS: findZoneByFqdn failure: %v", err)
+		return fmt.Errorf("glesys: findZoneByFqdn failure: %v", err)
 	}
 
 	// determine name of TXT record
 	if !strings.HasSuffix(
 		strings.ToLower(fqdn), strings.ToLower("."+authZone)) {
-		return fmt.Errorf(
-			"GleSYS DNS: unexpected authZone %s for fqdn %s", authZone, fqdn)
+		return fmt.Errorf("glesys: unexpected authZone %s for fqdn %s", authZone, fqdn)
 	}
 	name := fqdn[:len(fqdn)-len("."+authZone)]
 
@@ -85,7 +124,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	defer d.inProgressMu.Unlock()
 
 	// add TXT record into authZone
-	recordID, err := d.addTXTRecord(domain, acme.UnFqdn(authZone), name, value, ttl)
+	recordID, err := d.addTXTRecord(domain, acme.UnFqdn(authZone), name, value, d.config.TTL)
 	if err != nil {
 		return err
 	}
@@ -118,36 +157,13 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 // are used by the acme package as timeout and check interval values
 // when checking for DNS record propagation with GleSYS.
 func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
-	return 20 * time.Minute, 20 * time.Second
-}
-
-// types for JSON method calls, parameters, and responses
-
-type addRecordRequest struct {
-	DomainName string `json:"domainname"`
-	Host       string `json:"host"`
-	Type       string `json:"type"`
-	Data       string `json:"data"`
-	TTL        int    `json:"ttl,omitempty"`
-}
-
-type deleteRecordRequest struct {
-	RecordID int `json:"recordid"`
-}
-
-type responseStruct struct {
-	Response struct {
-		Status struct {
-			Code int `json:"code"`
-		} `json:"status"`
-		Record deleteRecordRequest `json:"record"`
-	} `json:"response"`
+	return d.config.PropagationTimeout, d.config.PollingInterval
 }
 
 // POSTing/Marshalling/Unmarshalling
 
 func (d *DNSProvider) sendRequest(method string, resource string, payload interface{}) (*responseStruct, error) {
-	url := fmt.Sprintf("%s/%s", domainAPI, resource)
+	url := fmt.Sprintf("%s/%s", defaultBaseURL, resource)
 
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -160,16 +176,16 @@ func (d *DNSProvider) sendRequest(method string, resource string, payload interf
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	req.SetBasicAuth(d.apiUser, d.apiKey)
+	req.SetBasicAuth(d.config.APIUser, d.config.APIKey)
 
-	resp, err := d.client.Do(req)
+	resp, err := d.config.HTTPClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("GleSYS DNS: request failed with HTTP status code %d", resp.StatusCode)
+		return nil, fmt.Errorf("request failed with HTTP status code %d", resp.StatusCode)
 	}
 
 	var response responseStruct
@@ -190,7 +206,7 @@ func (d *DNSProvider) addTXTRecord(fqdn string, domain string, name string, valu
 	})
 
 	if response != nil && response.Response.Status.Code == http.StatusOK {
-		log.Infof("[%s] GleSYS DNS: Successfully created record id %d", fqdn, response.Response.Record.RecordID)
+		log.Infof("[%s]: Successfully created record id %d", fqdn, response.Response.Record.RecordID)
 		return response.Response.Record.RecordID, nil
 	}
 	return 0, err
@@ -201,7 +217,7 @@ func (d *DNSProvider) deleteTXTRecord(fqdn string, recordid int) error {
 		RecordID: recordid,
 	})
 	if response != nil && response.Response.Status.Code == 200 {
-		log.Infof("[%s] GleSYS DNS: Successfully deleted record id %d", fqdn, recordid)
+		log.Infof("[%s]: Successfully deleted record id %d", fqdn, recordid)
 	}
 	return err
 }

--- a/providers/dns/iij/iij_test.go
+++ b/providers/dns/iij/iij_test.go
@@ -95,7 +95,7 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	os.Setenv("IIJ_DO_SERVICE_CODE", "")
 
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "IIJ: some credentials information are missing: IIJ_API_ACCESS_KEY,IIJ_API_SECRET_KEY,IIJ_DO_SERVICE_CODE")
+	assert.EqualError(t, err, "iij: some credentials information are missing: IIJ_API_ACCESS_KEY,IIJ_API_SECRET_KEY,IIJ_DO_SERVICE_CODE")
 }
 
 func TestNewDNSProvider(t *testing.T) {

--- a/providers/dns/lightsail/lightsail_test.go
+++ b/providers/dns/lightsail/lightsail_test.go
@@ -43,8 +43,10 @@ func makeLightsailProvider(ts *httptest.Server) (*DNSProvider, error) {
 		return nil, err
 	}
 
+	conf := NewDefaultConfig()
+
 	client := lightsail.New(sess)
-	return &DNSProvider{client: client}, nil
+	return &DNSProvider{client: client, config: conf}, nil
 }
 
 func TestCredentialsFromEnv(t *testing.T) {

--- a/providers/dns/linode/linode_test.go
+++ b/providers/dns/linode/linode_test.go
@@ -86,17 +86,22 @@ func TestNewDNSProviderWithoutEnv(t *testing.T) {
 	os.Setenv("LINODE_API_KEY", "")
 
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "Linode: some credentials information are missing: LINODE_API_KEY")
+	assert.EqualError(t, err, "linode: some credentials information are missing: LINODE_API_KEY")
 }
 
 func TestNewDNSProviderCredentialsWithKey(t *testing.T) {
-	_, err := NewDNSProviderCredentials("testing")
+	config := NewDefaultConfig()
+	config.APIKey = "testing"
+
+	_, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 }
 
 func TestNewDNSProviderCredentialsWithoutKey(t *testing.T) {
-	_, err := NewDNSProviderCredentials("")
-	assert.EqualError(t, err, "Linode credentials missing")
+	config := NewDefaultConfig()
+
+	_, err := NewDNSProviderConfig(config)
+	assert.EqualError(t, err, "linode: credentials missing")
 }
 
 func TestDNSProvider_Present(t *testing.T) {

--- a/providers/dns/namecheap/client.go
+++ b/providers/dns/namecheap/client.go
@@ -1,0 +1,44 @@
+package namecheap
+
+import "encoding/xml"
+
+// host describes a DNS record returned by the Namecheap DNS gethosts API.
+// Namecheap uses the term "host" to refer to all DNS records that include
+// a host field (A, AAAA, CNAME, NS, TXT, URL).
+type host struct {
+	Type    string `xml:",attr"`
+	Name    string `xml:",attr"`
+	Address string `xml:",attr"`
+	MXPref  string `xml:",attr"`
+	TTL     string `xml:",attr"`
+}
+
+// apierror describes an error record in a namecheap API response.
+type apierror struct {
+	Number      int    `xml:",attr"`
+	Description string `xml:",innerxml"`
+}
+
+type setHostsResponse struct {
+	XMLName xml.Name   `xml:"ApiResponse"`
+	Status  string     `xml:"Status,attr"`
+	Errors  []apierror `xml:"Errors>Error"`
+	Result  struct {
+		IsSuccess string `xml:",attr"`
+	} `xml:"CommandResponse>DomainDNSSetHostsResult"`
+}
+
+type getHostsResponse struct {
+	XMLName xml.Name   `xml:"ApiResponse"`
+	Status  string     `xml:"Status,attr"`
+	Errors  []apierror `xml:"Errors>Error"`
+	Hosts   []host     `xml:"CommandResponse>DomainDNSGetHostsResult>host"`
+}
+
+type getTldsResponse struct {
+	XMLName xml.Name   `xml:"ApiResponse"`
+	Errors  []apierror `xml:"Errors>Error"`
+	Result  []struct {
+		Name string `xml:",attr"`
+	} `xml:"CommandResponse>Tlds>Tld"`
+}

--- a/providers/dns/namecheap/namecheap.go
+++ b/providers/dns/namecheap/namecheap.go
@@ -4,10 +4,12 @@ package namecheap
 
 import (
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -29,84 +31,175 @@ import (
 //    address as a form or query string value. This code uses a namecheap
 //    service to query the client's IP address.
 
-var (
-	debug          = false
+const (
 	defaultBaseURL = "https://api.namecheap.com/xml.response"
 	getIPURL       = "https://dynamicdns.park-your-domain.com/getip"
 )
 
+// A challenge represents all the data needed to specify a dns-01 challenge
+// to lets-encrypt.
+type challenge struct {
+	domain   string
+	key      string
+	keyFqdn  string
+	keyValue string
+	tld      string
+	sld      string
+	host     string
+}
+
+// Config is used to configure the creation of the DNSProvider
+type Config struct {
+	Debug              bool
+	BaseURL            string
+	APIUser            string
+	APIKey             string
+	ClientIP           string
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+	TTL                int
+	HTTPClient         *http.Client
+}
+
+// NewDefaultConfig returns a default configuration for the DNSProvider
+func NewDefaultConfig() *Config {
+	return &Config{
+		BaseURL:            defaultBaseURL,
+		Debug:              env.GetOrDefaultBool("NAMECHEAP_DEBUG", false),
+		TTL:                env.GetOrDefaultInt("NAMECHEAP_TTL", 120),
+		PropagationTimeout: env.GetOrDefaultSecond("NAMECHEAP_PROPAGATION_TIMEOUT", 60*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond("NAMECHEAP_POLLING_INTERVAL", 15*time.Second),
+		HTTPClient: &http.Client{
+			Timeout: env.GetOrDefaultSecond("NAMECHEAP_HTTP_TIMEOUT", 60*time.Second),
+		},
+	}
+}
+
 // DNSProvider is an implementation of the ChallengeProviderTimeout interface
 // that uses Namecheap's tool API to manage TXT records for a domain.
 type DNSProvider struct {
-	baseURL  string
-	apiUser  string
-	apiKey   string
-	clientIP string
-	client   *http.Client
+	config *Config
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for namecheap.
-// Credentials must be passed in the environment variables: NAMECHEAP_API_USER
-// and NAMECHEAP_API_KEY.
+// Credentials must be passed in the environment variables:
+// NAMECHEAP_API_USER and NAMECHEAP_API_KEY.
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("NAMECHEAP_API_USER", "NAMECHEAP_API_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("NameCheap: %v", err)
+		return nil, fmt.Errorf("namecheap: %v", err)
 	}
 
-	return NewDNSProviderCredentials(values["NAMECHEAP_API_USER"], values["NAMECHEAP_API_KEY"])
+	config := NewDefaultConfig()
+	config.APIUser = values["NAMECHEAP_API_USER"]
+	config.APIKey = values["NAMECHEAP_API_KEY"]
+
+	return NewDNSProviderConfig(config)
 }
 
-// NewDNSProviderCredentials uses the supplied credentials to return a
-// DNSProvider instance configured for namecheap.
+// NewDNSProviderCredentials uses the supplied credentials
+// to return a DNSProvider instance configured for namecheap.
+// Deprecated
 func NewDNSProviderCredentials(apiUser, apiKey string) (*DNSProvider, error) {
-	if apiUser == "" || apiKey == "" {
-		return nil, fmt.Errorf("Namecheap credentials missing")
-	}
+	config := NewDefaultConfig()
+	config.APIUser = apiUser
+	config.APIKey = apiKey
 
-	client := &http.Client{Timeout: 60 * time.Second}
-
-	clientIP, err := getClientIP(client)
-	if err != nil {
-		return nil, err
-	}
-
-	return &DNSProvider{
-		baseURL:  defaultBaseURL,
-		apiUser:  apiUser,
-		apiKey:   apiKey,
-		clientIP: clientIP,
-		client:   client,
-	}, nil
+	return NewDNSProviderConfig(config)
 }
 
-// Timeout returns the timeout and interval to use when checking for DNS
-// propagation. Namecheap can sometimes take a long time to complete an
-// update, so wait up to 60 minutes for the update to propagate.
+// NewDNSProviderConfig return a DNSProvider instance configured for namecheap.
+func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
+	if config == nil {
+		return nil, errors.New("namecheap: the configuration of the DNS provider is nil")
+	}
+
+	if config.APIUser == "" || config.APIKey == "" {
+		return nil, fmt.Errorf("namecheap: credentials missing")
+	}
+
+	if len(config.ClientIP) == 0 {
+		clientIP, err := getClientIP(config.HTTPClient, config.Debug)
+		if err != nil {
+			return nil, fmt.Errorf("namecheap: %v", err)
+		}
+		config.ClientIP = clientIP
+	}
+
+	return &DNSProvider{config: config}, nil
+}
+
+// Timeout returns the timeout and interval to use when checking for DNS propagation.
+// Namecheap can sometimes take a long time to complete an update, so wait up to 60 minutes for the update to propagate.
 func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
-	return 60 * time.Minute, 15 * time.Second
+	return d.config.PropagationTimeout, d.config.PollingInterval
 }
 
-// host describes a DNS record returned by the Namecheap DNS gethosts API.
-// Namecheap uses the term "host" to refer to all DNS records that include
-// a host field (A, AAAA, CNAME, NS, TXT, URL).
-type host struct {
-	Type    string `xml:",attr"`
-	Name    string `xml:",attr"`
-	Address string `xml:",attr"`
-	MXPref  string `xml:",attr"`
-	TTL     string `xml:",attr"`
+// Present installs a TXT record for the DNS challenge.
+func (d *DNSProvider) Present(domain, token, keyAuth string) error {
+	tlds, err := d.getTLDs()
+	if err != nil {
+		return fmt.Errorf("namecheap: %v", err)
+	}
+
+	ch, err := newChallenge(domain, keyAuth, tlds)
+	if err != nil {
+		return fmt.Errorf("namecheap: %v", err)
+	}
+
+	hosts, err := d.getHosts(ch)
+	if err != nil {
+		return fmt.Errorf("namecheap: %v", err)
+	}
+
+	d.addChallengeRecord(ch, &hosts)
+
+	if d.config.Debug {
+		for _, h := range hosts {
+			log.Printf(
+				"%-5.5s %-30.30s %-6s %-70.70s\n",
+				h.Type, h.Name, h.TTL, h.Address)
+		}
+	}
+
+	err = d.setHosts(ch, hosts)
+	if err != nil {
+		return fmt.Errorf("namecheap: %v", err)
+	}
+	return nil
 }
 
-// apierror describes an error record in a namecheap API response.
-type apierror struct {
-	Number      int    `xml:",attr"`
-	Description string `xml:",innerxml"`
+// CleanUp removes a TXT record used for a previous DNS challenge.
+func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
+	tlds, err := d.getTLDs()
+	if err != nil {
+		return fmt.Errorf("namecheap: %v", err)
+	}
+
+	ch, err := newChallenge(domain, keyAuth, tlds)
+	if err != nil {
+		return fmt.Errorf("namecheap: %v", err)
+	}
+
+	hosts, err := d.getHosts(ch)
+	if err != nil {
+		return fmt.Errorf("namecheap: %v", err)
+	}
+
+	if removed := d.removeChallengeRecord(ch, &hosts); !removed {
+		return nil
+	}
+
+	err = d.setHosts(ch, hosts)
+	if err != nil {
+		return fmt.Errorf("namecheap: %v", err)
+	}
+	return nil
 }
 
-// getClientIP returns the client's public IP address. It uses namecheap's
-// IP discovery service to perform the lookup.
-func getClientIP(client *http.Client) (addr string, err error) {
+// getClientIP returns the client's public IP address.
+// It uses namecheap's IP discovery service to perform the lookup.
+func getClientIP(client *http.Client, debug bool) (addr string, err error) {
 	resp, err := client.Get(getIPURL)
 	if err != nil {
 		return "", err
@@ -122,18 +215,6 @@ func getClientIP(client *http.Client) (addr string, err error) {
 		log.Println("Client IP:", string(clientIP))
 	}
 	return string(clientIP), nil
-}
-
-// A challenge represents all the data needed to specify a dns-01 challenge
-// to lets-encrypt.
-type challenge struct {
-	domain   string
-	key      string
-	keyFqdn  string
-	keyValue string
-	tld      string
-	sld      string
-	host     string
 }
 
 // newChallenge builds a challenge record from a domain name, a challenge
@@ -178,11 +259,11 @@ func newChallenge(domain, keyAuth string, tlds map[string]string) (*challenge, e
 // setGlobalParams adds the namecheap global parameters to the provided url
 // Values record.
 func (d *DNSProvider) setGlobalParams(v *url.Values, cmd string) {
-	v.Set("ApiUser", d.apiUser)
-	v.Set("ApiKey", d.apiKey)
-	v.Set("UserName", d.apiUser)
-	v.Set("ClientIp", d.clientIP)
+	v.Set("ApiUser", d.config.APIUser)
+	v.Set("ApiKey", d.config.APIKey)
+	v.Set("UserName", d.config.APIUser)
 	v.Set("Command", cmd)
+	v.Set("ClientIp", d.config.ClientIP)
 }
 
 // getTLDs requests the list of available TLDs from namecheap.
@@ -190,10 +271,13 @@ func (d *DNSProvider) getTLDs() (tlds map[string]string, err error) {
 	values := make(url.Values)
 	d.setGlobalParams(&values, "namecheap.domains.getTldList")
 
-	reqURL, _ := url.Parse(d.baseURL)
+	reqURL, err := url.Parse(d.config.BaseURL)
+	if err != nil {
+		return nil, err
+	}
 	reqURL.RawQuery = values.Encode()
 
-	resp, err := d.client.Get(reqURL.String())
+	resp, err := d.config.HTTPClient.Get(reqURL.String())
 	if err != nil {
 		return nil, err
 	}
@@ -208,21 +292,12 @@ func (d *DNSProvider) getTLDs() (tlds map[string]string, err error) {
 		return nil, err
 	}
 
-	type GetTldsResponse struct {
-		XMLName xml.Name   `xml:"ApiResponse"`
-		Errors  []apierror `xml:"Errors>Error"`
-		Result  []struct {
-			Name string `xml:",attr"`
-		} `xml:"CommandResponse>Tlds>Tld"`
-	}
-
-	var gtr GetTldsResponse
+	var gtr getTldsResponse
 	if err := xml.Unmarshal(body, &gtr); err != nil {
 		return nil, err
 	}
 	if len(gtr.Errors) > 0 {
-		return nil, fmt.Errorf("Namecheap error: %s [%d]",
-			gtr.Errors[0].Description, gtr.Errors[0].Number)
+		return nil, fmt.Errorf("%s [%d]", gtr.Errors[0].Description, gtr.Errors[0].Number)
 	}
 
 	tlds = make(map[string]string)
@@ -236,13 +311,17 @@ func (d *DNSProvider) getTLDs() (tlds map[string]string, err error) {
 func (d *DNSProvider) getHosts(ch *challenge) (hosts []host, err error) {
 	values := make(url.Values)
 	d.setGlobalParams(&values, "namecheap.domains.dns.getHosts")
+
 	values.Set("SLD", ch.sld)
 	values.Set("TLD", ch.tld)
 
-	reqURL, _ := url.Parse(d.baseURL)
+	reqURL, err := url.Parse(d.config.BaseURL)
+	if err != nil {
+		return nil, err
+	}
 	reqURL.RawQuery = values.Encode()
 
-	resp, err := d.client.Get(reqURL.String())
+	resp, err := d.config.HTTPClient.Get(reqURL.String())
 	if err != nil {
 		return nil, err
 	}
@@ -257,20 +336,12 @@ func (d *DNSProvider) getHosts(ch *challenge) (hosts []host, err error) {
 		return nil, err
 	}
 
-	type GetHostsResponse struct {
-		XMLName xml.Name   `xml:"ApiResponse"`
-		Status  string     `xml:"Status,attr"`
-		Errors  []apierror `xml:"Errors>Error"`
-		Hosts   []host     `xml:"CommandResponse>DomainDNSGetHostsResult>host"`
-	}
-
-	var ghr GetHostsResponse
+	var ghr getHostsResponse
 	if err = xml.Unmarshal(body, &ghr); err != nil {
 		return nil, err
 	}
 	if len(ghr.Errors) > 0 {
-		return nil, fmt.Errorf("Namecheap error: %s [%d]",
-			ghr.Errors[0].Description, ghr.Errors[0].Number)
+		return nil, fmt.Errorf("%s [%d]", ghr.Errors[0].Description, ghr.Errors[0].Number)
 	}
 
 	return ghr.Hosts, nil
@@ -280,6 +351,7 @@ func (d *DNSProvider) getHosts(ch *challenge) (hosts []host, err error) {
 func (d *DNSProvider) setHosts(ch *challenge, hosts []host) error {
 	values := make(url.Values)
 	d.setGlobalParams(&values, "namecheap.domains.dns.setHosts")
+
 	values.Set("SLD", ch.sld)
 	values.Set("TLD", ch.tld)
 
@@ -292,7 +364,7 @@ func (d *DNSProvider) setHosts(ch *challenge, hosts []host) error {
 		values.Add("TTL"+ind, h.TTL)
 	}
 
-	resp, err := d.client.PostForm(d.baseURL, values)
+	resp, err := d.config.HTTPClient.PostForm(d.config.BaseURL, values)
 	if err != nil {
 		return err
 	}
@@ -307,25 +379,15 @@ func (d *DNSProvider) setHosts(ch *challenge, hosts []host) error {
 		return err
 	}
 
-	type SetHostsResponse struct {
-		XMLName xml.Name   `xml:"ApiResponse"`
-		Status  string     `xml:"Status,attr"`
-		Errors  []apierror `xml:"Errors>Error"`
-		Result  struct {
-			IsSuccess string `xml:",attr"`
-		} `xml:"CommandResponse>DomainDNSSetHostsResult"`
-	}
-
-	var shr SetHostsResponse
+	var shr setHostsResponse
 	if err := xml.Unmarshal(body, &shr); err != nil {
 		return err
 	}
 	if len(shr.Errors) > 0 {
-		return fmt.Errorf("Namecheap error: %s [%d]",
-			shr.Errors[0].Description, shr.Errors[0].Number)
+		return fmt.Errorf("%s [%d]", shr.Errors[0].Description, shr.Errors[0].Number)
 	}
 	if shr.Result.IsSuccess != "true" {
-		return fmt.Errorf("Namecheap setHosts failed")
+		return fmt.Errorf("setHosts failed")
 	}
 
 	return nil
@@ -339,7 +401,7 @@ func (d *DNSProvider) addChallengeRecord(ch *challenge, hosts *[]host) {
 		Type:    "TXT",
 		Address: ch.keyValue,
 		MXPref:  "10",
-		TTL:     "120",
+		TTL:     strconv.Itoa(d.config.TTL),
 	}
 
 	// If there's already a TXT record with the same name, replace it.
@@ -366,58 +428,4 @@ func (d *DNSProvider) removeChallengeRecord(ch *challenge, hosts *[]host) bool {
 	}
 
 	return false
-}
-
-// Present installs a TXT record for the DNS challenge.
-func (d *DNSProvider) Present(domain, token, keyAuth string) error {
-	tlds, err := d.getTLDs()
-	if err != nil {
-		return err
-	}
-
-	ch, err := newChallenge(domain, keyAuth, tlds)
-	if err != nil {
-		return err
-	}
-
-	hosts, err := d.getHosts(ch)
-	if err != nil {
-		return err
-	}
-
-	d.addChallengeRecord(ch, &hosts)
-
-	if debug {
-		for _, h := range hosts {
-			log.Printf(
-				"%-5.5s %-30.30s %-6s %-70.70s\n",
-				h.Type, h.Name, h.TTL, h.Address)
-		}
-	}
-
-	return d.setHosts(ch, hosts)
-}
-
-// CleanUp removes a TXT record used for a previous DNS challenge.
-func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
-	tlds, err := d.getTLDs()
-	if err != nil {
-		return err
-	}
-
-	ch, err := newChallenge(domain, keyAuth, tlds)
-	if err != nil {
-		return err
-	}
-
-	hosts, err := d.getHosts(ch)
-	if err != nil {
-		return err
-	}
-
-	if removed := d.removeChallengeRecord(ch, &hosts); !removed {
-		return nil
-	}
-
-	return d.setHosts(ch, hosts)
 }

--- a/providers/dns/namedotcom/namedotcom.go
+++ b/providers/dns/namedotcom/namedotcom.go
@@ -3,66 +3,115 @@
 package namedotcom
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/namedotcom/go/namecom"
 	"github.com/xenolf/lego/acme"
 	"github.com/xenolf/lego/platform/config/env"
 )
 
+// Config is used to configure the creation of the DNSProvider
+type Config struct {
+	Username           string
+	APIToken           string
+	Server             string
+	TTL                int
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+	HTTPClient         *http.Client
+}
+
+// NewDefaultConfig returns a default configuration for the DNSProvider
+func NewDefaultConfig() *Config {
+	return &Config{
+		TTL:                env.GetOrDefaultInt("NAMECOM_TTL", 120),
+		PropagationTimeout: env.GetOrDefaultSecond("NAMECOM_PROPAGATION_TIMEOUT", acme.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond("NAMECOM_POLLING_INTERVAL", acme.DefaultPollingInterval),
+		HTTPClient: &http.Client{
+			Timeout: env.GetOrDefaultSecond("NAMECOM_HTTP_TIMEOUT", 10*time.Second),
+		},
+	}
+}
+
 // DNSProvider is an implementation of the acme.ChallengeProvider interface.
 type DNSProvider struct {
 	client *namecom.NameCom
+	config *Config
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for namedotcom.
-// Credentials must be passed in the environment variables: NAMECOM_USERNAME and NAMECOM_API_TOKEN
+// Credentials must be passed in the environment variables:
+// NAMECOM_USERNAME and NAMECOM_API_TOKEN
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("NAMECOM_USERNAME", "NAMECOM_API_TOKEN")
 	if err != nil {
-		return nil, fmt.Errorf("Name.com: %v", err)
+		return nil, fmt.Errorf("namedotcom: %v", err)
 	}
 
-	server := os.Getenv("NAMECOM_SERVER")
-	return NewDNSProviderCredentials(values["NAMECOM_USERNAME"], values["NAMECOM_API_TOKEN"], server)
+	config := NewDefaultConfig()
+	config.Username = values["NAMECOM_USERNAME"]
+	config.APIToken = values["NAMECOM_API_TOKEN"]
+	config.Server = os.Getenv("NAMECOM_SERVER")
+
+	return NewDNSProviderConfig(config)
 }
 
-// NewDNSProviderCredentials uses the supplied credentials to return a
-// DNSProvider instance configured for namedotcom.
+// NewDNSProviderCredentials uses the supplied credentials
+// to return a DNSProvider instance configured for namedotcom.
+// Deprecated
 func NewDNSProviderCredentials(username, apiToken, server string) (*DNSProvider, error) {
-	if username == "" {
-		return nil, fmt.Errorf("Name.com Username is required")
-	}
-	if apiToken == "" {
-		return nil, fmt.Errorf("Name.com API token is required")
+	config := NewDefaultConfig()
+	config.Username = username
+	config.APIToken = apiToken
+	config.Server = server
+
+	return NewDNSProviderConfig(config)
+}
+
+// NewDNSProviderConfig return a DNSProvider instance configured for namedotcom.
+func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
+	if config == nil {
+		return nil, errors.New("namedotcom: the configuration of the DNS provider is nil")
 	}
 
-	client := namecom.New(username, apiToken)
-
-	if server != "" {
-		client.Server = server
+	if config.Username == "" {
+		return nil, fmt.Errorf("namedotcom: username is required")
 	}
 
-	return &DNSProvider{client: client}, nil
+	if config.APIToken == "" {
+		return nil, fmt.Errorf("namedotcom: API token is required")
+	}
+
+	client := namecom.New(config.Username, config.APIToken)
+	client.Client = config.HTTPClient
+
+	if config.Server != "" {
+		client.Server = config.Server
+	}
+
+	return &DNSProvider{client: client, config: config}, nil
 }
 
 // Present creates a TXT record to fulfil the dns-01 challenge.
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
-	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
+	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
 
 	request := &namecom.Record{
 		DomainName: domain,
 		Host:       d.extractRecordName(fqdn, domain),
 		Type:       "TXT",
-		TTL:        uint32(ttl),
+		TTL:        uint32(d.config.TTL),
 		Answer:     value,
 	}
 
 	_, err := d.client.CreateRecord(request)
 	if err != nil {
-		return fmt.Errorf("Name.com API call failed: %v", err)
+		return fmt.Errorf("namedotcom: API call failed: %v", err)
 	}
 
 	return nil
@@ -74,7 +123,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	records, err := d.getRecords(domain)
 	if err != nil {
-		return err
+		return fmt.Errorf("namedotcom: %v", err)
 	}
 
 	for _, rec := range records {
@@ -85,7 +134,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 			}
 			_, err := d.client.DeleteRecord(request)
 			if err != nil {
-				return err
+				return fmt.Errorf("namedotcom: %v", err)
 			}
 		}
 	}
@@ -93,20 +142,21 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	return nil
 }
 
-func (d *DNSProvider) getRecords(domain string) ([]*namecom.Record, error) {
-	var (
-		err      error
-		records  []*namecom.Record
-		response *namecom.ListRecordsResponse
-	)
+// Timeout returns the timeout and interval to use when checking for DNS propagation.
+// Adjusting here to cope with spikes in propagation times.
+func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
+	return d.config.PropagationTimeout, d.config.PollingInterval
+}
 
+func (d *DNSProvider) getRecords(domain string) ([]*namecom.Record, error) {
 	request := &namecom.ListRecordsRequest{
 		DomainName: domain,
 		Page:       1,
 	}
 
+	var records []*namecom.Record
 	for request.Page > 0 {
-		response, err = d.client.ListRecords(request)
+		response, err := d.client.ListRecords(request)
 		if err != nil {
 			return nil, err
 		}

--- a/providers/dns/namedotcom/namedotcom_test.go
+++ b/providers/dns/namedotcom/namedotcom_test.go
@@ -32,7 +32,12 @@ func TestLiveNamedotcomPresent(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	provider, err := NewDNSProviderCredentials(namedotcomUsername, namedotcomAPIToken, namedotcomServer)
+	config := NewDefaultConfig()
+	config.Username = namedotcomUsername
+	config.APIToken = namedotcomAPIToken
+	config.Server = namedotcomServer
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	err = provider.Present(namedotcomDomain, "", "123d==")
@@ -50,7 +55,12 @@ func TestLiveNamedotcomCleanUp(t *testing.T) {
 
 	time.Sleep(time.Second * 1)
 
-	provider, err := NewDNSProviderCredentials(namedotcomUsername, namedotcomAPIToken, namedotcomServer)
+	config := NewDefaultConfig()
+	config.Username = namedotcomUsername
+	config.APIToken = namedotcomAPIToken
+	config.Server = namedotcomServer
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	err = provider.CleanUp(namedotcomDomain, "", "123d==")

--- a/providers/dns/netcup/client_test.go
+++ b/providers/dns/netcup/client_test.go
@@ -2,10 +2,8 @@ package netcup
 
 import (
 	"fmt"
-	"net/http"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/xenolf/lego/acme"
@@ -17,10 +15,7 @@ func TestClientAuth(t *testing.T) {
 	}
 
 	// Setup
-	httpClient := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-	client := NewClient(httpClient, testCustomerNumber, testAPIKey, testAPIPassword)
+	client := NewClient(testCustomerNumber, testAPIKey, testAPIPassword)
 
 	for i := 1; i < 4; i++ {
 		i := i
@@ -42,10 +37,7 @@ func TestClientGetDnsRecords(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	httpClient := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-	client := NewClient(httpClient, testCustomerNumber, testAPIKey, testAPIPassword)
+	client := NewClient(testCustomerNumber, testAPIKey, testAPIPassword)
 
 	// Setup
 	sessionID, err := client.Login()
@@ -73,10 +65,7 @@ func TestClientUpdateDnsRecord(t *testing.T) {
 	}
 
 	// Setup
-	httpClient := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-	client := NewClient(httpClient, testCustomerNumber, testAPIKey, testAPIPassword)
+	client := NewClient(testCustomerNumber, testAPIKey, testAPIPassword)
 
 	sessionID, err := client.Login()
 	assert.NoError(t, err)
@@ -88,7 +77,7 @@ func TestClientUpdateDnsRecord(t *testing.T) {
 
 	hostname := strings.Replace(fqdn, "."+zone, "", 1)
 
-	record := CreateTxtRecord(hostname, "asdf5678")
+	record := CreateTxtRecord(hostname, "asdf5678", 120)
 
 	// test
 	zone = acme.UnFqdn(zone)

--- a/providers/dns/netcup/netcup.go
+++ b/providers/dns/netcup/netcup.go
@@ -2,6 +2,7 @@
 package netcup
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -11,37 +12,78 @@ import (
 	"github.com/xenolf/lego/platform/config/env"
 )
 
+// Config is used to configure the creation of the DNSProvider
+type Config struct {
+	Key                string
+	Password           string
+	Customer           string
+	TTL                int
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+	HTTPClient         *http.Client
+}
+
+// NewDefaultConfig returns a default configuration for the DNSProvider
+func NewDefaultConfig() *Config {
+	return &Config{
+		TTL:                env.GetOrDefaultInt("NETCUP_TTL", 120),
+		PropagationTimeout: env.GetOrDefaultSecond("NETCUP_PROPAGATION_TIMEOUT", acme.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond("NETCUP_POLLING_INTERVAL", acme.DefaultPollingInterval),
+		HTTPClient: &http.Client{
+			Timeout: env.GetOrDefaultSecond("NETCUP_HTTP_TIMEOUT", 10*time.Second),
+		},
+	}
+}
+
 // DNSProvider is an implementation of the acme.ChallengeProvider interface
 type DNSProvider struct {
 	client *Client
+	config *Config
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for netcup.
-// Credentials must be passed in the environment variables: NETCUP_CUSTOMER_NUMBER,
-// NETCUP_API_KEY, NETCUP_API_PASSWORD
+// Credentials must be passed in the environment variables:
+// NETCUP_CUSTOMER_NUMBER, NETCUP_API_KEY, NETCUP_API_PASSWORD
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("NETCUP_CUSTOMER_NUMBER", "NETCUP_API_KEY", "NETCUP_API_PASSWORD")
 	if err != nil {
 		return nil, fmt.Errorf("netcup: %v", err)
 	}
 
-	return NewDNSProviderCredentials(values["NETCUP_CUSTOMER_NUMBER"], values["NETCUP_API_KEY"], values["NETCUP_API_PASSWORD"])
+	config := NewDefaultConfig()
+	config.Customer = values["NETCUP_CUSTOMER_NUMBER"]
+	config.Key = values["NETCUP_API_KEY"]
+	config.Password = values["NETCUP_API_PASSWORD"]
+
+	return NewDNSProviderConfig(config)
 }
 
-// NewDNSProviderCredentials uses the supplied credentials to return a
-// DNSProvider instance configured for netcup.
+// NewDNSProviderCredentials uses the supplied credentials
+// to return a DNSProvider instance configured for netcup.
+// Deprecated
 func NewDNSProviderCredentials(customer, key, password string) (*DNSProvider, error) {
-	if customer == "" || key == "" || password == "" {
+	config := NewDefaultConfig()
+	config.Customer = customer
+	config.Key = key
+	config.Password = password
+
+	return NewDNSProviderConfig(config)
+}
+
+// NewDNSProviderConfig return a DNSProvider instance configured for netcup.
+func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
+	if config == nil {
+		return nil, errors.New("netcup: the configuration of the DNS provider is nil")
+	}
+
+	if config.Customer == "" || config.Key == "" || config.Password == "" {
 		return nil, fmt.Errorf("netcup: netcup credentials missing")
 	}
 
-	httpClient := &http.Client{
-		Timeout: 10 * time.Second,
-	}
+	client := NewClient(config.Customer, config.Key, config.Password)
+	client.HTTPClient = config.HTTPClient
 
-	return &DNSProvider{
-		client: NewClient(httpClient, customer, key, password),
-	}, nil
+	return &DNSProvider{client: client, config: config}, nil
 }
 
 // Present creates a TXT record to fulfill the dns-01 challenge
@@ -55,21 +97,25 @@ func (d *DNSProvider) Present(domainName, token, keyAuth string) error {
 
 	sessionID, err := d.client.Login()
 	if err != nil {
-		return err
+		return fmt.Errorf("netcup: %v", err)
 	}
 
 	hostname := strings.Replace(fqdn, "."+zone, "", 1)
-	record := CreateTxtRecord(hostname, value)
+	record := CreateTxtRecord(hostname, value, d.config.TTL)
 
 	err = d.client.UpdateDNSRecord(sessionID, acme.UnFqdn(zone), record)
 	if err != nil {
 		if errLogout := d.client.Logout(sessionID); errLogout != nil {
-			return fmt.Errorf("failed to add TXT-Record: %v; %v", err, errLogout)
+			return fmt.Errorf("netcup: failed to add TXT-Record: %v; %v", err, errLogout)
 		}
-		return fmt.Errorf("failed to add TXT-Record: %v", err)
+		return fmt.Errorf("netcup: failed to add TXT-Record: %v", err)
 	}
 
-	return d.client.Logout(sessionID)
+	err = d.client.Logout(sessionID)
+	if err != nil {
+		return fmt.Errorf("netcup: %v", err)
+	}
+	return nil
 }
 
 // CleanUp removes the TXT record matching the specified parameters
@@ -78,12 +124,12 @@ func (d *DNSProvider) CleanUp(domainname, token, keyAuth string) error {
 
 	zone, err := acme.FindZoneByFqdn(fqdn, acme.RecursiveNameservers)
 	if err != nil {
-		return fmt.Errorf("failed to find DNSZone, %v", err)
+		return fmt.Errorf("netcup: failed to find DNSZone, %v", err)
 	}
 
 	sessionID, err := d.client.Login()
 	if err != nil {
-		return err
+		return fmt.Errorf("netcup: %v", err)
 	}
 
 	hostname := strings.Replace(fqdn, "."+zone, "", 1)
@@ -92,14 +138,14 @@ func (d *DNSProvider) CleanUp(domainname, token, keyAuth string) error {
 
 	records, err := d.client.GetDNSRecords(zone, sessionID)
 	if err != nil {
-		return err
+		return fmt.Errorf("netcup: %v", err)
 	}
 
-	record := CreateTxtRecord(hostname, value)
+	record := CreateTxtRecord(hostname, value, 0)
 
 	idx, err := GetDNSRecordIdx(records, record)
 	if err != nil {
-		return err
+		return fmt.Errorf("netcup: %v", err)
 	}
 
 	records[idx].DeleteRecord = true
@@ -107,10 +153,20 @@ func (d *DNSProvider) CleanUp(domainname, token, keyAuth string) error {
 	err = d.client.UpdateDNSRecord(sessionID, zone, records[idx])
 	if err != nil {
 		if errLogout := d.client.Logout(sessionID); errLogout != nil {
-			return fmt.Errorf("%v; %v", err, errLogout)
+			return fmt.Errorf("netcup: %v; %v", err, errLogout)
 		}
-		return err
+		return fmt.Errorf("netcup: %v", err)
 	}
 
-	return d.client.Logout(sessionID)
+	err = d.client.Logout(sessionID)
+	if err != nil {
+		return fmt.Errorf("netcup: %v", err)
+	}
+	return nil
+}
+
+// Timeout returns the timeout and interval to use when checking for DNS propagation.
+// Adjusting here to cope with spikes in propagation times.
+func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
+	return d.config.PropagationTimeout, d.config.PollingInterval
 }

--- a/providers/dns/nifcloud/client_test.go
+++ b/providers/dns/nifcloud/client_test.go
@@ -31,7 +31,8 @@ func TestChangeResourceRecordSets(t *testing.T) {
 	server := runTestServer(responseBody, http.StatusOK)
 	defer server.Close()
 
-	client := newClient(nil, "", "", server.URL)
+	client := NewClient("", "")
+	client.BaseURL = server.URL
 
 	res, err := client.ChangeResourceRecordSets("example.com", ChangeResourceRecordSetsRequest{})
 	require.NoError(t, err)
@@ -82,7 +83,8 @@ func TestChangeResourceRecordSetsErrors(t *testing.T) {
 			server := runTestServer(test.responseBody, test.statusCode)
 			defer server.Close()
 
-			client := newClient(nil, "", "", server.URL)
+			client := NewClient("", "")
+			client.BaseURL = server.URL
 
 			res, err := client.ChangeResourceRecordSets("example.com", ChangeResourceRecordSetsRequest{})
 			assert.Nil(t, res)
@@ -105,7 +107,8 @@ func TestGetChange(t *testing.T) {
 	server := runTestServer(responseBody, http.StatusOK)
 	defer server.Close()
 
-	client := newClient(nil, "", "", server.URL)
+	client := NewClient("", "")
+	client.BaseURL = server.URL
 
 	res, err := client.GetChange("12345")
 	require.NoError(t, err)
@@ -156,7 +159,8 @@ func TestGetChangeErrors(t *testing.T) {
 			server := runTestServer(test.responseBody, test.statusCode)
 			defer server.Close()
 
-			client := newClient(nil, "", "", server.URL)
+			client := NewClient("", "")
+			client.BaseURL = server.URL
 
 			res, err := client.GetChange("12345")
 			assert.Nil(t, res)

--- a/providers/dns/nifcloud/nifcloud.go
+++ b/providers/dns/nifcloud/nifcloud.go
@@ -3,6 +3,7 @@
 package nifcloud
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -12,49 +13,110 @@ import (
 	"github.com/xenolf/lego/platform/config/env"
 )
 
+// Config is used to configure the creation of the DNSProvider
+type Config struct {
+	BaseURL            string
+	AccessKey          string
+	SecretKey          string
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+	TTL                int
+	HTTPClient         *http.Client
+}
+
+// NewDefaultConfig returns a default configuration for the DNSProvider
+func NewDefaultConfig() *Config {
+	return &Config{
+		TTL:                env.GetOrDefaultInt("NIFCLOUD_TTL", 120),
+		PropagationTimeout: env.GetOrDefaultSecond("NIFCLOUD_PROPAGATION_TIMEOUT", acme.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond("NIFCLOUD_POLLING_INTERVAL", acme.DefaultPollingInterval),
+		HTTPClient: &http.Client{
+			Timeout: env.GetOrDefaultSecond("NIFCLOUD_HTTP_TIMEOUT", 30*time.Second),
+		},
+	}
+}
+
 // DNSProvider implements the acme.ChallengeProvider interface
 type DNSProvider struct {
 	client *Client
+	config *Config
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for the NIFCLOUD DNS service.
-// Credentials must be passed in the environment variables: NIFCLOUD_ACCESS_KEY_ID and NIFCLOUD_SECRET_ACCESS_KEY.
+// Credentials must be passed in the environment variables:
+// NIFCLOUD_ACCESS_KEY_ID and NIFCLOUD_SECRET_ACCESS_KEY.
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("NIFCLOUD_ACCESS_KEY_ID", "NIFCLOUD_SECRET_ACCESS_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("NIFCLOUD: %v", err)
+		return nil, fmt.Errorf("nifcloud: %v", err)
 	}
 
-	endpoint := os.Getenv("NIFCLOUD_DNS_ENDPOINT")
-	if endpoint == "" {
-		endpoint = defaultEndpoint
-	}
+	config := NewDefaultConfig()
+	config.BaseURL = os.Getenv("NIFCLOUD_DNS_ENDPOINT")
+	config.AccessKey = values["NIFCLOUD_ACCESS_KEY_ID"]
+	config.SecretKey = values["NIFCLOUD_SECRET_ACCESS_KEY"]
 
-	httpClient := &http.Client{Timeout: 30 * time.Second}
-
-	return NewDNSProviderCredentials(httpClient, endpoint, values["NIFCLOUD_ACCESS_KEY_ID"], values["NIFCLOUD_SECRET_ACCESS_KEY"])
+	return NewDNSProviderConfig(config)
 }
 
-// NewDNSProviderCredentials uses the supplied credentials to return a
-// DNSProvider instance configured for NIFCLOUD.
+// NewDNSProviderCredentials uses the supplied credentials
+// to return a DNSProvider instance configured for NIFCLOUD.
+// Deprecated
 func NewDNSProviderCredentials(httpClient *http.Client, endpoint, accessKey, secretKey string) (*DNSProvider, error) {
-	client := newClient(httpClient, accessKey, secretKey, endpoint)
+	config := NewDefaultConfig()
+	config.HTTPClient = httpClient
+	config.BaseURL = endpoint
+	config.AccessKey = accessKey
+	config.SecretKey = secretKey
 
-	return &DNSProvider{
-		client: client,
-	}, nil
+	return NewDNSProviderConfig(config)
+}
+
+// NewDNSProviderConfig return a DNSProvider instance configured for NIFCLOUD.
+func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
+	if config == nil {
+		return nil, errors.New("nifcloud: the configuration of the DNS provider is nil")
+	}
+
+	client := NewClient(config.AccessKey, config.SecretKey)
+
+	if config.HTTPClient != nil {
+		client.HTTPClient = config.HTTPClient
+	}
+
+	if len(config.BaseURL) > 0 {
+		client.BaseURL = config.BaseURL
+	}
+
+	return &DNSProvider{client: client, config: config}, nil
 }
 
 // Present creates a TXT record using the specified parameters
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
-	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
-	return d.changeRecord("CREATE", fqdn, value, domain, ttl)
+	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
+
+	err := d.changeRecord("CREATE", fqdn, value, domain, d.config.TTL)
+	if err != nil {
+		return fmt.Errorf("nifcloud: %v", err)
+	}
+	return err
 }
 
 // CleanUp removes the TXT record matching the specified parameters
 func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
-	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
-	return d.changeRecord("DELETE", fqdn, value, domain, ttl)
+	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
+
+	err := d.changeRecord("DELETE", fqdn, value, domain, d.config.TTL)
+	if err != nil {
+		return fmt.Errorf("nifcloud: %v", err)
+	}
+	return err
+}
+
+// Timeout returns the timeout and interval to use when checking for DNS propagation.
+// Adjusting here to cope with spikes in propagation times.
+func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
+	return d.config.PropagationTimeout, d.config.PollingInterval
 }
 
 func (d *DNSProvider) changeRecord(action, fqdn, value, domain string, ttl int) error {

--- a/providers/dns/ns1/ns1.go
+++ b/providers/dns/ns1/ns1.go
@@ -3,6 +3,7 @@
 package ns1
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -14,9 +15,31 @@ import (
 	"gopkg.in/ns1/ns1-go.v2/rest/model/dns"
 )
 
+// Config is used to configure the creation of the DNSProvider
+type Config struct {
+	APIKey             string
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+	TTL                int
+	HTTPClient         *http.Client
+}
+
+// NewDefaultConfig returns a default configuration for the DNSProvider
+func NewDefaultConfig() *Config {
+	return &Config{
+		TTL:                env.GetOrDefaultInt("NS1_TTL", 120),
+		PropagationTimeout: env.GetOrDefaultSecond("NS1_PROPAGATION_TIMEOUT", acme.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond("NS1_POLLING_INTERVAL", acme.DefaultPollingInterval),
+		HTTPClient: &http.Client{
+			Timeout: env.GetOrDefaultSecond("NS1_HTTP_TIMEOUT", 10*time.Second),
+		},
+	}
+}
+
 // DNSProvider is an implementation of the acme.ChallengeProvider interface.
 type DNSProvider struct {
 	client *rest.Client
+	config *Config
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for NS1.
@@ -24,38 +47,53 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("NS1_API_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("NS1: %v", err)
+		return nil, fmt.Errorf("ns1: %v", err)
 	}
 
-	return NewDNSProviderCredentials(values["NS1_API_KEY"])
+	config := NewDefaultConfig()
+	config.APIKey = values["NS1_API_KEY"]
+
+	return NewDNSProviderConfig(config)
 }
 
-// NewDNSProviderCredentials uses the supplied credentials to return a
-// DNSProvider instance configured for NS1.
+// NewDNSProviderCredentials uses the supplied credentials
+// to return a DNSProvider instance configured for NS1.
+// Deprecated
 func NewDNSProviderCredentials(key string) (*DNSProvider, error) {
-	if key == "" {
-		return nil, fmt.Errorf("NS1 credentials missing")
+	config := NewDefaultConfig()
+	config.APIKey = key
+
+	return NewDNSProviderConfig(config)
+}
+
+// NewDNSProviderConfig return a DNSProvider instance configured for NS1.
+func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
+	if config == nil {
+		return nil, errors.New("ns1: the configuration of the DNS provider is nil")
 	}
 
-	httpClient := &http.Client{Timeout: time.Second * 10}
-	client := rest.NewClient(httpClient, rest.SetAPIKey(key))
+	if config.APIKey == "" {
+		return nil, fmt.Errorf("ns1: credentials missing")
+	}
 
-	return &DNSProvider{client}, nil
+	client := rest.NewClient(config.HTTPClient, rest.SetAPIKey(config.APIKey))
+
+	return &DNSProvider{client: client, config: config}, nil
 }
 
 // Present creates a TXT record to fulfil the dns-01 challenge.
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
-	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
+	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
 
 	zone, err := d.getHostedZone(domain)
 	if err != nil {
-		return err
+		return fmt.Errorf("ns1: %v", err)
 	}
 
-	record := d.newTxtRecord(zone, fqdn, value, ttl)
+	record := d.newTxtRecord(zone, fqdn, value, d.config.TTL)
 	_, err = d.client.Records.Create(record)
 	if err != nil && err != rest.ErrRecordExists {
-		return err
+		return fmt.Errorf("ns1: %v", err)
 	}
 
 	return nil
@@ -67,23 +105,29 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	zone, err := d.getHostedZone(domain)
 	if err != nil {
-		return err
+		return fmt.Errorf("ns1: %v", err)
 	}
 
 	name := acme.UnFqdn(fqdn)
 	_, err = d.client.Records.Delete(zone.Zone, name, "TXT")
-	return err
+	return fmt.Errorf("ns1: %v", err)
+}
+
+// Timeout returns the timeout and interval to use when checking for DNS propagation.
+// Adjusting here to cope with spikes in propagation times.
+func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
+	return d.config.PropagationTimeout, d.config.PollingInterval
 }
 
 func (d *DNSProvider) getHostedZone(domain string) (*dns.Zone, error) {
 	authZone, err := getAuthZone(domain)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ns1: %v", err)
 	}
 
 	zone, _, err := d.client.Zones.Get(authZone)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ns1: %v", err)
 	}
 
 	return zone, nil

--- a/providers/dns/ns1/ns1_test.go
+++ b/providers/dns/ns1/ns1_test.go
@@ -30,7 +30,10 @@ func TestNewDNSProviderValid(t *testing.T) {
 	defer restoreEnv()
 	os.Setenv("NS1_API_KEY", "")
 
-	_, err := NewDNSProviderCredentials("123")
+	config := NewDefaultConfig()
+	config.APIKey = "123"
+
+	_, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 }
 
@@ -39,7 +42,7 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	os.Setenv("NS1_API_KEY", "")
 
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "NS1: some credentials information are missing: NS1_API_KEY")
+	assert.EqualError(t, err, "ns1: some credentials information are missing: NS1_API_KEY")
 }
 
 func TestLivePresent(t *testing.T) {
@@ -47,7 +50,10 @@ func TestLivePresent(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	provider, err := NewDNSProviderCredentials(apiKey)
+	config := NewDefaultConfig()
+	config.APIKey = apiKey
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	err = provider.Present(domain, "", "123d==")
@@ -61,7 +67,10 @@ func TestLiveCleanUp(t *testing.T) {
 
 	time.Sleep(time.Second * 1)
 
-	provider, err := NewDNSProviderCredentials(apiKey)
+	config := NewDefaultConfig()
+	config.APIKey = apiKey
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	err = provider.CleanUp(domain, "", "123d==")

--- a/providers/dns/otc/client.go
+++ b/providers/dns/otc/client.go
@@ -1,0 +1,68 @@
+package otc
+
+type recordset struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Type        string   `json:"type"`
+	TTL         int      `json:"ttl"`
+	Records     []string `json:"records"`
+}
+
+type nameResponse struct {
+	Name string `json:"name"`
+}
+
+type userResponse struct {
+	Name     string       `json:"name"`
+	Password string       `json:"password"`
+	Domain   nameResponse `json:"domain"`
+}
+
+type passwordResponse struct {
+	User userResponse `json:"user"`
+}
+
+type identityResponse struct {
+	Methods  []string         `json:"methods"`
+	Password passwordResponse `json:"password"`
+}
+
+type scopeResponse struct {
+	Project nameResponse `json:"project"`
+}
+
+type authResponse struct {
+	Identity identityResponse `json:"identity"`
+	Scope    scopeResponse    `json:"scope"`
+}
+
+type loginResponse struct {
+	Auth authResponse `json:"auth"`
+}
+
+type endpointResponse struct {
+	Token struct {
+		Catalog []struct {
+			Type      string `json:"type"`
+			Endpoints []struct {
+				URL string `json:"url"`
+			} `json:"endpoints"`
+		} `json:"catalog"`
+	} `json:"token"`
+}
+
+type zoneItem struct {
+	ID string `json:"id"`
+}
+
+type zonesResponse struct {
+	Zones []zoneItem `json:"zones"`
+}
+
+type recordSet struct {
+	ID string `json:"id"`
+}
+
+type recordSetsResponse struct {
+	RecordSets []recordSet `json:"recordsets"`
+}

--- a/providers/dns/otc/otc_test.go
+++ b/providers/dns/otc/otc_test.go
@@ -31,7 +31,15 @@ func TestOTCDNSTestSuite(t *testing.T) {
 
 func (s *OTCDNSTestSuite) createDNSProvider() (*DNSProvider, error) {
 	url := fmt.Sprintf("%s/v3/auth/token", s.Mock.Server.URL)
-	return NewDNSProviderCredentials(fakeOTCUserName, fakeOTCPassword, fakeOTCDomainName, fakeOTCProjectName, url)
+
+	config := NewDefaultConfig()
+	config.UserName = fakeOTCUserName
+	config.Password = fakeOTCPassword
+	config.DomainName = fakeOTCDomainName
+	config.ProjectName = fakeOTCProjectName
+	config.IdentityEndpoint = url
+
+	return NewDNSProviderConfig(config)
 }
 
 func (s *OTCDNSTestSuite) TestOTCDNSLoginEnv() {
@@ -45,24 +53,24 @@ func (s *OTCDNSTestSuite) TestOTCDNSLoginEnv() {
 
 	provider, err := NewDNSProvider()
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), provider.domainName, "unittest1")
-	assert.Equal(s.T(), provider.userName, "unittest2")
-	assert.Equal(s.T(), provider.password, "unittest3")
-	assert.Equal(s.T(), provider.projectName, "unittest4")
-	assert.Equal(s.T(), provider.identityEndpoint, "unittest5")
+	assert.Equal(s.T(), provider.config.DomainName, "unittest1")
+	assert.Equal(s.T(), provider.config.UserName, "unittest2")
+	assert.Equal(s.T(), provider.config.Password, "unittest3")
+	assert.Equal(s.T(), provider.config.ProjectName, "unittest4")
+	assert.Equal(s.T(), provider.config.IdentityEndpoint, "unittest5")
 
 	os.Setenv("OTC_IDENTITY_ENDPOINT", "")
 
 	provider, err = NewDNSProvider()
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), provider.identityEndpoint, "https://iam.eu-de.otc.t-systems.com:443/v3/auth/tokens")
+	assert.Equal(s.T(), provider.config.IdentityEndpoint, "https://iam.eu-de.otc.t-systems.com:443/v3/auth/tokens")
 }
 
 func (s *OTCDNSTestSuite) TestOTCDNSLoginEnvEmpty() {
 	defer os.Clearenv()
 
 	_, err := NewDNSProvider()
-	assert.EqualError(s.T(), err, "OTC: some credentials information are missing: OTC_DOMAIN_NAME,OTC_USER_NAME,OTC_PASSWORD,OTC_PROJECT_NAME")
+	assert.EqualError(s.T(), err, "otc: some credentials information are missing: OTC_DOMAIN_NAME,OTC_USER_NAME,OTC_PASSWORD,OTC_PROJECT_NAME")
 }
 
 func (s *OTCDNSTestSuite) TestOTCDNSLogin() {
@@ -71,7 +79,7 @@ func (s *OTCDNSTestSuite) TestOTCDNSLogin() {
 	assert.Nil(s.T(), err)
 	err = otcProvider.loginRequest()
 	assert.Nil(s.T(), err)
-	assert.Equal(s.T(), otcProvider.otcBaseURL, fmt.Sprintf("%s/v2", s.Mock.Server.URL))
+	assert.Equal(s.T(), otcProvider.baseURL, fmt.Sprintf("%s/v2", s.Mock.Server.URL))
 	assert.Equal(s.T(), fakeOTCToken, otcProvider.token)
 }
 

--- a/providers/dns/ovh/ovh.go
+++ b/providers/dns/ovh/ovh.go
@@ -3,9 +3,12 @@
 package ovh
 
 import (
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/ovh/go-ovh/ovh"
 	"github.com/xenolf/lego/acme"
@@ -15,9 +18,34 @@ import (
 // OVH API reference:       https://eu.api.ovh.com/
 // Create a Token:					https://eu.api.ovh.com/createToken/
 
+// Config is used to configure the creation of the DNSProvider
+type Config struct {
+	APIEndpoint        string
+	ApplicationKey     string
+	ApplicationSecret  string
+	ConsumerKey        string
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+	TTL                int
+	HTTPClient         *http.Client
+}
+
+// NewDefaultConfig returns a default configuration for the DNSProvider
+func NewDefaultConfig() *Config {
+	return &Config{
+		TTL:                env.GetOrDefaultInt("OVH_TTL", 120),
+		PropagationTimeout: env.GetOrDefaultSecond("OVH_PROPAGATION_TIMEOUT", acme.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond("OVH_POLLING_INTERVAL", acme.DefaultPollingInterval),
+		HTTPClient: &http.Client{
+			Timeout: env.GetOrDefaultSecond("OVH_HTTP_TIMEOUT", ovh.DefaultTimeout),
+		},
+	}
+}
+
 // DNSProvider is an implementation of the acme.ChallengeProvider interface
 // that uses OVH's REST API to manage TXT records for a domain.
 type DNSProvider struct {
+	config      *Config
 	client      *ovh.Client
 	recordIDs   map[string]int
 	recordIDsMu sync.Mutex
@@ -32,69 +60,88 @@ type DNSProvider struct {
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("OVH_ENDPOINT", "OVH_APPLICATION_KEY", "OVH_APPLICATION_SECRET", "OVH_CONSUMER_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("OVH: %v", err)
+		return nil, fmt.Errorf("ovh: %v", err)
 	}
 
-	return NewDNSProviderCredentials(
-		values["OVH_ENDPOINT"],
-		values["OVH_APPLICATION_KEY"],
-		values["OVH_APPLICATION_SECRET"],
-		values["OVH_CONSUMER_KEY"],
-	)
+	config := NewDefaultConfig()
+	config.APIEndpoint = values["OVH_ENDPOINT"]
+	config.ApplicationKey = values["OVH_APPLICATION_KEY"]
+	config.ApplicationSecret = values["OVH_APPLICATION_SECRET"]
+	config.ConsumerKey = values["OVH_CONSUMER_KEY"]
+
+	return NewDNSProviderConfig(config)
 }
 
-// NewDNSProviderCredentials uses the supplied credentials to return a
-// DNSProvider instance configured for OVH.
+// NewDNSProviderCredentials uses the supplied credentials
+// to return a DNSProvider instance configured for OVH.
+// Deprecated
 func NewDNSProviderCredentials(apiEndpoint, applicationKey, applicationSecret, consumerKey string) (*DNSProvider, error) {
-	if apiEndpoint == "" || applicationKey == "" || applicationSecret == "" || consumerKey == "" {
-		return nil, fmt.Errorf("OVH credentials missing")
+	config := NewDefaultConfig()
+	config.APIEndpoint = apiEndpoint
+	config.ApplicationKey = applicationKey
+	config.ApplicationSecret = applicationSecret
+	config.ConsumerKey = consumerKey
+
+	return NewDNSProviderConfig(config)
+}
+
+// NewDNSProviderConfig return a DNSProvider instance configured for OVH.
+func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
+	if config == nil {
+		return nil, errors.New("ovh: the configuration of the DNS provider is nil")
 	}
 
-	ovhClient, err := ovh.NewClient(
-		apiEndpoint,
-		applicationKey,
-		applicationSecret,
-		consumerKey,
+	if config.APIEndpoint == "" || config.ApplicationKey == "" || config.ApplicationSecret == "" || config.ConsumerKey == "" {
+		return nil, fmt.Errorf("ovh: credentials missing")
+	}
+
+	client, err := ovh.NewClient(
+		config.APIEndpoint,
+		config.ApplicationKey,
+		config.ApplicationSecret,
+		config.ConsumerKey,
 	)
-
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ovh: %v", err)
 	}
+
+	client.Client = config.HTTPClient
 
 	return &DNSProvider{
-		client:    ovhClient,
+		config:    config,
+		client:    client,
 		recordIDs: make(map[string]int),
 	}, nil
 }
 
 // Present creates a TXT record to fulfil the dns-01 challenge.
 func (d *DNSProvider) Present(domain, token, keyAuth string) error {
-	fqdn, value, ttl := acme.DNS01Record(domain, keyAuth)
+	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
 
 	// Parse domain name
 	authZone, err := acme.FindZoneByFqdn(acme.ToFqdn(domain), acme.RecursiveNameservers)
 	if err != nil {
-		return fmt.Errorf("could not determine zone for domain: '%s'. %s", domain, err)
+		return fmt.Errorf("ovh: could not determine zone for domain: '%s'. %s", domain, err)
 	}
 
 	authZone = acme.UnFqdn(authZone)
 	subDomain := d.extractRecordName(fqdn, authZone)
 
 	reqURL := fmt.Sprintf("/domain/zone/%s/record", authZone)
-	reqData := txtRecordRequest{FieldType: "TXT", SubDomain: subDomain, Target: value, TTL: ttl}
+	reqData := txtRecordRequest{FieldType: "TXT", SubDomain: subDomain, Target: value, TTL: d.config.TTL}
 	var respData txtRecordResponse
 
 	// Create TXT record
 	err = d.client.Post(reqURL, reqData, &respData)
 	if err != nil {
-		return fmt.Errorf("error when call OVH api to add record: %v", err)
+		return fmt.Errorf("ovh: error when call api to add record: %v", err)
 	}
 
 	// Apply the change
 	reqURL = fmt.Sprintf("/domain/zone/%s/refresh", authZone)
 	err = d.client.Post(reqURL, nil, nil)
 	if err != nil {
-		return fmt.Errorf("error when call OVH api to refresh zone: %v", err)
+		return fmt.Errorf("ovh: error when call api to refresh zone: %v", err)
 	}
 
 	d.recordIDsMu.Lock()
@@ -113,12 +160,12 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	recordID, ok := d.recordIDs[fqdn]
 	d.recordIDsMu.Unlock()
 	if !ok {
-		return fmt.Errorf("unknown record ID for '%s'", fqdn)
+		return fmt.Errorf("ovh: unknown record ID for '%s'", fqdn)
 	}
 
 	authZone, err := acme.FindZoneByFqdn(acme.ToFqdn(domain), acme.RecursiveNameservers)
 	if err != nil {
-		return fmt.Errorf("could not determine zone for domain: '%s'. %s", domain, err)
+		return fmt.Errorf("ovh: could not determine zone for domain: '%s'. %s", domain, err)
 	}
 
 	authZone = acme.UnFqdn(authZone)
@@ -127,7 +174,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	err = d.client.Delete(reqURL, nil)
 	if err != nil {
-		return fmt.Errorf("error when call OVH api to delete challenge record: %v", err)
+		return fmt.Errorf("ovh: error when call OVH api to delete challenge record: %v", err)
 	}
 
 	// Delete record ID from map
@@ -136,6 +183,12 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	d.recordIDsMu.Unlock()
 
 	return nil
+}
+
+// Timeout returns the timeout and interval to use when checking for DNS propagation.
+// Adjusting here to cope with spikes in propagation times.
+func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
+	return d.config.PropagationTimeout, d.config.PollingInterval
 }
 
 func (d *DNSProvider) extractRecordName(fqdn, domain string) string {

--- a/providers/dns/ovh/ovh_test.go
+++ b/providers/dns/ovh/ovh_test.go
@@ -59,7 +59,7 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 				"OVH_APPLICATION_SECRET": "5678",
 				"OVH_CONSUMER_KEY":       "abcde",
 			},
-			expected: "OVH: some credentials information are missing: OVH_ENDPOINT",
+			expected: "ovh: some credentials information are missing: OVH_ENDPOINT",
 		},
 		{
 			desc: "missing OVH_APPLICATION_KEY",
@@ -69,7 +69,7 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 				"OVH_APPLICATION_SECRET": "5678",
 				"OVH_CONSUMER_KEY":       "abcde",
 			},
-			expected: "OVH: some credentials information are missing: OVH_APPLICATION_KEY",
+			expected: "ovh: some credentials information are missing: OVH_APPLICATION_KEY",
 		},
 		{
 			desc: "missing OVH_APPLICATION_SECRET",
@@ -79,7 +79,7 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 				"OVH_APPLICATION_SECRET": "",
 				"OVH_CONSUMER_KEY":       "abcde",
 			},
-			expected: "OVH: some credentials information are missing: OVH_APPLICATION_SECRET",
+			expected: "ovh: some credentials information are missing: OVH_APPLICATION_SECRET",
 		},
 		{
 			desc: "missing OVH_CONSUMER_KEY",
@@ -89,7 +89,7 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 				"OVH_APPLICATION_SECRET": "5678",
 				"OVH_CONSUMER_KEY":       "",
 			},
-			expected: "OVH: some credentials information are missing: OVH_CONSUMER_KEY",
+			expected: "ovh: some credentials information are missing: OVH_CONSUMER_KEY",
 		},
 		{
 			desc: "all missing",
@@ -99,7 +99,7 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 				"OVH_APPLICATION_SECRET": "",
 				"OVH_CONSUMER_KEY":       "",
 			},
-			expected: "OVH: some credentials information are missing: OVH_ENDPOINT,OVH_APPLICATION_KEY,OVH_APPLICATION_SECRET,OVH_CONSUMER_KEY",
+			expected: "ovh: some credentials information are missing: OVH_ENDPOINT,OVH_APPLICATION_KEY,OVH_APPLICATION_SECRET,OVH_CONSUMER_KEY",
 		},
 	}
 

--- a/providers/dns/pdns/pdns_test.go
+++ b/providers/dns/pdns/pdns_test.go
@@ -37,7 +37,12 @@ func TestNewDNSProviderValid(t *testing.T) {
 	os.Setenv("PDNS_API_KEY", "")
 
 	tmpURL, _ := url.Parse("http://localhost:8081")
-	_, err := NewDNSProviderCredentials(tmpURL, "123")
+
+	config := NewDefaultConfig()
+	config.Host = tmpURL
+	config.APIKey = "123"
+
+	_, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 }
 
@@ -56,7 +61,7 @@ func TestNewDNSProviderMissingHostErr(t *testing.T) {
 	os.Setenv("PDNS_API_KEY", "123")
 
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "PDNS: some credentials information are missing: PDNS_API_URL")
+	assert.EqualError(t, err, "pdns: some credentials information are missing: PDNS_API_URL")
 }
 
 func TestNewDNSProviderMissingKeyErr(t *testing.T) {
@@ -65,7 +70,7 @@ func TestNewDNSProviderMissingKeyErr(t *testing.T) {
 	os.Setenv("PDNS_API_KEY", "")
 
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "PDNS: some credentials information are missing: PDNS_API_KEY,PDNS_API_URL")
+	assert.EqualError(t, err, "pdns: some credentials information are missing: PDNS_API_KEY,PDNS_API_URL")
 }
 
 func TestPdnsPresentAndCleanup(t *testing.T) {
@@ -73,7 +78,11 @@ func TestPdnsPresentAndCleanup(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	provider, err := NewDNSProviderCredentials(pdnsURL, pdnsAPIKey)
+	config := NewDefaultConfig()
+	config.Host = pdnsURL
+	config.APIKey = pdnsAPIKey
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	err = provider.Present(pdnsDomain, "", "123d==")

--- a/providers/dns/rackspace/client.go
+++ b/providers/dns/rackspace/client.go
@@ -1,0 +1,47 @@
+package rackspace
+
+// APIKeyCredentials API credential
+type APIKeyCredentials struct {
+	Username string `json:"username"`
+	APIKey   string `json:"apiKey"`
+}
+
+// Auth auth credentials
+type Auth struct {
+	APIKeyCredentials `json:"RAX-KSKEY:apiKeyCredentials"`
+}
+
+// AuthData Auth data
+type AuthData struct {
+	Auth `json:"auth"`
+}
+
+// Identity  Identity
+type Identity struct {
+	Access struct {
+		ServiceCatalog []struct {
+			Endpoints []struct {
+				PublicURL string `json:"publicURL"`
+				TenantID  string `json:"tenantId"`
+			} `json:"endpoints"`
+			Name string `json:"name"`
+		} `json:"serviceCatalog"`
+		Token struct {
+			ID string `json:"id"`
+		} `json:"token"`
+	} `json:"access"`
+}
+
+// Records is the list of records sent/received from the DNS API
+type Records struct {
+	Record []Record `json:"records"`
+}
+
+// Record represents a Rackspace DNS record
+type Record struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+	Data string `json:"data"`
+	TTL  int    `json:"ttl,omitempty"`
+	ID   string `json:"id,omitempty"`
+}

--- a/providers/dns/rackspace/rackspace.go
+++ b/providers/dns/rackspace/rackspace.go
@@ -5,6 +5,7 @@ package rackspace
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -14,42 +15,85 @@ import (
 	"github.com/xenolf/lego/platform/config/env"
 )
 
-// rackspaceAPIURL represents the Identity API endpoint to call
-var rackspaceAPIURL = "https://identity.api.rackspacecloud.com/v2.0/tokens"
+// defaultBaseURL represents the Identity API endpoint to call
+const defaultBaseURL = "https://identity.api.rackspacecloud.com/v2.0/tokens"
+
+// Config is used to configure the creation of the DNSProvider
+type Config struct {
+	BaseURL            string
+	APIUser            string
+	APIKey             string
+	PropagationTimeout time.Duration
+	PollingInterval    time.Duration
+	TTL                int
+	HTTPClient         *http.Client
+}
+
+// NewDefaultConfig returns a default configuration for the DNSProvider
+func NewDefaultConfig() *Config {
+	return &Config{
+		BaseURL:            defaultBaseURL,
+		TTL:                env.GetOrDefaultInt("RACKSPACE_TTL", 300),
+		PropagationTimeout: env.GetOrDefaultSecond("RACKSPACE_PROPAGATION_TIMEOUT", acme.DefaultPropagationTimeout),
+		PollingInterval:    env.GetOrDefaultSecond("RACKSPACE_POLLING_INTERVAL", acme.DefaultPollingInterval),
+		HTTPClient: &http.Client{
+			Timeout: env.GetOrDefaultSecond("RACKSPACE_HTTP_TIMEOUT", 30*time.Second),
+		},
+	}
+}
 
 // DNSProvider is an implementation of the acme.ChallengeProvider interface
 // used to store the reusable token and DNS API endpoint
 type DNSProvider struct {
+	config           *Config
 	token            string
 	cloudDNSEndpoint string
-	client           *http.Client
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for Rackspace.
-// Credentials must be passed in the environment variables: RACKSPACE_USER
-// and RACKSPACE_API_KEY.
+// Credentials must be passed in the environment variables:
+// RACKSPACE_USER and RACKSPACE_API_KEY.
 func NewDNSProvider() (*DNSProvider, error) {
 	values, err := env.Get("RACKSPACE_USER", "RACKSPACE_API_KEY")
 	if err != nil {
-		return nil, fmt.Errorf("Rackspace: %v", err)
+		return nil, fmt.Errorf("rackspace: %v", err)
 	}
 
-	return NewDNSProviderCredentials(values["RACKSPACE_USER"], values["RACKSPACE_API_KEY"])
+	config := NewDefaultConfig()
+	config.APIUser = values["RACKSPACE_USER"]
+	config.APIKey = values["RACKSPACE_API_KEY"]
+
+	return NewDNSProviderConfig(config)
 }
 
-// NewDNSProviderCredentials uses the supplied credentials to return a
-// DNSProvider instance configured for Rackspace. It authenticates against
-// the API, also grabbing the DNS Endpoint.
+// NewDNSProviderCredentials uses the supplied credentials
+// to return a DNSProvider instance configured for Rackspace.
+// It authenticates against the API, also grabbing the DNS Endpoint.
+// Deprecated
 func NewDNSProviderCredentials(user, key string) (*DNSProvider, error) {
-	if user == "" || key == "" {
-		return nil, fmt.Errorf("Rackspace credentials missing")
+	config := NewDefaultConfig()
+	config.APIUser = user
+	config.APIKey = key
+
+	return NewDNSProviderConfig(config)
+}
+
+// NewDNSProviderConfig return a DNSProvider instance configured for Rackspace.
+// It authenticates against the API, also grabbing the DNS Endpoint.
+func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
+	if config == nil {
+		return nil, errors.New("rackspace: the configuration of the DNS provider is nil")
+	}
+
+	if config.APIUser == "" || config.APIKey == "" {
+		return nil, fmt.Errorf("rackspace: credentials missing")
 	}
 
 	authData := AuthData{
 		Auth: Auth{
 			APIKeyCredentials: APIKeyCredentials{
-				Username: user,
-				APIKey:   key,
+				Username: config.APIUser,
+				APIKey:   config.APIKey,
 			},
 		},
 	}
@@ -59,46 +103,47 @@ func NewDNSProviderCredentials(user, key string) (*DNSProvider, error) {
 		return nil, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, rackspaceAPIURL, bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, config.BaseURL, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
+	// client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := config.HTTPClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("error querying Rackspace Identity API: %v", err)
+		return nil, fmt.Errorf("rackspace: error querying Identity API: %v", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Rackspace Authentication failed. Response code: %d", resp.StatusCode)
+		return nil, fmt.Errorf("rackspace: authentication failed: response code: %d", resp.StatusCode)
 	}
 
-	var rackspaceIdentity Identity
-	err = json.NewDecoder(resp.Body).Decode(&rackspaceIdentity)
+	var identity Identity
+	err = json.NewDecoder(resp.Body).Decode(&identity)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("rackspace: %v", err)
 	}
 
 	// Iterate through the Service Catalog to get the DNS Endpoint
 	var dnsEndpoint string
-	for _, service := range rackspaceIdentity.Access.ServiceCatalog {
+	for _, service := range identity.Access.ServiceCatalog {
 		if service.Name == "cloudDNS" {
 			dnsEndpoint = service.Endpoints[0].PublicURL
 			break
 		}
 	}
 	if dnsEndpoint == "" {
-		return nil, fmt.Errorf("failed to populate DNS endpoint, check Rackspace API for changes")
+		return nil, fmt.Errorf("rackspace: failed to populate DNS endpoint, check Rackspace API for changes")
 	}
 
 	return &DNSProvider{
-		token:            rackspaceIdentity.Access.Token.ID,
+		config:           config,
+		token:            identity.Access.Token.ID,
 		cloudDNSEndpoint: dnsEndpoint,
-		client:           client,
 	}, nil
+
 }
 
 // Present creates a TXT record to fulfil the dns-01 challenge
@@ -106,7 +151,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
 	zoneID, err := d.getHostedZoneID(fqdn)
 	if err != nil {
-		return err
+		return fmt.Errorf("rackspace: %v", err)
 	}
 
 	rec := Records{
@@ -114,17 +159,20 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 			Name: acme.UnFqdn(fqdn),
 			Type: "TXT",
 			Data: value,
-			TTL:  300,
+			TTL:  d.config.TTL,
 		}},
 	}
 
 	body, err := json.Marshal(rec)
 	if err != nil {
-		return err
+		return fmt.Errorf("rackspace: %v", err)
 	}
 
 	_, err = d.makeRequest(http.MethodPost, fmt.Sprintf("/domains/%d/records", zoneID), bytes.NewReader(body))
-	return err
+	if err != nil {
+		return fmt.Errorf("rackspace: %v", err)
+	}
+	return nil
 }
 
 // CleanUp removes the TXT record matching the specified parameters
@@ -132,16 +180,25 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	fqdn, _, _ := acme.DNS01Record(domain, keyAuth)
 	zoneID, err := d.getHostedZoneID(fqdn)
 	if err != nil {
-		return err
+		return fmt.Errorf("rackspace: %v", err)
 	}
 
 	record, err := d.findTxtRecord(fqdn, zoneID)
 	if err != nil {
-		return err
+		return fmt.Errorf("rackspace: %v", err)
 	}
 
 	_, err = d.makeRequest(http.MethodDelete, fmt.Sprintf("/domains/%d/records?id=%s", zoneID, record.ID), nil)
-	return err
+	if err != nil {
+		return fmt.Errorf("rackspace: %v", err)
+	}
+	return nil
+}
+
+// Timeout returns the timeout and interval to use when checking for DNS propagation.
+// Adjusting here to cope with spikes in propagation times.
+func (d *DNSProvider) Timeout() (timeout, interval time.Duration) {
+	return d.config.PropagationTimeout, d.config.PollingInterval
 }
 
 // getHostedZoneID performs a lookup to get the DNS zone which needs
@@ -216,8 +273,7 @@ func (d *DNSProvider) makeRequest(method, uri string, body io.Reader) (json.RawM
 	req.Header.Set("X-Auth-Token", d.token)
 	req.Header.Set("Content-Type", "application/json")
 
-	client := http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := d.config.HTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error querying DNS API: %v", err)
 	}
@@ -235,50 +291,4 @@ func (d *DNSProvider) makeRequest(method, uri string, body io.Reader) (json.RawM
 	}
 
 	return r, nil
-}
-
-// APIKeyCredentials API credential
-type APIKeyCredentials struct {
-	Username string `json:"username"`
-	APIKey   string `json:"apiKey"`
-}
-
-// Auth auth credentials
-type Auth struct {
-	APIKeyCredentials `json:"RAX-KSKEY:apiKeyCredentials"`
-}
-
-// AuthData Auth data
-type AuthData struct {
-	Auth `json:"auth"`
-}
-
-// Identity  Identity
-type Identity struct {
-	Access struct {
-		ServiceCatalog []struct {
-			Endpoints []struct {
-				PublicURL string `json:"publicURL"`
-				TenantID  string `json:"tenantId"`
-			} `json:"endpoints"`
-			Name string `json:"name"`
-		} `json:"serviceCatalog"`
-		Token struct {
-			ID string `json:"id"`
-		} `json:"token"`
-	} `json:"access"`
-}
-
-// Records is the list of records sent/received from the DNS API
-type Records struct {
-	Record []Record `json:"records"`
-}
-
-// Record represents a Rackspace DNS record
-type Record struct {
-	Name string `json:"name"`
-	Type string `json:"type"`
-	Data string `json:"data"`
-	TTL  int    `json:"ttl,omitempty"`
-	ID   string `json:"id,omitempty"`
 }

--- a/providers/dns/rfc2136/rfc2136_test.go
+++ b/providers/dns/rfc2136/rfc2136_test.go
@@ -59,7 +59,10 @@ func TestRFC2136ServerSuccess(t *testing.T) {
 	require.NoError(t, err, "Failed to start test server")
 	defer server.Shutdown()
 
-	provider, err := NewDNSProviderCredentials(addrstr, "", "", "", "")
+	config := NewDefaultConfig()
+	config.Nameserver = addrstr
+
+	provider, err := NewDNSProviderConfig(config)
 	require.NoError(t, err)
 
 	err = provider.Present(rfc2136TestDomain, "", rfc2136TestKeyAuth)
@@ -75,7 +78,10 @@ func TestRFC2136ServerError(t *testing.T) {
 	require.NoError(t, err, "Failed to start test server")
 	defer server.Shutdown()
 
-	provider, err := NewDNSProviderCredentials(addrstr, "", "", "", "")
+	config := NewDefaultConfig()
+	config.Nameserver = addrstr
+
+	provider, err := NewDNSProviderConfig(config)
 	require.NoError(t, err)
 
 	err = provider.Present(rfc2136TestDomain, "", rfc2136TestKeyAuth)
@@ -94,7 +100,12 @@ func TestRFC2136TsigClient(t *testing.T) {
 	require.NoError(t, err, "Failed to start test server")
 	defer server.Shutdown()
 
-	provider, err := NewDNSProviderCredentials(addrstr, "", rfc2136TestTsigKey, rfc2136TestTsigSecret, "")
+	config := NewDefaultConfig()
+	config.Nameserver = addrstr
+	config.TSIGKey = rfc2136TestTsigKey
+	config.TSIGSecret = rfc2136TestTsigSecret
+
+	provider, err := NewDNSProviderConfig(config)
 	require.NoError(t, err)
 
 	err = provider.Present(rfc2136TestDomain, "", rfc2136TestKeyAuth)
@@ -121,7 +132,10 @@ func TestRFC2136ValidUpdatePacket(t *testing.T) {
 	expect, err := m.Pack()
 	require.NoError(t, err, "error packing")
 
-	provider, err := NewDNSProviderCredentials(addrstr, "", "", "", "")
+	config := NewDefaultConfig()
+	config.Nameserver = addrstr
+
+	provider, err := NewDNSProviderConfig(config)
 	require.NoError(t, err)
 
 	err = provider.Present(rfc2136TestDomain, "", "1234d==")

--- a/providers/dns/route53/route53.go
+++ b/providers/dns/route53/route53.go
@@ -30,13 +30,11 @@ type Config struct {
 
 // NewDefaultConfig returns a default configuration for the DNSProvider
 func NewDefaultConfig() *Config {
-	propagationMins := env.GetOrDefaultInt("AWS_PROPAGATION_TIMEOUT", 2)
-	intervalSecs := env.GetOrDefaultInt("AWS_POLLING_INTERVAL", 4)
 	return &Config{
 		MaxRetries:         env.GetOrDefaultInt("AWS_MAX_RETRIES", 5),
 		TTL:                env.GetOrDefaultInt("AWS_TTL", 10),
-		PropagationTimeout: time.Second * time.Duration(propagationMins),
-		PollingInterval:    time.Second * time.Duration(intervalSecs),
+		PropagationTimeout: env.GetOrDefaultSecond("AWS_PROPAGATION_TIMEOUT", 2*time.Minute),
+		PollingInterval:    env.GetOrDefaultSecond("AWS_POLLING_INTERVAL", 4*time.Second),
 		HostedZoneID:       os.Getenv("AWS_HOSTED_ZONE_ID"),
 	}
 }
@@ -91,20 +89,20 @@ func NewDNSProvider() (*DNSProvider, error) {
 // DNSProvider instance
 func NewDNSProviderConfig(config *Config) (*DNSProvider, error) {
 	if config == nil {
-		return nil, errors.New("the configuration of the Route53 DNS provider is nil")
+		return nil, errors.New("route53: the configuration of the Route53 DNS provider is nil")
 	}
 
 	r := customRetryer{}
 	r.NumMaxRetries = config.MaxRetries
 	sessionCfg := request.WithRetryer(aws.NewConfig(), r)
-	session, err := session.NewSessionWithOptions(session.Options{Config: *sessionCfg})
+	sess, err := session.NewSessionWithOptions(session.Options{Config: *sessionCfg})
 	if err != nil {
 		return nil, err
 	}
-	client := route53.New(session)
+	cl := route53.New(sess)
 
 	return &DNSProvider{
-		client: client,
+		client: cl,
 		config: config,
 	}, nil
 }
@@ -118,15 +116,23 @@ func (r *DNSProvider) Timeout() (timeout, interval time.Duration) {
 // Present creates a TXT record using the specified parameters
 func (r *DNSProvider) Present(domain, token, keyAuth string) error {
 	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
-	value = `"` + value + `"`
-	return r.changeRecord("UPSERT", fqdn, value, r.config.TTL)
+
+	err := r.changeRecord("UPSERT", fqdn, `"`+value+`"`, r.config.TTL)
+	if err != nil {
+		return fmt.Errorf("route53: %v", err)
+	}
+	return nil
 }
 
 // CleanUp removes the TXT record matching the specified parameters
 func (r *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	fqdn, value, _ := acme.DNS01Record(domain, keyAuth)
-	value = `"` + value + `"`
-	return r.changeRecord("DELETE", fqdn, value, r.config.TTL)
+
+	err := r.changeRecord("DELETE", fqdn, `"`+value+`"`, r.config.TTL)
+	if err != nil {
+		return fmt.Errorf("route53: %v", err)
+	}
+	return nil
 }
 
 func (r *DNSProvider) changeRecord(action, fqdn, value string, ttl int) error {
@@ -151,7 +157,7 @@ func (r *DNSProvider) changeRecord(action, fqdn, value string, ttl int) error {
 
 	resp, err := r.client.ChangeResourceRecordSets(reqParams)
 	if err != nil {
-		return fmt.Errorf("failed to change Route 53 record set: %v", err)
+		return fmt.Errorf("failed to change record set: %v", err)
 	}
 
 	statusID := resp.ChangeInfo.Id
@@ -162,7 +168,7 @@ func (r *DNSProvider) changeRecord(action, fqdn, value string, ttl int) error {
 		}
 		resp, err := r.client.GetChange(reqParams)
 		if err != nil {
-			return false, fmt.Errorf("failed to query Route 53 change status: %v", err)
+			return false, fmt.Errorf("failed to query change status: %v", err)
 		}
 		if aws.StringValue(resp.ChangeInfo.Status) == route53.ChangeStatusInsync {
 			return true, nil
@@ -200,7 +206,7 @@ func (r *DNSProvider) getHostedZoneID(fqdn string) (string, error) {
 	}
 
 	if len(hostedZoneID) == 0 {
-		return "", fmt.Errorf("zone %s not found in Route 53 for domain %s", authZone, fqdn)
+		return "", fmt.Errorf("zone %s not found for domain %s", authZone, fqdn)
 	}
 
 	if strings.HasPrefix(hostedZoneID, "/hostedzone/") {

--- a/providers/dns/sakuracloud/sakuracloud_test.go
+++ b/providers/dns/sakuracloud/sakuracloud_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/xenolf/lego/acme"
 )
 
@@ -54,7 +55,7 @@ func TestNewDNSProviderInvalidWithMissingAccessToken(t *testing.T) {
 	provider, err := NewDNSProvider()
 
 	assert.Nil(t, provider)
-	assert.EqualError(t, err, "SakuraCloud: some credentials information are missing: SAKURACLOUD_ACCESS_TOKEN,SAKURACLOUD_ACCESS_TOKEN_SECRET")
+	assert.EqualError(t, err, "sakuracloud: some credentials information are missing: SAKURACLOUD_ACCESS_TOKEN,SAKURACLOUD_ACCESS_TOKEN_SECRET")
 }
 
 //
@@ -62,18 +63,23 @@ func TestNewDNSProviderInvalidWithMissingAccessToken(t *testing.T) {
 //
 
 func TestNewDNSProviderCredentialsValid(t *testing.T) {
-	provider, err := NewDNSProviderCredentials("123", "456")
+	config := NewDefaultConfig()
+	config.Token = "123"
+	config.Secret = "456"
+
+	provider, err := NewDNSProviderConfig(config)
+	require.NoError(t, err)
 
 	assert.NotNil(t, provider)
 	assert.Equal(t, acme.UserAgent, provider.client.UserAgent)
-	assert.NoError(t, err)
 }
 
 func TestNewDNSProviderCredentialsInvalidWithMissingAccessToken(t *testing.T) {
-	provider, err := NewDNSProviderCredentials("", "")
+	config := NewDefaultConfig()
 
+	provider, err := NewDNSProviderConfig(config)
 	assert.Nil(t, provider)
-	assert.EqualError(t, err, "SakuraCloud AccessToken is missing")
+	assert.EqualError(t, err, "sakuracloud: AccessToken is missing")
 }
 
 //
@@ -85,7 +91,11 @@ func TestLiveSakuraCloudPresent(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	provider, err := NewDNSProviderCredentials(sakuracloudAccessToken, sakuracloudAccessSecret)
+	config := NewDefaultConfig()
+	config.Token = sakuracloudAccessToken
+	config.Secret = sakuracloudAccessSecret
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	err = provider.Present(sakuracloudDomain, "", "123d==")
@@ -103,7 +113,11 @@ func TestLiveSakuraCloudCleanUp(t *testing.T) {
 
 	time.Sleep(time.Second * 1)
 
-	provider, err := NewDNSProviderCredentials(sakuracloudAccessToken, sakuracloudAccessSecret)
+	config := NewDefaultConfig()
+	config.Token = sakuracloudAccessToken
+	config.Secret = sakuracloudAccessSecret
+
+	provider, err := NewDNSProviderConfig(config)
 	assert.NoError(t, err)
 
 	err = provider.CleanUp(sakuracloudDomain, "", "123d==")

--- a/providers/dns/vegadns/vegadns_test.go
+++ b/providers/dns/vegadns/vegadns_test.go
@@ -147,7 +147,7 @@ func TestVegaDNSPresentFailToFindZone(t *testing.T) {
 	require.NoError(t, err)
 
 	err = provider.Present("example.com", "token", "keyAuth")
-	assert.EqualError(t, err, "can't find Authoritative Zone for _acme-challenge.example.com. in Present: Unable to find auth zone for fqdn _acme-challenge.example.com")
+	assert.EqualError(t, err, "vegadns: can't find Authoritative Zone for _acme-challenge.example.com. in Present: Unable to find auth zone for fqdn _acme-challenge.example.com")
 }
 
 func TestVegaDNSPresentFailToCreateTXT(t *testing.T) {
@@ -161,7 +161,7 @@ func TestVegaDNSPresentFailToCreateTXT(t *testing.T) {
 	require.NoError(t, err)
 
 	err = provider.Present("example.com", "token", "keyAuth")
-	assert.EqualError(t, err, "Got bad answer from VegaDNS on CreateTXT. Code: 400. Message: ")
+	assert.EqualError(t, err, "vegadns: Got bad answer from VegaDNS on CreateTXT. Code: 400. Message: ")
 }
 
 func TestVegaDNSCleanUpSuccess(t *testing.T) {
@@ -189,7 +189,7 @@ func TestVegaDNSCleanUpFailToFindZone(t *testing.T) {
 	require.NoError(t, err)
 
 	err = provider.CleanUp("example.com", "token", "keyAuth")
-	assert.EqualError(t, err, "can't find Authoritative Zone for _acme-challenge.example.com. in CleanUp: Unable to find auth zone for fqdn _acme-challenge.example.com")
+	assert.EqualError(t, err, "vegadns: can't find Authoritative Zone for _acme-challenge.example.com. in CleanUp: Unable to find auth zone for fqdn _acme-challenge.example.com")
 }
 
 func TestVegaDNSCleanUpFailToGetRecordID(t *testing.T) {
@@ -203,7 +203,7 @@ func TestVegaDNSCleanUpFailToGetRecordID(t *testing.T) {
 	require.NoError(t, err)
 
 	err = provider.CleanUp("example.com", "token", "keyAuth")
-	assert.EqualError(t, err, "couldn't get Record ID in CleanUp: Got bad answer from VegaDNS on GetRecordID. Code: 404. Message: ")
+	assert.EqualError(t, err, "vegadns: couldn't get Record ID in CleanUp: Got bad answer from VegaDNS on GetRecordID. Code: 404. Message: ")
 }
 
 func vegaDNSMuxSuccess() *http.ServeMux {

--- a/providers/dns/vultr/vultr_test.go
+++ b/providers/dns/vultr/vultr_test.go
@@ -37,7 +37,7 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	os.Setenv("VULTR_API_KEY", "")
 
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "Vultr: some credentials information are missing: VULTR_API_KEY")
+	assert.EqualError(t, err, "vultr: some credentials information are missing: VULTR_API_KEY")
 }
 
 func TestLivePresent(t *testing.T) {


### PR DESCRIPTION
Allow to configure TTL, interval or timeout (if they are available) with env var or with a DNSProvider constructor:
- `XXX_TTL`
- `XXX_PROPAGATION_TIMEOUT`
- `XXX_POLLING_INTERVAL`
- `XXX_HTTP_TIMEOUT`

Related to #474, #475
