### PR TITLE
Resolve CNAME when creating dns-01 challenge

### DIFF
--- a/challenge/dns01/cname.go
+++ b/challenge/dns01/cname.go
@@ -7,10 +7,10 @@ func updateDomainWithCName(r *dns.Msg, fqdn string) string {
 	for _, rr := range r.Answer {
 		if cn, ok := rr.(*dns.CNAME); ok {
 			if cn.Hdr.Name == fqdn {
-				fqdn = cn.Target
-				break
+				return cn.Target
 			}
 		}
 	}
+
 	return fqdn
 }

--- a/challenge/dns01/cname.go
+++ b/challenge/dns01/cname.go
@@ -1,0 +1,16 @@
+package dns01
+
+import "github.com/miekg/dns"
+
+// Update FQDN with CNAME if any
+func updateDomainWithCName(r *dns.Msg, fqdn string) string {
+	for _, rr := range r.Answer {
+		if cn, ok := rr.(*dns.CNAME); ok {
+			if cn.Hdr.Name == fqdn {
+				fqdn = cn.Target
+				break
+			}
+		}
+	}
+	return fqdn
+}

--- a/challenge/dns01/precheck.go
+++ b/challenge/dns01/precheck.go
@@ -60,15 +60,7 @@ func (p preCheck) checkDNSPropagation(fqdn, value string) (bool, error) {
 	}
 
 	if r.Rcode == dns.RcodeSuccess {
-		// If we see a CNAME here then use the alias
-		for _, rr := range r.Answer {
-			if cn, ok := rr.(*dns.CNAME); ok {
-				if cn.Hdr.Name == fqdn {
-					fqdn = cn.Target
-					break
-				}
-			}
-		}
+		fqdn = updateDomainWithCName(r, fqdn)
 	}
 
 	authoritativeNss, err := lookupNameservers(fqdn)

--- a/providers/dns/acmedns/acmedns_test.go
+++ b/providers/dns/acmedns/acmedns_test.go
@@ -19,7 +19,7 @@ var (
 const (
 	// Fixed test data for unit tests.
 	egDomain  = "threeletter.agency"
-	egFQDN    = "_acme-challenge." + egDomain + "."
+	egFQDN    = "30feb5f3-7cfa-43e2-95aa-d42ca56db9b0.pki." + egDomain + "."
 	egKeyAuth = "⚷"
 )
 

--- a/providers/dns/acmedns/acmedns_test.go
+++ b/providers/dns/acmedns/acmedns_test.go
@@ -19,7 +19,7 @@ var (
 const (
 	// Fixed test data for unit tests.
 	egDomain  = "threeletter.agency"
-	egFQDN    = "30feb5f3-7cfa-43e2-95aa-d42ca56db9b0.pki." + egDomain + "."
+	egFQDN    = "_acme-challenge." + egDomain + "."
 	egKeyAuth = "⚷"
 )
 


### PR DESCRIPTION
It may be desirable to host the dns-01 challenge in a zone other than
the one where the challenge is presented. For example, when validating
a.example.com, the challenge may need to live on example.org.

This change resolves CNAMEs encountered when determining the FQDN of the
challenge, and replaces them with the alias.

This PR is based on the original work in #584.

Closes #584 #506
Related to #479

Co-authored-by: Gurvinder Singh <gurvinder.singh@uninett.no>