### PR TITLE
dnsmadeeasy: log response body on error

### DIFF
--- a/providers/dns/dnsmadeeasy/client.go
+++ b/providers/dns/dnsmadeeasy/client.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"time"
 )
@@ -151,7 +152,11 @@ func (c *Client) sendRequest(method, resource string, payload interface{}) (*htt
 	}
 
 	if resp.StatusCode > 299 {
-		return nil, fmt.Errorf("DNSMadeEasy API request failed with HTTP status code %d", resp.StatusCode)
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("DNSMadeEasy API request failed with HTTP status code %d", resp.StatusCode)
+		}
+		return nil, fmt.Errorf("DNSMadeEasy API request failed with HTTP status code %d: %s", resp.StatusCode, string(body))
 	}
 
 	return resp, nil

--- a/providers/dns/dnsmadeeasy/client.go
+++ b/providers/dns/dnsmadeeasy/client.go
@@ -28,6 +28,10 @@ type Record struct {
 	SourceID int    `json:"sourceId"`
 }
 
+type recordsResponse struct {
+	Records *[]Record `json:"data"`
+}
+
 // Client DNSMadeEasy client
 type Client struct {
 	apiKey     string
@@ -82,10 +86,6 @@ func (c *Client) GetRecords(domain *Domain, recordName, recordType string) (*[]R
 		return nil, err
 	}
 	defer resp.Body.Close()
-
-	type recordsResponse struct {
-		Records *[]Record `json:"data"`
-	}
 
 	records := &recordsResponse{}
 	err = json.NewDecoder(resp.Body).Decode(&records)
@@ -154,9 +154,9 @@ func (c *Client) sendRequest(method, resource string, payload interface{}) (*htt
 	if resp.StatusCode > 299 {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			return nil, fmt.Errorf("DNSMadeEasy API request failed with HTTP status code %d", resp.StatusCode)
+			return nil, fmt.Errorf("request failed with HTTP status code %d", resp.StatusCode)
 		}
-		return nil, fmt.Errorf("DNSMadeEasy API request failed with HTTP status code %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("request failed with HTTP status code %d: %s", resp.StatusCode, string(body))
 	}
 
 	return resp, nil

--- a/providers/dns/dnsmadeeasy/dnsmadeeasy.go
+++ b/providers/dns/dnsmadeeasy/dnsmadeeasy.go
@@ -113,13 +113,13 @@ func (d *DNSProvider) Present(domainName, token, keyAuth string) error {
 
 	authZone, err := acme.FindZoneByFqdn(fqdn, acme.RecursiveNameservers)
 	if err != nil {
-		return err
+		return fmt.Errorf("dnsmadeeasy: unable to find zone for %s: %v", fqdn, err)
 	}
 
 	// fetch the domain details
 	domain, err := d.client.GetDomain(authZone)
 	if err != nil {
-		return err
+		return fmt.Errorf("dnsmadeeasy: unable to get domain for zone %s: %v", authZone, err)
 	}
 
 	// create the TXT record
@@ -127,7 +127,10 @@ func (d *DNSProvider) Present(domainName, token, keyAuth string) error {
 	record := &Record{Type: "TXT", Name: name, Value: value, TTL: d.config.TTL}
 
 	err = d.client.CreateRecord(domain, record)
-	return err
+	if err != nil {
+		return fmt.Errorf("dnsmadeeasy: unable to create record for %s: %v", name, err)
+	}
+	return nil
 }
 
 // CleanUp removes the TXT records matching the specified parameters
@@ -136,31 +139,32 @@ func (d *DNSProvider) CleanUp(domainName, token, keyAuth string) error {
 
 	authZone, err := acme.FindZoneByFqdn(fqdn, acme.RecursiveNameservers)
 	if err != nil {
-		return err
+		return fmt.Errorf("dnsmadeeasy: unable to find zone for %s: %v", fqdn, err)
 	}
 
 	// fetch the domain details
 	domain, err := d.client.GetDomain(authZone)
 	if err != nil {
-		return err
+		return fmt.Errorf("dnsmadeeasy: unable to get domain for zone %s: %v", authZone, err)
 	}
 
 	// find matching records
 	name := strings.Replace(fqdn, "."+authZone, "", 1)
 	records, err := d.client.GetRecords(domain, name, "TXT")
 	if err != nil {
-		return err
+		return fmt.Errorf("dnsmadeeasy: unable to get records for domain %s: %v", domain.Name, err)
 	}
 
 	// delete records
+	var lastError error
 	for _, record := range *records {
 		err = d.client.DeleteRecord(record)
 		if err != nil {
-			return err
+			lastError = fmt.Errorf("dnsmadeeasy: unable to delete record [id=%d, name=%s]: %v", record.ID, record.Name, err)
 		}
 	}
 
-	return nil
+	return lastError
 }
 
 // Timeout returns the timeout and interval to use when checking for DNS propagation.


### PR DESCRIPTION
When dnsmadeeasy returns status code > 299 it also often returns a helpful diagnostic message inside the request body. This message used to be discarded. This PR makes a change to log this message along with the status code