### PR TITLE
Use GCE_PROJECT for project always, if specified

### DIFF
--- a/providers/dns/gcloud/googlecloud.go
+++ b/providers/dns/gcloud/googlecloud.go
@@ -55,10 +55,12 @@ type DNSProvider struct {
 // Project name must be passed in the environment variable: GCE_PROJECT.
 // A Service Account file can be passed in the environment variable: GCE_SERVICE_ACCOUNT_FILE
 func NewDNSProvider() (*DNSProvider, error) {
+	// Use a service account file if specified via environment variable.
 	if saFile, ok := os.LookupEnv("GCE_SERVICE_ACCOUNT_FILE"); ok {
 		return NewDNSProviderServiceAccount(saFile)
 	}
 
+	// Use default credentials.
 	project := os.Getenv("GCE_PROJECT")
 	return NewDNSProviderCredentials(project)
 }
@@ -94,15 +96,20 @@ func NewDNSProviderServiceAccount(saFile string) (*DNSProvider, error) {
 		return nil, fmt.Errorf("googlecloud: unable to read Service Account file: %v", err)
 	}
 
-	// read project id from service account file
-	var datJSON struct {
-		ProjectID string `json:"project_id"`
+	// If GCE_PROJECT is non-empty it overrides the project in the service
+	// account file.
+	project := os.Getenv("GCE_PROJECT")
+	if project != "" {
+		// read project id from service account file
+		var datJSON struct {
+			ProjectID string `json:"project_id"`
+		}
+		err = json.Unmarshal(dat, &datJSON)
+		if err != nil || datJSON.ProjectID == "" {
+			return nil, fmt.Errorf("googlecloud: project ID not found in Google Cloud Service Account file")
+		}
+		project = datJSON.ProjectID
 	}
-	err = json.Unmarshal(dat, &datJSON)
-	if err != nil || datJSON.ProjectID == "" {
-		return nil, fmt.Errorf("googlecloud: project ID not found in Google Cloud Service Account file")
-	}
-	project := datJSON.ProjectID
 
 	conf, err := google.JWTConfigFromJSON(dat, dns.NdevClouddnsReadwriteScope)
 	if err != nil {


### PR DESCRIPTION
Currently if `GCE_SERVICE_ACCOUNT_FILE` is set, `GCE_PROJECT` is ignored. This PR changes the behavior to use `GCE_PROJECT` for the project in all cases, if it is set.

I believe in practice the most common scenario is that a provided service account file does not specify a project, which is the default when generating a service account key via gcloud CLI or web console. So this change helps avoid forcing users to add a project ID to their service account file by simply specifying `GCE_PROJECT` as I think a user would expect.

This change also allows a user to override a project id in a service account file, which is probably a less common scenario but is the use case described in #604.

To use the project ID from a service account file, the user simply specifies `GCE_SERVICE_ACCOUNT_FILE` and not `GCE_PROJECT`. The new behavior seems most intuitive.

Fixes #604 