### PR TITLE
option to specify gcloud service account json by env as string

### DIFF
--- a/cmd/cmd_dnshelp.go
+++ b/cmd/cmd_dnshelp.go
@@ -51,7 +51,7 @@ Here is an example bash command using the CloudFlare DNS provider:
 	fmt.Fprintln(w, "\tfastdns:\tAKAMAI_HOST, AKAMAI_CLIENT_TOKEN, AKAMAI_CLIENT_SECRET, AKAMAI_ACCESS_TOKEN")
 	fmt.Fprintln(w, "\tgandi:\tGANDI_API_KEY")
 	fmt.Fprintln(w, "\tgandiv5:\tGANDIV5_API_KEY")
-	fmt.Fprintln(w, "\tgcloud:\tGCE_PROJECT, 'Application Default Credentials', [GCE_SERVICE_ACCOUNT_FILE]")
+	fmt.Fprintln(w, "\tgcloud:\tGCE_PROJECT, 'Application Default Credentials', [GCE_SERVICE_ACCOUNT_FILE], [GCE_SERVICE_ACCOUNT_KEY]")
 	fmt.Fprintln(w, "\tglesys:\tGLESYS_API_USER, GLESYS_API_KEY")
 	fmt.Fprintln(w, "\tgodaddy:\tGODADDY_API_KEY, GODADDY_API_SECRET")
 	fmt.Fprintln(w, "\thostingde:\tHOSTINGDE_API_KEY, HOSTINGDE_ZONE_NAME")

--- a/cmd/cmd_dnshelp.go
+++ b/cmd/cmd_dnshelp.go
@@ -51,7 +51,7 @@ Here is an example bash command using the CloudFlare DNS provider:
 	fmt.Fprintln(w, "\tfastdns:\tAKAMAI_HOST, AKAMAI_CLIENT_TOKEN, AKAMAI_CLIENT_SECRET, AKAMAI_ACCESS_TOKEN")
 	fmt.Fprintln(w, "\tgandi:\tGANDI_API_KEY")
 	fmt.Fprintln(w, "\tgandiv5:\tGANDIV5_API_KEY")
-	fmt.Fprintln(w, "\tgcloud:\tGCE_PROJECT, 'Application Default Credentials', [GCE_SERVICE_ACCOUNT_FILE], [GCE_SERVICE_ACCOUNT_KEY]")
+	fmt.Fprintln(w, "\tgcloud:\tGCE_PROJECT, 'Application Default Credentials', [GCE_SERVICE_ACCOUNT_FILE], [GCE_SERVICE_ACCOUNT]")
 	fmt.Fprintln(w, "\tglesys:\tGLESYS_API_USER, GLESYS_API_KEY")
 	fmt.Fprintln(w, "\tgodaddy:\tGODADDY_API_KEY, GODADDY_API_SECRET")
 	fmt.Fprintln(w, "\thostingde:\tHOSTINGDE_API_KEY, HOSTINGDE_ZONE_NAME")

