### PR TITLE
Use new challtestsrv.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,8 @@ before_install:
   - curl -sI https://github.com/golang/dep/releases/latest | grep -Fi Location  | tr -d '\r' | sed "s/tag/download/g" | awk -F " " '{ print $2 "/dep-linux-amd64"}' | wget --output-document=$GOPATH/bin/dep -i -
   - chmod +x $GOPATH/bin/dep
 
-  # Install Pebble
+  # Install Pebble and challtestsrv
   - go get -u github.com/letsencrypt/pebble/...
-
-  # Install challtestsrv
-  - go get -u github.com/letsencrypt/boulder/test/challtestsrv/...
 
   # Install linters and misspell
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.12.2

--- a/e2e/loader/loader.go
+++ b/e2e/loader/loader.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	cmdNamePebble   = "pebble"
-	cmdNameChallSrv = "challtestsrv"
+	cmdNameChallSrv = "pebble-challtestsrv"
 )
 
 type CmdOption struct {

--- a/e2e/readme.md
+++ b/e2e/readme.md
@@ -16,11 +16,6 @@ How to run:
 go get -u github.com/letsencrypt/pebble/...
 ```
 
-- Install [challtestsrv](https://github.com/letsencrypt/boulder/tree/master/test/challtestsrv):
-```bash
-go get -u github.com/letsencrypt/boulder/test/challtestsrv/...
-```
-
 - Launch tests:
 ```bash
 make e2e


### PR DESCRIPTION
Let's Encrypt move the challtestsrv from boulder to pebble (which is great).

**This change made by LE is breaking all our builds.**

- https://github.com/letsencrypt/boulder/pull/3980
- https://github.com/letsencrypt/pebble/pull/181

ping @cpu 
