### PR TITLE
namecheap: fix panic.

### DIFF
--- a/providers/dns/namecheap/namecheap.go
+++ b/providers/dns/namecheap/namecheap.go
@@ -180,10 +180,12 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	// Find the challenge TXT record and remove it if found.
 	var found bool
-	for i, h := range records {
+	newRecords := records[:0]
+	for _, h := range records {
 		if h.Name == ch.key && h.Type == "TXT" {
-			records = append(records[:i], records[i+1:]...)
 			found = true
+		} else {
+			newRecords = append(newRecords, h)
 		}
 	}
 
@@ -191,7 +193,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 		return nil
 	}
 
-	err = d.setHosts(ch.sld, ch.tld, records)
+	err = d.setHosts(ch.sld, ch.tld, newRecords)
 	if err != nil {
 		return fmt.Errorf("namecheap: %v", err)
 	}

--- a/providers/dns/namecheap/namecheap.go
+++ b/providers/dns/namecheap/namecheap.go
@@ -180,7 +180,7 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 
 	// Find the challenge TXT record and remove it if found.
 	var found bool
-	newRecords := records[:0]
+	var newRecords []Record
 	for _, h := range records {
 		if h.Name == ch.key && h.Type == "TXT" {
 			found = true

--- a/providers/dns/namecheap/namecheap_test.go
+++ b/providers/dns/namecheap/namecheap_test.go
@@ -208,10 +208,10 @@ func mockServer(tc *testCase, t *testing.T) http.Handler {
 			case "namecheap.domains.dns.getHosts":
 				assertHdr(tc, t, &values)
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprintf(w, tc.getHostsResponse)
+				fmt.Fprint(w, tc.getHostsResponse)
 			case "namecheap.domains.getTldList":
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprintf(w, responseGetTlds)
+				fmt.Fprint(w, responseGetTlds)
 			default:
 				t.Errorf("Unexpected GET command: %s", cmd)
 			}


### PR DESCRIPTION
When the list of records contains multiple times the same records, the provider panics:
```
Stack: goroutine 54 [running]:
runtime/debug.Stack(0x26c79d0, 0x17, 0xc00032dc20)
/usr/local/go/src/runtime/debug/stack.go:24 +0xa7
github.com/containous/traefik/safe.defaultRecoverGoroutine(0x2243120, 0x45fc290)
/go/src/github.com/containous/traefik/safe/routine.go:148 +0x89
github.com/containous/traefik/safe.OperationWithRecover.func1.1(0xc0009f5b30)
/go/src/github.com/containous/traefik/safe/routine.go:156 +0x56
panic(0x2243120, 0x45fc290)
/usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/containous/traefik/vendor/github.com/xenolf/lego/providers/dns/namecheap.(*DNSProvider).CleanUp(0xc00000cbb0, 0xc00039d740, 0x7, 0xc000732690, 0x2b, 0xc000be6ea0, 0x57, 0xc00039d738, 0x3)
/go/src/github.com/containous/traefik/vendor/github.com/xenolf/lego/providers/dns/namecheap/namecheap.go:185 +0x77a
github.com/containous/traefik/vendor/github.com/xenolf/lego/challenge/dns01.(*Challenge).CleanUp(0xc0000cfc00, 0xc00039d747, 0x7, 0x0, 0xed3e11ff3, 0x0, 0xc00039d738, 0x3, 0xc00039d740, 0x7, ...)
/go/src/github.com/containous/traefik/vendor/github.com/xenolf/lego/challenge/dns01/dns_challenge.go:155 +0x2a9
github.com/containous/traefik/vendor/github.com/xenolf/lego/challenge/resolver.cleanUp(0x29bf740, 0xc0000cfc00, 0xc00039d747, 0x7, 0x0, 0xed3e11ff3, 0x0, 0xc00039d738, 0x3, 0xc00039d740, ...)
/go/src/github.com/containous/traefik/vendor/github.com/xenolf/lego/challenge/resolver/prober.go:168 +0x10f
github.com/containous/traefik/vendor/github.com/xenolf/lego/challenge/resolver.parallelSolve.func1(0xc000823560, 0x2, 0x2)
/go/src/github.com/containous/traefik/vendor/github.com/xenolf/lego/challenge/resolver/prober.go:145 +0x7e
github.com/containous/traefik/vendor/github.com/xenolf/lego/challenge/resolver.parallelSolve(0xc000823560, 0x2, 0x2, 0xc000558bd0)
/go/src/github.com/containous/traefik/vendor/github.com/xenolf/lego/challenge/resolver/prober.go:163 +0x49b
github.com/containous/traefik/vendor/github.com/xenolf/lego/challenge/resolver.(*Prober).Solve(0xc0000b00f0, 0xc0009181a0, 0x2, 0x2, 0x1e, 0xc00056df80)
/go/src/github.com/containous/traefik/vendor/github.com/xenolf/lego/challenge/resolver/prober.go:84 +0x35e
github.com/containous/traefik/vendor/github.com/xenolf/lego/certificate.(*Certifier).Obtain(0xc0002d0660, 0xc0006971c0, 0x2, 0x2, 0x1, 0x0, 0x0, 0x0, 0x6fad22, 0xbf09997cc0c4ded9, ...)
/go/src/github.com/containous/traefik/vendor/github.com/xenolf/lego/certificate/certificates.go:106 +0x36e
github.com/containous/traefik/provider/acme.obtainCertificateWithRetry.func1(0x8, 0x277fa80)
/go/src/github.com/containous/traefik/provider/acme/provider.go:500 +0xd4
github.com/containous/traefik/safe.OperationWithRecover.func1(0x0, 0x0)
/go/src/github.com/containous/traefik/safe/routine.go:160 +0x62
github.com/containous/traefik/vendor/github.com/cenk/backoff.RetryNotify(0xc000856d00, 0x29c6000, 0xc0000a3080, 0x277f758, 0xc000301c10, 0x7)
/go/src/github.com/containous/traefik/vendor/github.com/cenk/backoff/retry.go:37 +0xa2
github.com/containous/traefik/provider/acme.obtainCertificateWithRetry(0xc0006971c0, 0x2, 0x2, 0xc00000a260, 0x34630b8a000, 0x37e11d600, 0x1, 0x2, 0x2, 0x2)
/go/src/github.com/containous/traefik/provider/acme/provider.go:514 +0x186
github.com/containous/traefik/provider/acme.(*Provider).resolveCertificate(0xc0001b6a20, 0xc000301be0, 0x9, 0xc000696f30, 0x1, 0x1, 0x1016201, 0x0, 0x0, 0x0)
/go/src/github.com/containous/traefik/provider/acme/provider.go:414 +0x3ba
github.com/containous/traefik/provider/acme.(*Provider).Provide.func1()
/go/src/github.com/containous/traefik/provider/acme/provider.go:188 +0x72
github.com/containous/traefik/safe.GoWithRecover.func1(0x277fa88, 0xc000696fc0)
/go/src/github.com/containous/traefik/safe/routine.go:142 +0x4d
created by github.com/containous/traefik/safe.GoWithRecover
/go/src/github.com/containous/traefik/safe/routine.go:136 +0x49
```

How to reproduce:
```go
func TestPanic(t *testing.T) {
	key := "t5"

	records := []string{"t0", "t1", "t2", "t5", "t4", "t5"}

	for i, x := range records {
		if x == key {
			fmt.Println(i, records[:i])
			fmt.Println(i+1, records[i+1:])
			records = append(records[:i], records[i+1:]...)
		}
	}
}
```