--- a/providers/dns/gcloud/googlecloud.go
+++ b/providers/dns/gcloud/googlecloud.go
@@ -53,7 +53,7 @@ type DNSProvider struct {
 
 // NewDNSProvider returns a DNSProvider instance configured for Google Cloud DNS.
 // Project name must be passed in the environment variable: GCE_PROJECT.
-// A Service Account can be passed in the environment variable: GCE_SERVICE_ACCOUNT_KEY
+// A Service Account can be passed in the environment variable: GCE_SERVICE_ACCOUNT
 // or by specifying the keyfile location: GCE_SERVICE_ACCOUNT_FILE
 func NewDNSProvider() (*DNSProvider, error) {
 	// Use a service account file if specified via environment variable.
@@ -63,7 +63,7 @@ func NewDNSProvider() (*DNSProvider, error) {
 			return nil, fmt.Errorf("googlecloud: unable to read Service Account file: %v", err)
 		}
 		return NewDNSProviderServiceAccount(saKey)
-	} else if saKey, ok := os.LookupEnv("GCE_SERVICE_ACCOUNT_KEY"); ok {
+	} else if saKey, ok := os.LookupEnv("GCE_SERVICE_ACCOUNT"); ok {
 		return NewDNSProviderServiceAccount([]byte(saKey))
 	}
 

--- a/providers/dns/gcloud/googlecloud.go
+++ b/providers/dns/gcloud/googlecloud.go
@@ -54,7 +54,7 @@ type DNSProvider struct {
 // NewDNSProvider returns a DNSProvider instance configured for Google Cloud DNS.
 // Project name must be passed in the environment variable: GCE_PROJECT.
 // A Service Account can be passed in the environment variable: GCE_SERVICE_ACCOUNT_KEY
-// or by specifing the keyfile location: GCE_SERVICE_ACCOUNT_FILE
+// or by specifying the keyfile location: GCE_SERVICE_ACCOUNT_FILE
 func NewDNSProvider() (*DNSProvider, error) {
 	// Use a service account file if specified via environment variable.
 	if saFile, ok := os.LookupEnv("GCE_SERVICE_ACCOUNT_FILE"); ok {

--- a/providers/dns/gcloud/googlecloud_test.go
+++ b/providers/dns/gcloud/googlecloud_test.go
@@ -61,8 +61,8 @@ func TestNewDNSProvider(t *testing.T) {
 		{
 			desc: "success key",
 			envVars: map[string]string{
-				"GCE_PROJECT":             "",
-				"GCE_SERVICE_ACCOUNT":     `{"project_id": "A","type": "service_account","client_email": "foo@bar.com","private_key_id": "pki","private_key": "pk","token_uri": "/token","client_secret": "secret","client_id": "C","refresh_token": "D"}`,
+				"GCE_PROJECT":         "",
+				"GCE_SERVICE_ACCOUNT": `{"project_id": "A","type": "service_account","client_email": "foo@bar.com","private_key_id": "pki","private_key": "pk","token_uri": "/token","client_secret": "secret","client_id": "C","refresh_token": "D"}`,
 			},
 		},
 	}

--- a/providers/dns/gcloud/googlecloud_test.go
+++ b/providers/dns/gcloud/googlecloud_test.go
@@ -20,7 +20,7 @@ var envTest = tester.NewEnvTest(
 	"GCE_PROJECT",
 	"GCE_SERVICE_ACCOUNT_FILE",
 	"GOOGLE_APPLICATION_CREDENTIALS",
-	"GCE_SERVICE_ACCOUNT_KEY").
+	"GCE_SERVICE_ACCOUNT").
 	WithDomain("GCE_DOMAIN").
 	WithLiveTestExtra(func() bool {
 		_, err := google.DefaultClient(context.Background(), dns.NdevClouddnsReadwriteScope)
@@ -62,7 +62,7 @@ func TestNewDNSProvider(t *testing.T) {
 			desc: "success key",
 			envVars: map[string]string{
 				"GCE_PROJECT":             "",
-				"GCE_SERVICE_ACCOUNT_KEY": `{"project_id": "A","type": "service_account","client_email": "foo@bar.com","private_key_id": "pki","private_key": "pk","token_uri": "/token","client_secret": "secret","client_id": "C","refresh_token": "D"}`,
+				"GCE_SERVICE_ACCOUNT": `{"project_id": "A","type": "service_account","client_email": "foo@bar.com","private_key_id": "pki","private_key": "pk","token_uri": "/token","client_secret": "secret","client_id": "C","refresh_token": "D"}`,
 			},
 		},
 	}

--- a/providers/dns/gcloud/googlecloud_test.go
+++ b/providers/dns/gcloud/googlecloud_test.go
@@ -3,6 +3,7 @@ package gcloud
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -51,10 +52,17 @@ func TestNewDNSProvider(t *testing.T) {
 			expected: "googlecloud: project name missing",
 		},
 		{
-			desc: "success",
+			desc: "success key file",
 			envVars: map[string]string{
 				"GCE_PROJECT":              "",
 				"GCE_SERVICE_ACCOUNT_FILE": "fixtures/gce_account_service_file.json",
+			},
+		},
+		{
+			desc: "success key",
+			envVars: map[string]string{
+				"GCE_PROJECT":             "",
+				"GCE_SERVICE_ACCOUNT_KEY": ioutil.ReadFile("fixtures/gce_account_service_file.json"),
 			},
 		},
 	}

--- a/providers/dns/gcloud/googlecloud_test.go
+++ b/providers/dns/gcloud/googlecloud_test.go
@@ -3,7 +3,6 @@ package gcloud
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -62,7 +61,7 @@ func TestNewDNSProvider(t *testing.T) {
 			desc: "success key",
 			envVars: map[string]string{
 				"GCE_PROJECT":             "",
-				"GCE_SERVICE_ACCOUNT_KEY": ioutil.ReadFile("fixtures/gce_account_service_file.json"),
+				"GCE_SERVICE_ACCOUNT_KEY": `{"project_id": "A","type": "service_account","client_email": "foo@bar.com","private_key_id": "pki","private_key": "pk","token_uri": "/token","client_secret": "secret","client_id": "C","refresh_token": "D"}`,
 			},
 		},
 	}

--- a/providers/dns/gcloud/googlecloud_test.go
+++ b/providers/dns/gcloud/googlecloud_test.go
@@ -62,7 +62,7 @@ func TestNewDNSProvider(t *testing.T) {
 			desc: "success key",
 			envVars: map[string]string{
 				"GCE_PROJECT":             "",
-				"GCE_SERVICE_ACCOUNT": `{"project_id": "A","type": "service_account","client_email": "foo@bar.com","private_key_id": "pki","private_key": "pk","token_uri": "/token","client_secret": "secret","client_id": "C","refresh_token": "D"}`,
+				"GCE_SERVICE_ACCOUNT":     `{"project_id": "A","type": "service_account","client_email": "foo@bar.com","private_key_id": "pki","private_key": "pk","token_uri": "/token","client_secret": "secret","client_id": "C","refresh_token": "D"}`,
 			},
 		},
 	}

--- a/providers/dns/gcloud/googlecloud_test.go
+++ b/providers/dns/gcloud/googlecloud_test.go
@@ -19,7 +19,8 @@ import (
 var envTest = tester.NewEnvTest(
 	"GCE_PROJECT",
 	"GCE_SERVICE_ACCOUNT_FILE",
-	"GOOGLE_APPLICATION_CREDENTIALS").
+	"GOOGLE_APPLICATION_CREDENTIALS",
+	"GCE_SERVICE_ACCOUNT_KEY").
 	WithDomain("GCE_DOMAIN").
 	WithLiveTestExtra(func() bool {
 		_, err := google.DefaultClient(context.Background(), dns.NdevClouddnsReadwriteScope)


### PR DESCRIPTION
Added the option to provide the gcloud service account as a string via the environment variable `GCE_SERVICE_ACCOUNT` in addition to the already available option to specify a filepath to a keyfile.
see #775 