### PR TITLE
Rename Alibaba DNS env var.

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -203,7 +203,7 @@ Here is an example bash command using the CloudFlare DNS provider:
 	fmt.Fprintln(w, "Valid providers and their associated credential environment variables:")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "\tacme-dns:\tACME_DNS_API_BASE, ACME_DNS_STORAGE_PATH")
-	fmt.Fprintln(w, "\talidns:\tALIDNS_API_KEY, ALIDNS_SECRET_KEY")
+	fmt.Fprintln(w, "\talidns:\tALICLOUD_ACCESS_KEY, ALICLOUD_SECRET_KEY")
 	fmt.Fprintln(w, "\tazure:\tAZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_SUBSCRIPTION_ID, AZURE_TENANT_ID, AZURE_RESOURCE_GROUP")
 	fmt.Fprintln(w, "\tauroradns:\tAURORA_USER_ID, AURORA_KEY, AURORA_ENDPOINT")
 	fmt.Fprintln(w, "\tbluecat:\tBLUECAT_SERVER_URL, BLUECAT_USER_NAME, BLUECAT_PASSWORD, BLUECAT_CONFIG_NAME, BLUECAT_DNS_VIEW")

--- a/providers/dns/alidns/alidns.go
+++ b/providers/dns/alidns/alidns.go
@@ -21,16 +21,16 @@ type DNSProvider struct {
 }
 
 // NewDNSProvider returns a DNSProvider instance configured for Alibaba Cloud DNS.
-// Credentials must be passed in the environment variables: ALIDNS_API_KEY and ALIDNS_SECRET_KEY.
+// Credentials must be passed in the environment variables: ALICLOUD_ACCESS_KEY and ALICLOUD_SECRET_KEY.
 func NewDNSProvider() (*DNSProvider, error) {
-	values, err := env.Get("ALIDNS_API_KEY", "ALIDNS_SECRET_KEY")
+	values, err := env.Get("ALICLOUD_ACCESS_KEY", "ALICLOUD_SECRET_KEY")
 	if err != nil {
 		return nil, fmt.Errorf("AliDNS: %v", err)
 	}
 
-	regionID := os.Getenv("ALIDNS_REGION_ID")
+	regionID := os.Getenv("ALICLOUD_REGION_ID")
 
-	return NewDNSProviderCredentials(values["ALIDNS_API_KEY"], values["ALIDNS_SECRET_KEY"], regionID)
+	return NewDNSProviderCredentials(values["ALICLOUD_ACCESS_KEY"], values["ALICLOUD_SECRET_KEY"], regionID)
 }
 
 // NewDNSProviderCredentials uses the supplied credentials to return a DNSProvider instance configured for alidns.

--- a/providers/dns/alidns/alidns_test.go
+++ b/providers/dns/alidns/alidns_test.go
@@ -16,8 +16,8 @@ var (
 )
 
 func init() {
-	alidnsAPIKey = os.Getenv("ALIDNS_API_KEY")
-	alidnsSecretKey = os.Getenv("ALIDNS_SECRET_KEY")
+	alidnsAPIKey = os.Getenv("ALICLOUD_ACCESS_KEY")
+	alidnsSecretKey = os.Getenv("ALICLOUD_SECRET_KEY")
 	alidnsDomain = os.Getenv("ALIDNS_DOMAIN")
 
 	if len(alidnsAPIKey) > 0 && len(alidnsSecretKey) > 0 && len(alidnsDomain) > 0 {
@@ -26,14 +26,14 @@ func init() {
 }
 
 func restoreEnv() {
-	os.Setenv("ALIDNS_API_KEY", alidnsAPIKey)
-	os.Setenv("ALIDNS_SECRET_KEY", alidnsSecretKey)
+	os.Setenv("ALICLOUD_ACCESS_KEY", alidnsAPIKey)
+	os.Setenv("ALICLOUD_SECRET_KEY", alidnsSecretKey)
 }
 
 func TestNewDNSProviderValid(t *testing.T) {
 	defer restoreEnv()
-	os.Setenv("ALIDNS_API_KEY", "")
-	os.Setenv("ALIDNS_SECRET_KEY", "")
+	os.Setenv("ALICLOUD_ACCESS_KEY", "")
+	os.Setenv("ALICLOUD_SECRET_KEY", "")
 
 	_, err := NewDNSProviderCredentials("123", "123", "")
 	assert.NoError(t, err)
@@ -41,8 +41,8 @@ func TestNewDNSProviderValid(t *testing.T) {
 
 func TestNewDNSProviderValidEnv(t *testing.T) {
 	defer restoreEnv()
-	os.Setenv("ALIDNS_API_KEY", "123")
-	os.Setenv("ALIDNS_SECRET_KEY", "123")
+	os.Setenv("ALICLOUD_ACCESS_KEY", "123")
+	os.Setenv("ALICLOUD_SECRET_KEY", "123")
 
 	_, err := NewDNSProvider()
 	assert.NoError(t, err)
@@ -50,11 +50,11 @@ func TestNewDNSProviderValidEnv(t *testing.T) {
 
 func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	defer restoreEnv()
-	os.Setenv("CLOUDXNS_API_KEY", "")
-	os.Setenv("CLOUDXNS_SECRET_KEY", "")
+	os.Setenv("ALICLOUD_ACCESS_KEY", "")
+	os.Setenv("ALICLOUD_SECRET_KEY", "")
 
 	_, err := NewDNSProvider()
-	assert.EqualError(t, err, "AliDNS: some credentials information are missing: ALIDNS_API_KEY,ALIDNS_SECRET_KEY")
+	assert.EqualError(t, err, "AliDNS: some credentials information are missing: ALICLOUD_ACCESS_KEY,ALICLOUD_SECRET_KEY")
 }
 
 func TestCloudXNSPresent(t *testing.T) {


### PR DESCRIPTION
change credentials environment variables `ALIDNS_API_KEY` and `ALIDNS_SECRET_KEY` to `ALICLOUD_ACCESS_KEY` and `ALICLOUD_SECRET_KEY`

Fixes #632 