### PR TITLE
DNS: Automatically exclude all other challenges

### DIFF
--- a/cmd/setup_challenges.go
+++ b/cmd/setup_challenges.go
@@ -120,4 +120,8 @@ func setupDNS(ctx *cli.Context, client *lego.Client) {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// --dns=foo indicates that the user specifically want to do a DNS challenge
+	// infer that the user also wants to exclude all other challenges
+	client.Challenge.Exclude([]challenge.Type{challenge.HTTP01, challenge.TLSALPN01})
 }


### PR DESCRIPTION
This restores the behavior documented in the help: when `--dns` is
passed, users want to use the DNS challenge, so all other challenges are
disabled automatically.

Closes #737