### PR TITLE
Add version to xenolf-acme in User-Agent.

### DIFF
--- a/acme/http.go
+++ b/acme/http.go
@@ -42,12 +42,9 @@ var (
 )
 
 const (
-	// defaultGoUserAgent is the Go HTTP package user agent string. Too
-	// bad it isn't exported. If it changes, we should update it here, too.
-	defaultGoUserAgent = "Go-http-client/1.1"
-
 	// ourUserAgent is the User-Agent of this underlying library package.
-	ourUserAgent = "xenolf-acme"
+	// NOTE: Update this with each tagged release.
+	ourUserAgent = "xenolf-acme/1.2.1"
 
 	// caCertificatesEnvVar is the environment variable name that can be used to
 	// specify the path to PEM encoded CA Certificates that can be used to
@@ -205,6 +202,6 @@ func post(j *jws, uri string, reqBody []byte, respBody interface{}) (*http.Respo
 
 // userAgent builds and returns the User-Agent string to use in requests.
 func userAgent() string {
-	ua := fmt.Sprintf("%s %s (%s; %s) %s", UserAgent, ourUserAgent, runtime.GOOS, runtime.GOARCH, defaultGoUserAgent)
+	ua := fmt.Sprintf("%s %s (%s; %s)", UserAgent, ourUserAgent, runtime.GOOS, runtime.GOARCH)
 	return strings.TrimSpace(ua)
 }

--- a/acme/http.go
+++ b/acme/http.go
@@ -46,6 +46,11 @@ const (
 	// NOTE: Update this with each tagged release.
 	ourUserAgent = "xenolf-acme/1.2.1"
 
+	// ourUserAgentComment is part of the UA comment linked to the version status of this underlying library package.
+	// values: detach|release
+	// NOTE: Update this with each tagged release.
+	ourUserAgentComment = "detach"
+
 	// caCertificatesEnvVar is the environment variable name that can be used to
 	// specify the path to PEM encoded CA Certificates that can be used to
 	// authenticate an ACME server with a HTTPS certificate not issued by a CA in
@@ -202,6 +207,6 @@ func post(j *jws, uri string, reqBody []byte, respBody interface{}) (*http.Respo
 
 // userAgent builds and returns the User-Agent string to use in requests.
 func userAgent() string {
-	ua := fmt.Sprintf("%s %s (%s; %s)", UserAgent, ourUserAgent, runtime.GOOS, runtime.GOARCH)
+	ua := fmt.Sprintf("%s %s (%s; %s; %s)", UserAgent, ourUserAgent, ourUserAgentComment, runtime.GOOS, runtime.GOARCH)
 	return strings.TrimSpace(ua)
 }

--- a/acme/http_test.go
+++ b/acme/http_test.go
@@ -55,7 +55,6 @@ func TestHTTPUserAgent(t *testing.T) {
 func TestUserAgent(t *testing.T) {
 	ua := userAgent()
 
-	assert.Contains(t, ua, defaultGoUserAgent)
 	assert.Contains(t, ua, ourUserAgent)
 	if strings.HasSuffix(ua, " ") {
 		t.Errorf("UA should not have trailing spaces; got '%s'", ua)
@@ -65,7 +64,6 @@ func TestUserAgent(t *testing.T) {
 	UserAgent = "MyApp/1.2.3"
 	ua = userAgent()
 
-	assert.Contains(t, ua, defaultGoUserAgent)
 	assert.Contains(t, ua, ourUserAgent)
 	assert.Contains(t, ua, UserAgent)
 }


### PR DESCRIPTION
Also, remove "Go-http-client/1.1". In practice this added detail doesn't
wind up being useful in diagnosing problems, particularly since it can
be deduced from the xenolf-acme version.