### PR TITLE
OVH: Refresh zone after deleting challenge record

### DIFF
--- a/providers/dns/ovh/ovh.go
+++ b/providers/dns/ovh/ovh.go
@@ -173,6 +173,13 @@ func (d *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 		return fmt.Errorf("ovh: error when call OVH api to delete challenge record (%s): %v", reqURL, err)
 	}
 
+	// Apply the change
+	reqURL = fmt.Sprintf("/domain/zone/%s/refresh", authZone)
+	err = d.client.Post(reqURL, nil, nil)
+	if err != nil {
+		return fmt.Errorf("ovh: error when call api to refresh zone (%s): %v", reqURL, err)
+	}
+
 	// Delete record ID from map
 	d.recordIDsMu.Lock()
 	delete(d.recordIDs, fqdn)


### PR DESCRIPTION
After removing the challenge record from OVH, the zone itself
does not get refreshed and leaving the obsolete record in place.

Calling '/domain/zone/ZONE/refresh' after deleting the record will
apply the changes to the zone.