### PR TITLE
Client: Do not send a JWS body when POSTing challenges.

### DIFF
--- a/acme/client.go
+++ b/acme/client.go
@@ -914,7 +914,10 @@ func parseLinks(links []string) map[string]string {
 func validate(j *jws, domain, uri string, c challenge) error {
 	var chlng challenge
 
-	hdr, err := postJSON(j, uri, c, &chlng)
+	// Challenge initiation is done by sending a JWS payload containing the
+	// trivial JSON object `{}`. We use an empty struct instance as the postJSON
+	// payload here to achieve this result.
+	hdr, err := postJSON(j, uri, struct{}{}, &chlng)
 	if err != nil {
 		return err
 	}

--- a/acme/client_test.go
+++ b/acme/client_test.go
@@ -13,10 +13,9 @@ import (
 	"testing"
 	"time"
 
-	jose "gopkg.in/square/go-jose.v2"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/square/go-jose.v2"
 )
 
 func TestNewClient(t *testing.T) {

--- a/acme/client_test.go
+++ b/acme/client_test.go
@@ -164,10 +164,12 @@ func TestValidate(t *testing.T) {
 		if err != nil {
 			return err
 		}
+
 		jws, err := jose.ParseSigned(string(reqBody))
 		if err != nil {
 			return err
 		}
+
 		body, err := jws.Verify(&jose.JSONWebKey{
 			Key:       privKey.Public(),
 			Algorithm: "RSA",
@@ -175,8 +177,9 @@ func TestValidate(t *testing.T) {
 		if err != nil {
 			return err
 		}
+
 		if bodyStr := string(body); bodyStr != "{}" {
-			return fmt.Errorf(`Expected JWS POST body "{}", got %q`, bodyStr)
+			return fmt.Errorf(`expected JWS POST body "{}", got %q`, bodyStr)
 		}
 		return nil
 	}


### PR DESCRIPTION
In legacy ACME there was a requirement to send a JWS body that contained a key authorization as part of all challenge initiation POSTs. LEGO presently maintains this behaviour and sends the entire challenge resource back to the server in each POST.

Since both the client and server can reconstitute the key authorization there is no need to send it (or the rest of the challenge) and modern ACME expects challenges to be [initiated with a JWS carrying the trivial empty JSON object](https://tools.ietf.org/html/draft-ietf-acme-acme-16#section-7.5.1) (`{}`):
> 
>   A client responds with an empty object ({}) to acknowledge that the challenge can be validated by the server.

Some ACME servers (e.g. Pebble in `-strict` mode) will reject all challenge POSTs that have a legacy JWS body.

This commit updates `acme/client.go`'s `validate` function to send the correct JWS payload for challenge POSTs. A small adjustment is also made to `acme/client_test.go`'s `TestValidate` unit test to make the test server reject POSTs with a JWS body other than `{}`. Before applying the fix to `acme/client.go` this produces the expected test failure:
```
--- FAIL: TestValidate (0.03s)
    --- FAIL: TestValidate/POST-unexpected (0.00s)
        client_test.go:258: 
            	Error Trace:	client_test.go:258
            	Error:      	"acme: Error 400 -  - Expected JWS POST body "{}", got "{\"url\":\"\",\"type\":\"http-01\",\"status\":\"\",\"token\":\"token\",\"validated\":\"0001-01-01T00:00:00Z\",\"keyAuthorization\":\"\",\"error\":{\"type\":\"\",\"detail\":\"\"}}"
            	            	" does not contain "unexpected"
            	Test:       	TestValidate/POST-unexpected
    --- FAIL: TestValidate/POST-valid (0.00s)
        require.go:794: 
            	Error Trace:	client_test.go:255
            	Error:      	Received unexpected error:
            	            	acme: Error 400 -  - Expected JWS POST body "{}", got "{\"url\":\"\",\"type\":\"http-01\",\"status\":\"\",\"token\":\"token\",\"validated\":\"0001-01-01T00:00:00Z\",\"keyAuthorization\":\"\",\"error\":{\"type\":\"\",\"detail\":\"\"}}"
            	Test:       	TestValidate/POST-valid
    --- FAIL: TestValidate/GET-unexpected (0.00s)
        client_test.go:258: 
            	Error Trace:	client_test.go:258
            	Error:      	"acme: Error 400 -  - Expected JWS POST body "{}", got "{\"url\":\"\",\"type\":\"http-01\",\"status\":\"\",\"token\":\"token\",\"validated\":\"0001-01-01T00:00:00Z\",\"keyAuthorization\":\"\",\"error\":{\"type\":\"\",\"detail\":\"\"}}"
            	            	" does not contain "unexpected"
            	Test:       	TestValidate/GET-unexpected
    --- FAIL: TestValidate/GET-valid (0.00s)
        require.go:794: 
            	Error Trace:	client_test.go:255
            	Error:      	Received unexpected error:
            	            	acme: Error 400 -  - Expected JWS POST body "{}", got "{\"url\":\"\",\"type\":\"http-01\",\"status\":\"\",\"token\":\"token\",\"validated\":\"0001-01-01T00:00:00Z\",\"keyAuthorization\":\"\",\"error\":{\"type\":\"\",\"detail\":\"\"}}"
            	Test:       	TestValidate/GET-valid
```

After applying the fix the test passes.
