### PR TITLE
dns/gcloud: Fix check for GCE_PROJECT when using gcloud

### DIFF
--- a/providers/dns/gcloud/googlecloud.go
+++ b/providers/dns/gcloud/googlecloud.go
@@ -99,7 +99,7 @@ func NewDNSProviderServiceAccount(saFile string) (*DNSProvider, error) {
 	// If GCE_PROJECT is non-empty it overrides the project in the service
 	// account file.
 	project := os.Getenv("GCE_PROJECT")
-	if project != "" {
+	if project == "" {
 		// read project id from service account file
 		var datJSON struct {
 			ProjectID string `json:"project_id"`


### PR DESCRIPTION
Fixes a typo from #750 so that GCE_PROJECT is actually used.