### PR TITLE
Add a mechanism to wrap a PreCheckFunc

### DIFF
--- a/challenge/dns01/dns_challenge.go
+++ b/challenge/dns01/dns_challenge.go
@@ -127,7 +127,7 @@ func (c *Challenge) Solve(authz acme.Authorization) error {
 	log.Infof("[%s] acme: Checking DNS record propagation using %+v", domain, recursiveNameservers)
 
 	err = wait.For("propagation", timeout, interval, func() (bool, error) {
-		stop, errP := c.preCheck.call(fqdn, value)
+		stop, errP := c.preCheck.call(domain, fqdn, value)
 		if !stop || errP != nil {
 			log.Infof("[%s] acme: Waiting for DNS record propagation.", domain)
 		}


### PR DESCRIPTION
This allows a `lego` client to implement a fix for #770 by wrapping with a function that sleeps two minutes before calling the original function (using some closed-over metadata to keep track of how long each call actually needs to sleep).

I'll write tests if this is something you want to go forward with.

The following needs locking on `solveToken` and `solved` for concurrent use, but otherwise is the idea.

```go
var solveToken map[string]string

func getCert(client *lego.Client, domains []string) {
    token := randomString()
    for _, domain := range domains {
        solveToken[domain] = token
    }
    request := certificate.ObtainRequest{
        Domains: domains,
    }
    certs, err := client.Certificate.Obtain(request)
}

func main() {
    client := ...
    delay := 120 * time.Second
    solved := make(map[string]bool)
    solveToken = make(map[string]string)
    wrapFunc := func(domain, fqdn, value string, orig dns01.PreCheckFunc) (bool, error) {
            token := solveToken[domain]
            if !solved[token] {
                    log.Printf("[%s] Waiting %s before checking DNS propagation",
                            domain, delay.Round(time.Second))
                    time.Sleep(delay)
                    solved[token] = true
            }
            return orig(fqdn, value)
    }
    preCheckDelayOption := dns01.WrapPreCheck(wrapFunc)
    err = client.Challenge.SetDNS01Provider(provider, preCheckDelayOption)

    getCert(client, os.Args[1:])
}
```