### PR TITLE
removing `lego` from the dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 lego.exe
-lego
 .lego
 .gitcookies
 .idea


### PR DESCRIPTION
as it seems to prevent docker builds:

```go build -v -ldflags '-X "main.version=f05aa4c241fd8b43da9dc8cab8c8965e5b3c1b55"' -o dist/lego ./cmd/lego/
cmd/accounts_storage.go:20:2: cannot find package "github.com/xenolf/lego/lego" in any of:
    /go/src/github.com/xenolf/lego/vendor/github.com/xenolf/lego/lego (vendor tree)
    /usr/local/go/src/github.com/xenolf/lego/lego (from $GOROOT)
    /go/src/github.com/xenolf/lego/lego (from $GOPATH)
make: *** [Makefile:20: build] Error 1```