### PR TITLE
Change NIFCLOUD DNS base url

### DIFF
--- a/providers/dns/nifcloud/internal/client.go
+++ b/providers/dns/nifcloud/internal/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	defaultBaseURL = "https://dns.api.cloud.nifty.com"
+	defaultBaseURL = "https://dns.api.nifcloud.com"
 	apiVersion     = "2012-12-12N2013-12-16"
 	// XMLNs XML NS of Route53
 	XMLNs = "https://route53.amazonaws.com/doc/2012-12-12/"


### PR DESCRIPTION
NIFCLOUD DNS api endpoint changed.

http://info.biz.nifty.com/cloud/2019/01/post-163.html