### PR TITLE
cloudflare: removed dot suffix from authzone while searching for zone.

### DIFF
--- a/providers/dns/cloudflare/cloudflare.go
+++ b/providers/dns/cloudflare/cloudflare.go
@@ -114,7 +114,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		return fmt.Errorf("cloudflare: %v", err)
 	}
 
-	zoneID, err := d.client.ZoneIDByName(authZone)
+	zoneID, err := d.client.ZoneIDByName(acme.UnFqdn(authZone))
 	if err != nil {
 		return fmt.Errorf("cloudflare: failed to find zone %s: %v", authZone, err)
 	}
@@ -149,7 +149,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 		return fmt.Errorf("cloudflare: %v", err)
 	}
 
-	zoneID, err := d.client.ZoneIDByName(authZone)
+	zoneID, err := d.client.ZoneIDByName(acme.UnFqdn(authZone))
 	if err != nil {
 		return fmt.Errorf("cloudflare: failed to find zone %s: %v", authZone, err)
 	}


### PR DESCRIPTION
Cloudfare api won't work if domain has dot suffix beause even you get zone list with suffix, it won't match the name because of the code below.

```go
func (api *API) ZoneIDByName(zoneName string) (string, error) {
	res, err := api.ListZones(zoneName)
	if err != nil {
		return "", errors.Wrap(err, "ListZones command failed")
	}
	for _, zone := range res {
		if zone.Name == zoneName {
			return zone.ID, nil
		}
	}
	return "", errors.New("Zone could not be found")
}
```

`zone.Name == zoneName` won't match because even you request with suffix, api response without suffix.