### PR TITLE
fix: Cloudflare error.

### DIFF
--- a/providers/dns/cloudflare/cloudflare.go
+++ b/providers/dns/cloudflare/cloudflare.go
@@ -126,7 +126,7 @@ func (d *DNSProvider) Present(domain, token, keyAuth string) error {
 		TTL:     d.config.TTL,
 	}
 
-	response, _ := d.client.CreateDNSRecord(zoneID, dnsRecord)
+	response, err := d.client.CreateDNSRecord(zoneID, dnsRecord)
 	if err != nil {
 		return fmt.Errorf("cloudflare: failed to create TXT record: %v", err)
 	}


### PR DESCRIPTION
fix: Cloudflare error.

```
runtime/debug.Stack(0x265ea80, 0x17, 0xc00017a390)
	/usr/local/go/src/runtime/debug/stack.go:24 +0xa7
github.com/containous/traefik/safe.defaultRecoverGoroutine(0x21e5ca0, 0x4551d40)
	/go/src/github.com/containous/traefik/safe/routine.go:148 +0x89
github.com/containous/traefik/safe.OperationWithRecover.func1.1(0xc000749b68)
	/go/src/github.com/containous/traefik/safe/routine.go:156 +0x56
panic(0x21e5ca0, 0x4551d40)
	/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/containous/traefik/vendor/github.com/xenolf/lego/providers/dns/cloudflare.(*DNSProvider).Present(0xc0005f9b60, 0xc00073c540, 0x17, 0xc00045cb40, 0x2b, 0xc00088aa20, 0x57, 0x0, 0xc0007493f8)
	/go/src/github.com/containous/traefik/vendor/github.com/xenolf/lego/providers/dns/cloudflare/cloudflare.go:134 +0x3ca
github.com/containous/traefik/vendor/github.com/xenolf/lego/acme.(*dnsChallenge).PreSolve(0xc000920880, 0xc00008a380, 0x6a, 0xc0005327c0, 0x6, 0xc0005327c6, 0x7, 0xc00045cb40, 0x2b, 0x0, ...)
	/go/src/github.com/containous/traefik/vendor/github.com/xenolf/lego/acme/dns_challenge.go:102 +0x17d
github.com/containous/traefik/vendor/github.com/xenolf/lego/acme.(*Client).solveChallengeForAuthz(0xc0001bc0c0, 0xc00013e540, 0x2, 0x2, 0x0, 0x0)
	/go/src/github.com/containous/traefik/vendor/github.com/xenolf/lego/acme/client.go:603 +0x3c6
github.com/containous/traefik/vendor/github.com/xenolf/lego/acme.(*Client).ObtainCertificate(0xc0001bc0c0, 0xc0000e2a00, 0x2, 0x2, 0x4570501, 0x0, 0x0, 0xc00098bb00, 0x42b1f2, 0x8, ...)
	/go/src/github.com/containous/traefik/vendor/github.com/xenolf/lego/acme/client.go:437 +0x2b3
github.com/containous/traefik/provider/acme.obtainCertificateWithRetry.func1(0x8, 0x2714770)
	/go/src/github.com/containous/traefik/provider/acme/provider.go:487 +0x76
github.com/containous/traefik/safe.OperationWithRecover.func1(0x0, 0x0)
	/go/src/github.com/containous/traefik/safe/routine.go:160 +0x62
github.com/containous/traefik/vendor/github.com/cenk/backoff.RetryNotify(0xc0005f9b80, 0x2951d20, 0xc0009208a0, 0x2714448, 0xc0002023c0, 0x17)
	/go/src/github.com/containous/traefik/vendor/github.com/cenk/backoff/retry.go:37 +0xa2
github.com/containous/traefik/provider/acme.obtainCertificateWithRetry(0xc0000e2a00, 0x2, 0x2, 0xc0001bc0c0, 0x1bf08eb000, 0x77359400, 0x1, 0x2, 0x2, 0x2)
	/go/src/github.com/containous/traefik/provider/acme/provider.go:501 +0x193
github.com/containous/traefik/provider/acme.(*Provider).resolveCertificate(0xc0002a13b0, 0xc000202360, 0x19, 0xc00017bf80, 0x1, 0x1, 0xfad501, 0x0, 0x0, 0x0)
	/go/src/github.com/containous/traefik/provider/acme/provider.go:411 +0x3ba
github.com/containous/traefik/provider/acme.(*Provider).Provide.func1()
	/go/src/github.com/containous/traefik/provider/acme/provider.go:186 +0x72
github.com/containous/traefik/safe.GoWithRecover.func1(0x2714778, 0xc0000e2920)
	/go/src/github.com/containous/traefik/safe/routine.go:142 +0x4d
created by github.com/containous/traefik/safe.GoWithRecover
	/go/src/github.com/containous/traefik/safe/routine.go:136 +0x49
```

Related to https://github.com/containous/traefik/issues/4200