### PR TITLE
Prepare release v2.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ install:
   - echo "TRAVIS_GO_VERSION=$TRAVIS_GO_VERSION"
   - dep status -v
 
+after_success:
+  - make clean
+
 deploy:
   - provider: script
     skip_cleanup: true

--- a/acme/api/internal/sender/useragent.go
+++ b/acme/api/internal/sender/useragent.go
@@ -10,5 +10,5 @@ const (
 	// ourUserAgentComment is part of the UA comment linked to the version status of this underlying library package.
 	// values: detach|release
 	// NOTE: Update this with each tagged release.
-	ourUserAgentComment = "release"
+	ourUserAgentComment = "detach"
 )

--- a/acme/api/internal/sender/useragent.go
+++ b/acme/api/internal/sender/useragent.go
@@ -5,10 +5,10 @@ package sender
 
 const (
 	// ourUserAgent is the User-Agent of this underlying library package.
-	ourUserAgent = "xenolf-acme/2.0.0"
+	ourUserAgent = "xenolf-acme/2.0.1"
 
 	// ourUserAgentComment is part of the UA comment linked to the version status of this underlying library package.
 	// values: detach|release
 	// NOTE: Update this with each tagged release.
-	ourUserAgentComment = "detach"
+	ourUserAgentComment = "release"
 )


### PR DESCRIPTION
https://travis-ci.org/xenolf/lego/jobs/477470638

```
Deploying application
   • releasing using goreleaser 0.95.2...
   • loading config file       file=.goreleaser.yml
   • RUNNING BEFORE HOOKS
   • GETTING AND VALIDATING GIT STATE
      • releasing v2.0.0, commit 9b4afbb99869234b76f5a6b6e48fcb9111f207d7
   • SETTING DEFAULTS 
   • SNAPSHOTING      
      • skipped                   reason=not a snapshot
   • CHECKING ./DIST  
   ⨯ release failed after 0.10s error=dist is not empty, remove it before running goreleaser or use the --rm-dist flag
Script failed with status 1
```

The 2 commits must be kept: the merge be done with a **rebase** ( nor merge commit nor squash)