### PR TITLE
selectel: getting sub-domain

### DIFF
--- a/providers/dns/selectel/internal/client.go
+++ b/providers/dns/selectel/internal/client.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 )
 
 // Domain represents domain name.
@@ -65,7 +66,9 @@ func NewClient(opts ClientOpts) *Client {
 	}
 }
 
-// GetDomainByName gets Domain object by its name.
+// GetDomainByName gets Domain object by its name. If `domainName` level > 2 and there is
+// no such domain on the account - it'll recursively search for the first
+// which is exists in Selectel Domain API.
 func (c *Client) GetDomainByName(domainName string) (*Domain, error) {
 	uri := fmt.Sprintf("/%s", domainName)
 	req, err := c.newRequest(http.MethodGet, uri, nil)
@@ -74,9 +77,16 @@ func (c *Client) GetDomainByName(domainName string) (*Domain, error) {
 	}
 
 	domain := &Domain{}
-	_, err = c.do(req, domain)
+	resp, err := c.do(req, domain)
 	if err != nil {
-		return nil, err
+		switch {
+		case resp.StatusCode == http.StatusNotFound && strings.Count(domainName, ".") > 1:
+			// Look up for the next sub domain
+			subIndex := strings.Index(domainName, ".")
+			return c.GetDomainByName(domainName[subIndex+1:])
+		default:
+			return nil, err
+		}
 	}
 
 	return domain, nil


### PR DESCRIPTION
This PR fixes issue when domain that haven't been added in Selectel Domains API as "basic" domain in terms of [our API](https://blog.selectel.com/managing-domains-with-the-selectel-dns-api/) (for example, if just a "A" record was created, but we want to have an individual certificate for that) can't be fetched by its name and we can't set acme challenge TXT record for it. Instead of this, we could find it's "sub-domain" and set TXT record to that.

 I've tested it out:
```
dig +short testing.dstdfx.space A                                                                                                                       
95.213.158.178
```

```
./lego -m dstdfx@gmail.com --dns selectel -s https://acme-staging-v02.api.letsencrypt.org/directory -d "testing.dstdfx.space" run                               Thu Feb 21 16:02:34 2019
2019/02/21 16:02:38 [INFO] [testing.dstdfx.space] acme: Obtaining bundled SAN certificate
2019/02/21 16:02:40 [INFO] [testing.dstdfx.space] AuthURL: https://acme-staging-v02.api.letsencrypt.org/acme/authz/I8kMKZeu9KLx1kwCLlUKJ9fbi8qkYki0ZH35RyVMYG4
2019/02/21 16:02:40 [INFO] [testing.dstdfx.space] acme: Could not find solver for: tls-alpn-01
2019/02/21 16:02:40 [INFO] [testing.dstdfx.space] acme: Could not find solver for: http-01
2019/02/21 16:02:40 [INFO] [testing.dstdfx.space] acme: use dns-01 solver
2019/02/21 16:02:40 [INFO] [testing.dstdfx.space] acme: Preparing to solve DNS-01
2019/02/21 16:02:40 [INFO] [testing.dstdfx.space] acme: Trying to solve DNS-01
2019/02/21 16:02:40 [INFO] [testing.dstdfx.space] acme: Checking DNS record propagation using [10.0.9.16:53 188.93.16.19:53 188.93.17.19:53]
2019/02/21 16:02:40 [INFO] Wait for propagation [timeout: 2m0s, interval: 2s]
2019/02/21 16:02:40 [INFO] [testing.dstdfx.space] acme: Waiting for DNS record propagation.
2019/02/21 16:02:43 [INFO] [testing.dstdfx.space] acme: Waiting for DNS record propagation.
2019/02/21 16:02:45 [INFO] [testing.dstdfx.space] acme: Waiting for DNS record propagation.
2019/02/21 16:02:47 [INFO] [testing.dstdfx.space] acme: Waiting for DNS record propagation.
2019/02/21 16:02:49 [INFO] [testing.dstdfx.space] acme: Waiting for DNS record propagation.
2019/02/21 16:02:51 [INFO] [testing.dstdfx.space] acme: Waiting for DNS record propagation.
2019/02/21 16:02:53 [INFO] [testing.dstdfx.space] acme: Waiting for DNS record propagation.
2019/02/21 16:02:55 [INFO] [testing.dstdfx.space] acme: Waiting for DNS record propagation.
2019/02/21 16:02:57 [INFO] [testing.dstdfx.space] acme: Waiting for DNS record propagation.
2019/02/21 16:02:59 [INFO] [testing.dstdfx.space] acme: Waiting for DNS record propagation.
2019/02/21 16:03:07 [INFO] [testing.dstdfx.space] The server validated our request
2019/02/21 16:03:07 [INFO] [testing.dstdfx.space] acme: Cleaning DNS-01 challenge
2019/02/21 16:03:07 [INFO] [testing.dstdfx.space] acme: Validations succeeded; requesting certificates
2019/02/21 16:03:10 [INFO] [testing.dstdfx.space] Server responded with a certificate.
```